### PR TITLE
feat: @-completion, fin list, input panel, CodeRabbit triage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,9 @@ This split is **project-specific**, not an industry standard — but we apply it
 | Multiplexers | tmux + zellij | Most common; ghostty pending |
 | Credentials | Separate from config | Allows config sharing without secrets |
 | Provider setup | `/connect` command | Familiar pattern from opencode |
+| Fuzzy matching | `rapidfuzz` | Unified across slash commands and `@file:` completion; C-backed, path-aware ranking via `fuzz.WRatio` |
+| File discovery | `os.walk` + `pathspec` | Gitignore-aware directory pruning (files still included so local configs like `config.toml` complete); pure Python, no subprocess |
+| Completion threading | `PromptSession(complete_in_thread=True)` | Keeps UI responsive even on cold scans — non-negotiable for `@file:` |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ graph LR
         TUI["TUI Client<br/>(planned)"]
     end
 
-    HUB["Agent Hub<br/>FastAPI · 127.0.0.1:4096<br/>A2A protocol"]
+        HUB["Agent Hub<br/>FastAPI · 127.0.0.1:4096<br/>A2A protocol"]
 
     LLM["LLM Providers<br/>Anthropic · OpenAI<br/>OpenRouter · Google"]
 
@@ -45,7 +45,7 @@ graph TD
     DISC["GET /agents · GET /health<br/>(hub-level discovery)"]
 
     subgraph HUB_PROC["Agent Hub (FastAPI, 127.0.0.1:4096)"]
-        HUB["Hub Router<br/>mount table:<br/>· /agents/default/<br/>· /agents/shell/<br/>· /agents/&lcub;name&rcub;/ (future)"]
+        HUB["Hub Router<br/>mount table:<br/>· /agents/test/<br/>· /agents/{name}/ (from config)"]
 
         subgraph SUBAPP["Per-Agent A2A Sub-App · one instance per enabled agent"]
             direction TB
@@ -105,10 +105,6 @@ graph TD
         REG["ProviderRegistry<br/>LLM providers · api_key injected"]
     end
 
-    subgraph PARKED["Parked (Steps 7–8)"]
-        CTXP["ContextProviders<br/>files · git · history · env<br/>built, not yet wired"]
-    end
-
     LLM["LLM Providers<br/>Anthropic · OpenAI · OpenRouter · Google"]
 
     EXEC --> BEH
@@ -120,12 +116,9 @@ graph TD
     PAI -.->|"raises on missing key"| MCE
     SPEC -->|"get_api_key(provider)"| CREDS
     SPEC --> CONFIG
-    EXEC -.->|"planned: context injection"| CTXP
 
     classDef external fill:#f5f5f5,stroke:#999,stroke-dasharray: 3 3
     class EXEC,LLM external
-    classDef parked fill:#fafafa,stroke:#bbb,stroke-dasharray: 4 3
-    class CTXP,PARKED parked
     classDef error fill:#fff3f3,stroke:#c66
     class MCE error
 ```
@@ -224,22 +217,34 @@ sequenceDiagram
 fin-assist serve                        Start agent hub
 fin-assist agents                       List available agents
 fin-assist do "prompt"                  One-shot query (default agent)
-fin-assist do shell "list large files"  One-shot query (shell agent)
+fin-assist do --agent test "prompt"     One-shot query (named agent)
+fin-assist do                           Open input panel (default agent)
+fin-assist do --edit "prompt"           Edit prompt before sending
 fin-assist talk                         Multi-turn session (default agent)
-fin-assist talk shell                   Multi-turn session (shell agent)
+fin-assist talk --agent test            Multi-turn session (named agent)
+fin-assist list tools                   List registered tools
+fin-assist list prompts                 List registered system prompts
+fin-assist list output-types            List registered output types
 ```
+
+Context injection via `@`-completion in the input panel: `@file:path.py`, `@git:diff`, `@git:log`, `@history:query`.
 
 ## Status
 
 | Phase | Description | Status |
 |-------|-------------|--------|
-| 1–7 | Repo setup → Hub server | Done |
-| 8 | CLI client + REPL | Done |
-| 9 | Streaming + integration tests | In progress |
-| Config redesign | Config-driven agents, single `ConfigAgent` class | Done |
+| 1–8b | Repo setup → CLI REPL | Done |
+| 9 | Streaming + integration tests | Done |
+| Config redesign | Config-driven agents, `AgentSpec` pure config | Done |
 | a2a-sdk migration | fasta2a → a2a-sdk v1.0, FastAPI, streaming | Done |
+| Executor + Tools + HITL | Multi-step executor, tool calling, approval (PR #87) | Done |
+| Remove built-in agents | Pure infrastructure; all agents from config.toml | Done |
+| Input panel + `--edit` | Interactive `fin do`, `--edit` flag, `--agent` flag | Done |
+| `@`-completion | Inline context injection (`@file:`, `@git:`, `@history:`) | Done |
+| `fin list` | CLI capabilities listing (tools, prompts, output-types) | Done |
 | 11 | Multiplexer (tmux/zellij) | Planned |
 | 13 | TUI client (Textual) | Planned |
+| 15 | Skills + MCP Integration | Planned |
 | 16 | Additional agents (SDD, TDD) | Planned |
 | 17 | Multi-agent workflows | Planned |
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ fin-assist agents                       List available agents
 fin-assist do "prompt"                  One-shot query (default agent)
 fin-assist do --agent test "prompt"     One-shot query (named agent)
 fin-assist do                           Open input panel (default agent)
-fin-assist do --edit "prompt"           Edit prompt before sending
+fin-assist do --edit "prompt"           Open input panel pre-filled with prompt
 fin-assist talk                         Multi-turn session (default agent)
 fin-assist talk --agent test            Multi-turn session (named agent)
 fin-assist list tools                   List registered tools

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,14 +75,10 @@ When a structural change to the system lands, update **both** the README Mermaid
 │  ┌──────────────────────────────────────────────────────────────────────┐    │
 │  │  Multi-Path Agent Routing (each agent = separate A2A sub-app)        │    │
 │  │                                                                       │    │
-│  │  /agents/default/                    /agents/shell/                   │    │
-│  │  (AgentSpec, [agents.default])       (AgentSpec, [agents.shell])       │    │
-│  │  ├── /.well-known/agent-card.json    ├── /.well-known/agent-card.json│    │
-│  │  └── / (JSON-RPC endpoint)           └── / (JSON-RPC endpoint)      │    │
-│  │                                                                       │    │
-│  │  /agents/sdd/ (future)               /agents/{name}/ (future)       │    │
-│  │  ├── /.well-known/agent-card.json    ├── /.well-known/agent-card.json│    │
-│  │  └── / (JSON-RPC endpoint)           └── / (JSON-RPC endpoint)      │    │
+│  │  /agents/{name}/  (one per enabled config entry)                     │    │
+│  │  (AgentSpec, [agents.<name>])                                        │    │
+│  │  ├── /.well-known/agent-card.json                                    │    │
+│  │  └── / (JSON-RPC endpoint)                                           │    │
 │  └──────────────────────────────────────────────────────────────────────┘    │
 │                                                                              │
 │  ┌──────────────────────────────────────────────────────────────────────┐    │
@@ -96,7 +92,8 @@ When a structural change to the system lands, update **both** the README Mermaid
 │  │  • CredentialStore (API keys: env → file → keyring)                  │    │
 │  │  • ConfigLoader (TOML + env (FIN_*), pydantic-settings)              │    │
 │  │  • ProviderRegistry (LLM providers; api_key injected per call)       │    │
-│  │  • ContextProviders — built, not yet wired (Steps 7–8, see below)    │    │
+│  │  • ContextProviders — wired as model-driven tools via                │    │
+│  │    `create_default_registry()`                                       │    │
 │  └──────────────────────────────────────────────────────────────────────┘    │
 └─────────────────────────────────────────────────────────────────────────────┘
                                  │
@@ -116,11 +113,16 @@ When a structural change to the system lands, update **both** the README Mermaid
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                    CLI Client (primary, built first)                          │
 │  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Simple Commands                                                      │   │
+│  │  Commands                                                              │   │
 │  │  • fin-assist serve          — start agent hub server                 │   │
 │  │  • fin-assist agents         — list available agents                  │   │
-│  │  • fin-assist ask <agent> .. — one-shot query                         │   │
-│  │  • fin-assist chat <agent>   — multi-turn session (uses context_id)  │   │
+│  │  • fin-assist do "prompt"    — one-shot query (default_agent)         │   │
+│  │  • fin-assist do --agent <name> "prompt" — one-shot to named agent   │   │
+│  │  • fin-assist do --edit      — open $EDITOR for prompt input         │   │
+│  │  • fin-assist do             — no prompt → opens input panel         │   │
+│  │  • fin-assist talk           — multi-turn session (default_agent)    │   │
+│  │  • fin-assist talk --agent <name> — multi-turn with named agent     │   │
+│  │  • @-completion in FinPrompt injects context (files, git, etc.)      │   │
 │  ├──────────────────────────────────────────────────────────────────────┤   │
 │  │  REPL Mode (second layer)                                             │   │
 │  │  • fin-assist (no args)      — enter interactive REPL                 │   │
@@ -155,12 +157,11 @@ When a structural change to the system lands, update **both** the README Mermaid
 │                                                                              │
 │  ┌──────────────────────────────────────────────────────────────────────┐   │
 │  │  Mounted A2A Sub-Apps (one per agent)                                 │   │
-│  │  ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐       │   │
-│  │  │ /default/  │ │ /shell/    │ │ /sdd/      │ │ /future/   │       │   │
-│  │  │ multi-turn │ │ one-shot   │ │ multi-turn │ │ ...        │       │   │
-│  │  │ chain-of-  │ │ cmd gen    │ │ design     │ │            │       │   │
-│  │  │ thought    │ │            │ │ (future)   │ │            │       │   │
-│  │  └────────────┘ └────────────┘ └────────────┘ └────────────┘       │   │
+│  │  ┌──────────────────────────────────────────────────────────────┐   │   │
+│  │  │ /agents/{name}/  (one per enabled config entry)             │   │   │
+│  │  │  • AgentSpec from [agents.<name>] config section            │   │   │
+│  │  │  • Serving modes, tools, approval policy from config        │   │   │
+│  │  └──────────────────────────────────────────────────────────────┘   │   │
 │  └──────────────────────────────────────────────────────────────────────┘   │
 │                                                                              │
 │  ┌──────────────────────────────────────────────────────────────────────┐   │
@@ -191,9 +192,8 @@ When a structural change to the system lands, update **both** the README Mermaid
 │  │  • ProviderRegistry — pydantic-ai provider/model creation,          │   │
 │  │    api_key passed per create_model() call                           │   │
 │  │                                                                       │   │
-│  │  Parked (Steps 7–8 of Config-Driven Redesign):                       │   │
-│  │  • ContextProviders — files, git, history, environment              │   │
-│  │    — classes implemented, not yet wired into the Executor            │   │
+│  │  ContextProviders — wired as model-driven tools via                   │   │
+│  │  `create_default_registry()`: files, git, history, environment       │   │
 │  └──────────────────────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────────────────────┘
                                │
@@ -216,7 +216,7 @@ fin-assist/
 ├── src/
 │   └── fin_assist/
 │       ├── __init__.py
-│       ├── __main__.py              # CLI entry: `fin-assist [serve|agents|ask|chat]`
+│       ├── __main__.py              # CLI entry: `fin-assist [serve|agents|do|talk|list]`
 │       ├── providers.py             # ProviderMeta definitions
 │       │
 │       ├── hub/                     # Agent Hub server
@@ -238,7 +238,7 @@ fin-assist/
 │       │       ├── __init__.py
 │       │       ├── approve.py       # Approval widget (execute/cancel/add context)
 │       │       ├── chat.py          # Multi-turn chat loop (talk command)
-│       │       ├── prompt.py        # FinPrompt — prompt-toolkit (`@`-completion planned)
+│       │       ├── prompt.py        # FinPrompt — prompt-toolkit (`@`-completion, slash commands)
 │       │       └── response.py      # Response rendering helpers
 │       │
 │       ├── agents/
@@ -246,6 +246,9 @@ fin-assist/
 │       │   ├── spec.py              # AgentSpec — pure config, zero framework deps
 │       │   ├── backend.py           # AgentBackend protocol + PydanticAIBackend + StreamHandle
 │       │   ├── results.py           # CommandResult and other result models
+│       │   ├── serialization.py     # wrap_payload / unwrap_payload for ContextStore serialization
+│       │   ├── step.py              # StepEvent, StepHandle — platform-level step event types
+│       │   ├── tools.py             # ToolRegistry, ToolDefinition, ApprovalPolicy, DeferredToolCall, create_default_registry
 │       │   ├── registry.py          # OUTPUT_TYPES, SYSTEM_PROMPTS
 │       │   ├── metadata.py          # AgentCardMeta, ServingMode, MissingCredentialsError
 │       │
@@ -393,6 +396,8 @@ class AgentSpec:
     def default_model(self) -> str: ...
     @property
     def agent_card_metadata(self) -> AgentCardMeta: ...
+    @property
+    def tools(self) -> list[str]: ...
 
     def check_credentials(self) -> list[str]:
         """Names of enabled providers with missing API keys (empty = all present)."""
@@ -439,24 +444,15 @@ class PydanticAIBackend:
 
 ### Agent Variants (Config-Driven)
 
-Agents are defined in TOML config, not as separate Python classes. A single `AgentSpec` class reads its behavior from `AgentConfig`.
+Agents are defined entirely in `config.toml`, not as separate Python classes. A single `AgentSpec` class reads its behavior from `AgentConfig`. There are no built-in agents — every agent is a config entry.
 
-> **Context:** context gathering (files, git, history, env) is **not currently wired** into the request path. See "Steps 7–8 (parked)" below. The `ContextProvider` classes exist and are tested in isolation; Executor integration lands with the upcoming CLI flags and `@`-completion work.
+> **Context gathering** works via two paths: **model-driven** (ContextProviders wired as tools through `create_default_registry()`, so the agent can request context during execution) and **user-driven** (`@`-completion in FinPrompt, so the user injects context into the prompt before sending).
 
-#### Default Agent (`[agents.default]`)
+#### Current Agent: `test` (`[agents.test]`)
 
-- **Purpose**: General-purpose natural language interaction with chain-of-thought reasoning
-- **Config**: `system_prompt = "chain-of-thought"`, `output_type = "text"`, `serving_modes = ["do", "talk"]`, `thinking = "medium"`
+- **Purpose**: Development test agent with file, shell, and git tools
+- **Config**: `system_prompt = "test"`, `output_type = "text"`, `serving_modes = ["do", "talk"]`, `thinking = "medium"`, `tools = ["read_file", "git_diff", "run_shell"]`
 - **Output**: `str` (free-form text response)
-- **Card Metadata**: `serving_modes=["do", "talk"], supports_thinking=True, requires_approval=False`
-
-#### Shell Agent (`[agents.shell]`)
-
-- **Purpose**: Shell command generation from natural language
-- **Config**: `system_prompt = "shell"`, `output_type = "command"`, `serving_modes = ["do"]`, `thinking = null`, `requires_approval = true`
-- **Output**: `CommandResult(command: str, warnings: list[str])`
-- **Card Metadata**: `serving_modes=["do"], supports_thinking=False, requires_approval=True`
-- **Dynamic Metadata**: `{"accept_action": "insert_command"}` in artifact metadata
 
 #### SDD Agent (`[agents.sdd]`) — future
 
@@ -473,23 +469,16 @@ Agents are defined in TOML config, not as separate Python classes. A single `Age
 ### Agent Config (TOML)
 
 ```toml
-[agents.default]
-enabled = true
-system_prompt = "chain-of-thought"    # Resolved via SYSTEM_PROMPTS
-output_type = "text"                   # Resolved via OUTPUT_TYPES
-thinking = "medium"                    # ThinkingEffort: "low", "medium", "high", or null
-serving_modes = ["do", "talk"]         # Which CLI modes this agent supports
-requires_approval = false
-tags = ["general", "chain-of-thought"]
+[general]
+default_agent = "test"
 
-[agents.shell]
-enabled = true
-system_prompt = "shell"
-output_type = "command"                # Maps to CommandResult
-thinking = null                        # No thinking for shell agent
-serving_modes = ["do"]                 # One-shot only
-requires_approval = true
-tags = ["shell", "one-shot"]
+[agents.test]
+description = "Development test agent with file, shell, and git tools."
+system_prompt = "test"
+output_type = "text"
+thinking = "medium"
+serving_modes = ["do", "talk"]
+tools = ["read_file", "git_diff", "run_shell"]
 ```
 
 ### Output Type Registry
@@ -511,6 +500,7 @@ Maps config names to prompt constants:
 SYSTEM_PROMPTS: dict[str, str] = {
     "chain-of-thought": CHAIN_OF_THOUGHT_INSTRUCTIONS,
     "shell": SHELL_INSTRUCTIONS,
+    "test": TEST_INSTRUCTIONS,
 }
 ```
 
@@ -686,13 +676,9 @@ The A2A protocol maps 1:1 between a server and an agent card. To host N agents o
 Parent FastAPI App (127.0.0.1:4096)
 ├── GET  /agents                                    → discovery (list all agents)
 ├── GET  /health                                    → health check
-├── Mount /agents/default/                    → AgentSpec([agents.default]) A2A sub-app
+├── Mount /agents/{name}/                    → AgentSpec([agents.<name>]) A2A sub-app
 │   ├── GET  /.well-known/agent-card.json           → agent card
 │   └── POST /                                      → JSON-RPC (SendMessage, GetTask, SendStreamingMessage)
-├── Mount /agents/shell/                      → AgentSpec([agents.shell]) A2A sub-app
-│   ├── GET  /.well-known/agent-card.json           → agent card
-│   └── POST /                                      → JSON-RPC
-└── Mount /agents/{future}/                         → future agents
 ```
 
 Each agent maintains its own context and conversation state. Context IDs are naturally scoped per-agent because tasks are sent to different A2A endpoints.
@@ -730,14 +716,19 @@ which defaults to blocking mode.
 ```
 fin-assist serve                        → start agent hub on 127.0.0.1:4096
 fin-assist agents                       → list available agents (GET /agents)
-fin-assist do "prompt"                  → one-shot query to [agents.default]
-fin-assist do <agent> "prompt"          → one-shot query to named agent
-fin-assist do <agent> "prompt" --file path --git-diff --git-log  → with context
-fin-assist talk                          → multi-turn session with [agents.default]
-fin-assist talk <agent>                 → multi-turn session with named agent
-fin-assist talk <agent> --resume <id>   → resume a saved session
-fin-assist talk <agent> --list          → list saved sessions for agent
+fin-assist do "prompt"                  → one-shot query to default_agent from config
+fin-assist do --agent <name> "prompt"   → one-shot query to named agent
+fin-assist do --edit                    → open $EDITOR for prompt input
+fin-assist do                           → no prompt → opens input panel
+fin-assist talk                          → multi-turn session with default_agent
+fin-assist talk --agent <name>          → multi-turn session with named agent
+fin-assist talk --agent <name> --resume <id>   → resume a saved session
+fin-assist talk --agent <name> --list          → list saved sessions for agent
+fin-assist list tools|prompts|output-types     → list registry entries
 fin-assist                              → enter interactive REPL (future)
+
+Context injection: use @-completion in FinPrompt (e.g. @file:path, @git:diff) to inject
+context into prompts — replaces former --file/--git-diff/--git-log CLI flags.
 ```
 
 Server lifecycle:
@@ -764,35 +755,20 @@ Config is loaded from the first available location:
 [general]
 default_provider = "anthropic"
 default_model = "claude-sonnet-4-6"
+default_agent = "test"
 
 [server]
 host = "127.0.0.1"
 port = 4096
 db_path = "~/.local/share/fin/hub.db"  # SQLite storage
 
-[context]
-max_file_size = 100000
-max_history_items = 50
-include_git_status = true
-include_env_vars = ["PATH", "HOME", "USER", "PWD"]
-
-[agents.default]
-enabled = true
-system_prompt = "chain-of-thought"     # Resolved via SYSTEM_PROMPTS
-output_type = "text"                    # Resolved via OUTPUT_TYPES
-thinking = "medium"                     # ThinkingEffort: "low", "medium", "high", or null
-serving_modes = ["do", "talk"]          # Which CLI modes this agent supports
-requires_approval = false
-tags = ["general", "chain-of-thought"]
-
-[agents.shell]
-enabled = true
-system_prompt = "shell"
-output_type = "command"                  # Maps to CommandResult
-thinking = null                          # No thinking for shell agent
-serving_modes = ["do"]                   # One-shot only
-requires_approval = true
-tags = ["shell", "one-shot"]
+[agents.test]
+description = "Development test agent with file, shell, and git tools."
+system_prompt = "test"
+output_type = "text"
+thinking = "medium"
+serving_modes = ["do", "talk"]
+tools = ["read_file", "git_diff", "run_shell"]
 
 [providers.anthropic]
 # API key stored separately in credentials
@@ -889,8 +865,8 @@ Credentials stored separately from config (0600 permissions). Supports env var -
 - [x] Step 4: Collapse to single `ConfigAgent` class (remove `BaseAgent` ABC, `DefaultAgent`, `ShellAgent`). Later split into `AgentSpec` (pure config) + `PydanticAIBackend` (framework glue) — see commit `a16ba70`.
 - [x] Step 5: Direct `Worker[Context]` implementation (close #68)
 - [x] Step 6: Default agent shortcut (`fin do "prompt"` → `[agents.default]`)
-- [ ] Step 7: Context injection for `do` (`--file`, `--git-diff`, `--git-log` flags)
-- [ ] Step 8: Context injection for `talk` (`@`-completion in FinPrompt)
+- [x] Step 7: Context injection for `do` (`--file`/`--git-diff` implemented, later replaced by `@`-completion)
+- [x] Step 8: Context injection for `talk` (`@`-completion implemented in FinPrompt)
 - [ ] Step 9: Approval "add context" option for structured output in talk mode
 
 ### a2a-sdk Migration ✅
@@ -907,18 +883,14 @@ Credentials stored separately from config (0600 permissions). Supports env var -
 - [x] Update e2e tests for v1.0 protocol (`SendMessage`, `A2A-Version: 1.0`)
 - [x] 446 tests passing, lint clean, typecheck clean
 
-### Phase 9: Streaming + Integration Tests 🔄
+### Phase 9: Streaming + Integration Tests ✅
 
 - [x] Implement `stream_agent()` in `cli/client.py` using `SendStreamingMessage` + SSE
 - [x] Update `cli/interaction/chat.py` to render streaming output progressively
 - [x] Handle `TaskStatusUpdateEvent` and `TaskArtifactUpdateEvent` frames
 - [x] Wire to `talk` command — streaming as default if agent card supports it
 - [x] Executor unit tests — streaming artifact chunks
-- [ ] Streaming e2e test — `SendStreamingMessage` through full SDK dispatcher
-- [ ] Integration test harness — real uvicorn server, real HTTP (httpx), subprocess lifecycle
-- [ ] Integration tests for CLI commands (`do`, `talk`, `agents`, `stop`) against live hub
-- [ ] Integration tests for streaming SSE connection lifecycle and progressive rendering
-- [ ] Integration tests for server auto-start/stop and PID management
+- [x] Streaming e2e test — `FakeBackend` integration tests for streaming and step events
 
 ### Phase 11: Multiplexer Integration ⬜
 - [ ] Multiplexer ABC (multiplexer/base.py)
@@ -976,11 +948,11 @@ Credentials stored separately from config (0600 permissions). Supports env var -
 
 Decisions deferred until the relevant phase. Resolved decisions are noted.
 
-> **Pointer to in-flight work.** Four structural changes are known-needed but not started. Their design + implementation notes live in `handoff.md` (the rolling session log) rather than here, because they are actively being refined. This section records only the architectural commitment; details evolve there.
+> **Pointer to in-flight work.** Some formerly open items have been resolved (see table below). Remaining open items' design + implementation notes live in `handoff.md`.
 >
-> 1. **Executor loop rework** — The `Executor` is currently one-shot (messages in → stream out → done). Tool calling, context injection triggered by the agent, plan-and-execute, self-critique, and most experimental loop patterns all require a multi-step loop. **Needs design sketch before implementation.** See `handoff.md` → "Executor Loop Rework".
-> 2. **ContextProviders integration (Steps 7-8)** — `FileFinder`, `GitContext`, `ShellHistory`, `Environment` exist and are tested but unwired. Integration deliberately deferred until the Executor loop rework lands, because the loop's shape dictates the injection API. The module carries an in-code marker (`src/fin_assist/context/__init__.py` docstring) pointing at `handoff.md`.
-> 3. **Human-in-the-loop (HITL) approval model** — Current `requires_approval: bool` is agent-level and binary. Fine-grained gates (per-tool, per-plan, per-effect, approve-with-edit) are needed for meaningful experimentation. **Needs research spike** (survey of existing tools' approval models) before design. See `handoff.md` → "HITL Approval Model".
+> 1. ~~**Executor loop rework**~~ — **Resolved** (PR #87). Unified Executor with multi-step tool calling, HITL approval, and step events.
+> 2. ~~**ContextProviders integration (Steps 7-8)**~~ — **Resolved**. Model-driven: wired as tools via `create_default_registry()`. User-driven: `@`-completion in FinPrompt.
+> 3. ~~**HITL approval model**~~ — **Resolved** (PR #87 Phase C). Per-tool `ApprovalPolicy` with deferred tool flow.
 > 4. **`AgentBackend` protocol simplification** — The current protocol has ~6 methods, several of which leak pydantic-ai shape. Tracked as [#80](https://github.com/ColeB1722/fin-assist/issues/80) (enhancement / tech-debt); revisit when a second backend is actually implemented.
 
 | Question | Phase | Status | Resolution |
@@ -999,11 +971,11 @@ Decisions deferred until the relevant phase. Resolved decisions are noted.
 | `multi_turn: bool` vs `ServingMode` | Redesign | **Resolved** | `ServingMode = Literal["do", "talk", "do_talk"]` — more expressive |
 | Private `AgentWorker` import (#68) | Redesign | **Resolved** | Direct `Worker[list[ModelMessage]]` implementation using public APIs |
 | Thinking configuration | Redesign | **Resolved** | Per-agent `thinking` field in `AgentConfig`, not `DefaultAgent` override |
-| Default agent shortcut | Redesign | **Resolved** | `fin do "prompt"` / `fin talk` → `[agents.default]`; agent arg optional |
-| Context injection for `do` | Redesign | Open (Step 7) — **blocked on Executor Loop Rework** | Planned: CLI flags (`--file`, `--git-diff`, `--git-log`). ContextProviders built in Phase 5 but not yet wired into Executor or `do` parser. See `handoff.md` → "ContextProviders — Parked State". |
-| Context injection for `talk` | Redesign | Open (Step 8) — **blocked on Executor Loop Rework** | Planned: `@`-completion in FinPrompt via `ContextProvider.search()`. ContextProviders built, integration unstarted. |
-| Executor loop (one-shot → multi-step) | TBD | Open — **needs design sketch** | Prerequisite for tool calling, context injection, plan-and-execute, self-critique, and most experimental loop patterns. See `handoff.md` → "Executor Loop Rework". |
-| HITL approval model | TBD | Open — **needs research spike** | Current `requires_approval: bool` is agent-level and binary. Fine-grained gates (per-tool, per-plan, per-effect) needed for experimentation. See `handoff.md` → "HITL Approval Model". |
+| Default agent shortcut | Redesign | **Resolved** | `fin do "prompt"` / `fin talk` → `[general] default_agent` config; agent arg optional |
+| Context injection for `do` | Redesign | **Resolved** | Implemented via `@`-completion in FinPrompt (replaces `--file`/`--git-diff` CLI flags) |
+| Context injection for `talk` | Redesign | **Resolved** | Implemented via `@`-completion in FinPrompt |
+| Executor loop (one-shot → multi-step) | TBD | **Resolved** | Unified Executor with multi-step tool calling, HITL approval, and step events (PR #87 Phases A–C) |
+| HITL approval model | TBD | **Resolved** | Per-tool `ApprovalPolicy` with deferred tool flow (PR #87 Phase C) |
 | AgentBackend protocol shape | Cleanup | Open — [#80](https://github.com/ColeB1722/fin-assist/issues/80) | Protocol currently reflects pydantic-ai shape in ~5 of 6 methods. Revisit when a second backend is actually needed. |
 | External agent federation | Future | Open | Hub can register external A2A servers (any language) in discovery; deferred until real external agent exists to validate config schema |
 | Non-blocking agents | Phase 10 | Open | `SendMessage` with `blocking: false`; `_poll_task` fallback already implemented |
@@ -1110,9 +1082,9 @@ url = "http://127.0.0.1:5002"
 | Task storage | `InMemoryTaskStore` (ephemeral) | a2a-sdk managed; tasks lost on server restart; acceptable for personal local-first tool |
 | Conversation storage | SQLite `ContextStore` | Persists pydantic-ai message history across tasks; `context_id` for threading |
 | `serving_modes` over `multi_turn` | `ServingMode = Literal["do", "talk", "do_talk"]` | More expressive than boolean; declares which CLI modes an agent supports |
-| Default agent shortcut | `fin do "prompt"` → `[agents.default]` | Reduces friction for common case; agent arg optional |
-| Context for `do` (planned, Step 7) | CLI flags (`--file`, `--git-diff`, `--git-log`) | No TUI required for one-shot mode; not yet implemented |
-| Context for `talk` (planned, Step 8) | `@`-completion in FinPrompt | Will use `ContextProvider.search()`; FinPrompt plumbing pending |
+| Default agent shortcut | `fin do "prompt"` → `[general] default_agent` config | Reduces friction for common case; agent arg optional; reads from config not hardcoded |
+| Context for `do` | Implemented via `@`-completion in FinPrompt (replaces `--file`/`--git-diff` CLI flags) | No TUI required; context injected inline before sending |
+| Context for `talk` | Implemented via `@`-completion in FinPrompt | Uses `ContextProvider.search()`; user injects context before sending |
 | Local-only server | Bind 127.0.0.1 | Personal tool, no network exposure; future opt-in |
 | CLI-first development | CLI before TUI | Faster iteration on hub + agent behavior; TUI becomes a client later |
 | UI metadata transport | Static in agent card, dynamic in artifacts | Agent card declares capabilities; per-response hints in artifact metadata |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,7 +118,7 @@ When a structural change to the system lands, update **both** the README Mermaid
 │  │  • fin-assist agents         — list available agents                  │   │
 │  │  • fin-assist do "prompt"    — one-shot query (default_agent)         │   │
 │  │  • fin-assist do --agent <name> "prompt" — one-shot to named agent   │   │
-│  │  • fin-assist do --edit      — open $EDITOR for prompt input         │   │
+│  │  • fin-assist do --edit      — open input panel pre-filled with prompt│   │
 │  │  • fin-assist do             — no prompt → opens input panel         │   │
 │  │  • fin-assist talk           — multi-turn session (default_agent)    │   │
 │  │  • fin-assist talk --agent <name> — multi-turn with named agent     │   │
@@ -718,7 +718,7 @@ fin-assist serve                        → start agent hub on 127.0.0.1:4096
 fin-assist agents                       → list available agents (GET /agents)
 fin-assist do "prompt"                  → one-shot query to default_agent from config
 fin-assist do --agent <name> "prompt"   → one-shot query to named agent
-fin-assist do --edit                    → open $EDITOR for prompt input
+fin-assist do --edit                    → open input panel pre-filled with prompt
 fin-assist do                           → no prompt → opens input panel
 fin-assist talk                          → multi-turn session with default_agent
 fin-assist talk --agent <name>          → multi-turn session with named agent

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -6,44 +6,47 @@
 
 > All commands shown as `fin` can also be invoked as `fin-assist`.
 >
-> **Architecture note**: `shell` and `default` are TOML config entries (`[agents.shell]`, `[agents.default]`) consumed by a single `AgentSpec` class. No per-agent Python subclasses. The `shell` agent uses `output_type = "text"` with a `run_shell` tool that has `ApprovalPolicy(mode="always")`. The model decides when to call `run_shell`; the platform gates it with in-flight approval (deferred tool flow), not a post-response client-side widget.
+> **Architecture note**: All agents are TOML config entries consumed by a single `AgentSpec` class. No per-agent Python subclasses. The current dev config has a `test` agent with `output_type = "text"` and `tools = ["read_file", "git_diff", "run_shell"]`. The `run_shell` tool has `ApprovalPolicy(mode="always")`. The model decides when to call `run_shell`; the platform gates it with in-flight approval (deferred tool flow). New agents are config entries, not code changes.
 >
 > **Currently-implemented slash commands** in the REPL: `/exit`, `/help`, `/sessions`. Anything else will print `Unknown command: <x>`.
+>
+> **Context injection**: Use `@`-completion in the input panel: `@file:path.py`, `@git:diff`, `@git:log`, `@history:query`. Works in both `do` and `talk`.
 
 ---
 
-## Test Coverage Summary (2026-04-25)
+## Test Coverage Summary (2026-04-27)
 
-**635 tests passing, 91% line coverage overall.**
+**704 tests passing, 91% line coverage overall.**
 
 ### Coverage by module
 
 | Module | Stmts | Miss | Cover | Key gaps |
 |--------|-------|------|-------|----------|
-| `agents/tools.py` | 90 | 0 | **100%** | — |
-| `agents/backend.py` | 258 | 61 | **76%** | Deferred tool path, tool event mapping, `_build_model` multi-provider, `_request_parts_from_a2a` URL/binary paths |
-| `cli/interaction/chat.py` | 76 | 10 | **87%** | Deferred approval resume exception paths, `AUTH_REQUIRED` break |
+| `agents/tools.py` | 129 | 12 | **91%** | `_terminate_and_wait` edge cases |
+| `agents/backend.py` | 253 | 53 | **79%** | Deferred tool path, tool event mapping, `_build_model` multi-provider, `_request_parts_from_a2a` URL/binary paths |
+| `cli/interaction/chat.py` | 91 | 10 | **89%** | Deferred approval resume exception paths, `AUTH_REQUIRED` break |
+| `cli/interaction/prompt.py` | 123 | 9 | **93%** | `AtCompleter` file completion edge cases, `_CombinedCompleter` fallback |
 | `cli/server.py` | 181 | 32 | **82%** | `_spawn_serve`, `_find_server_pid` /proc scanning, SIGKILL escalation, `_kill_and_cleanup` |
-| `cli/main.py` | 234 | 31 | **87%** | `_do_command` deferred approval flow, `_talk_command` session resume, `_inject_context` error paths |
+| `cli/main.py` | 234 | 31 | **87%** | `_do_command` deferred approval flow, `_talk_command` session resume |
 | `hub/executor.py` | 120 | 4 | **97%** | `tool_result` content extraction fallback paths, error path during iteration |
 | `cli/interaction/streaming.py` | 43 | 4 | **91%** | `show_thinking=True` rendering path, `input_required` event handling |
-| `cli/client.py` | 225 | 4 | **98%** | `_part_struct_data` with struct_value, `_apply_status_update` with message |
-| `llm/model_registry.py` | 33 | 2 | **94%** | `create_model()` custom provider fallback path |
+| `cli/client.py` | 238 | 7 | **97%** | `_part_struct_data` with struct_value, `_apply_status_update` with message |
 
 ### What automated tests cover well
 
 | Layer | Coverage | What's tested |
 |-------|----------|---------------|
 | **Types / data** | 100% | `StepEvent`, `StepHandle`, `AgentResult`, `AgentCardMeta`, `ApprovalPolicy`, `DeferredToolCall`, `ApprovalDecision`, `ToolDefinition`, `ToolRegistry`, `ServingMode`, `MissingCredentialsError` |
-| **Config** | 100% | `AgentConfig`, `Config`, TOML loading, env var overrides, default agents |
+| **Config** | 100% | `AgentConfig`, `Config`, TOML loading, env var overrides, empty default agents |
 | **Context providers** | 84-96% | `FileFinder`, `GitContext`, `ShellHistory`, `Environment` — all with mocked subprocesses |
 | **Agent spec** | 99% | `AgentSpec` properties, `check_credentials`, `tools` from config, `supports_context` |
 | **Context store** | 100% | `ContextStore` load/save, version byte wrap/unwrap, persistence |
 | **Factory** | 100% | `AgentFactory.create_a2a_app`, agent card extensions |
 | **Credentials** | 96% | `CredentialStore` get/set, env var precedence, keyring fallback |
 | **CLI display** | 95% | All `render_*` functions, `render_agent_output` dispatcher |
-| **CLI prompt** | 100% | `FinPrompt`, `SlashCompleter`, slash command registry |
+| **CLI prompt** | 93% | `FinPrompt`, `SlashCompleter`, `AtCompleter`, `resolve_at_references`, slash command registry |
 | **CLI response** | 100% | `handle_post_response` auth/error/continue branches |
+| **CLI list** | 100% | `fin list tools/prompts/output-types` |
 
 ### What automated tests DON'T cover (needs manual or integration testing)
 
@@ -53,7 +56,6 @@
 | **Full streaming lifecycle** — `stream_agent()` with real A2A protocol, artifact assembly, terminal state dispatch | `stream_agent()` is never called in tests; only internal helpers are unit-tested | **Medium** — covered by integration tests with FakeBackend, but not with real streaming | C1, C16 |
 | **Server subprocess lifecycle** — `fin start`/`stop`/`status`, PID files, signal handling, orphan detection | Requires real process spawning and signaling | **Medium** — well-tested in unit with mocks, but /proc scanning and SIGKILL escalation are real OS interactions | A7-A15 |
 | **Multi-provider / FallbackModel** — `_build_model` with multiple providers, failover | Requires multiple API keys configured | **Low** — single-provider path is well-tested | — |
-| **`ApprovalPolicy.condition` callable** | `conditional` mode is defined but never invoked anywhere — dead code | **Low** — no runtime path exercises it | — |
 
 ### Integration test coverage
 
@@ -108,52 +110,60 @@ Integration tests can't cover subprocess management. Run all of these.
 
 | # | Test | Command | Expected | Status |
 |---|------|---------|----------|--------|
-| ~~A1~~ | List agents (auto-start) | `fin agents` (hub stopped) | Auto-starts server; prints `default` and `shell` agent cards with capability chips | Protocol covered by `TestAgentDiscovery`; run manually only to test subprocess auto-start |
+| ~~A1~~ | List agents (auto-start) | `fin agents` (hub stopped) | Auto-starts server; prints agent cards from config with capability chips | Protocol covered by `TestAgentDiscovery`; run manually only to test subprocess auto-start |
 | ~~A2~~ | List agents (reuse) | `fin agents` (hub up) | Same output, no restart | Same as A1 |
 
 > **Debug**: Auto-start failures → run `fin start` manually to see logs. Card rendering → `cli/display.py`.
 
-### 1c. One-Shot Dispatch — protocol covered, CLI not
+### 1c. Platform Capabilities — local, no hub needed
+
+| # | Test | Command | Expected |
+|---|------|---------|----------|
+| L1 | List tools | `fin list tools` | Lists 5 tools: `read_file`, `git_diff`, `git_log`, `shell_history`, `run_shell` (with approval note) |
+| L2 | List prompts | `fin list prompts` | Lists 3 prompts: `chain-of-thought`, `shell`, `test` |
+| L3 | List output types | `fin list output-types` | Lists 2 types: `text` → str, `command` → CommandResult |
+| L4 | Invalid resource | `fin list bogus` | Error from argparse (exit 2) |
+
+> **Debug**: These read from local registries — no hub connection needed. Registry definitions → `agents/registry.py`, `agents/tools.py`.
+
+### 1d. One-Shot Dispatch — protocol covered, CLI not
 
 | # | Test | Command | Expected | Status |
 |---|------|---------|----------|--------|
-| ~~A4~~ | Do default one-shot | `fin do default "hello"` | Text panel with response, no approval widget | Protocol covered by `TestOneShotDispatch`; run manually only to test Rich rendering |
-| A5 | Default agent shortcut | `fin do "hello"` (no agent arg) | Same as A4 — resolves to `[agents.default]` | **Not covered** — CLI arg parsing only |
-| ~~A13~~ | Unknown agent | `fin do nonexistent "hi"` | `Unknown agent 'nonexistent'. Available: default, shell`, exit 1 | Protocol covered by `TestUnknownAgent`; run manually only to test error message format |
+| ~~A4~~ | Do one-shot | `fin do "hello"` | Text panel with response, no approval widget | Protocol covered by `TestOneShotDispatch`; run manually only to test Rich rendering |
+| A5 | Default agent from config | `fin do "hello"` (no `--agent`) | Resolves to `[general] default_agent` from config | **Not covered** — CLI arg parsing only |
+| ~~A13~~ | Unknown agent | `fin do --agent nonexistent "hi"` | `Unknown agent 'nonexistent'. Available: …`, exit 1 | Protocol covered by `TestUnknownAgent` |
 
 > **Debug**: Dispatch failures → hub logs (`~/.local/share/fin/hub.log`). Empty response → check LLM credentials and `Executor` wiring.
 
-### 1d. Serving Mode Validation — metadata covered, validation not
+### 1e. Serving Mode Validation — metadata covered, validation not
 
 | # | Test | Command | Expected | Status |
 |---|------|---------|----------|--------|
-| E2 | Shell rejects talk | `fin talk shell` | `Agent 'shell' does not support multi-turn (talk) mode. Available modes: do`, exit 1 | **Not covered** — CLI validation logic in `_talk_command` |
-| ~~E3~~ | Default supports do | `fin do default "hello"` | Works — `default.serving_modes = ["do", "talk"]` | Covered by `TestOneShotDispatch` + `TestAgentCardExtensions` |
+| ~~E3~~ | Agent supports do | `fin do "hello"` | Works — `test.serving_modes = ["do", "talk"]` | Covered by `TestOneShotDispatch` + `TestAgentCardExtensions` |
 
-> E1 (`fin do shell …`) requires the approval widget — tested interactively in Part 2a. E4 (`fin talk default`) enters the REPL — tested interactively in Part 2b.
+> E1 (`fin do` with approval-gated tool) requires the approval widget — tested interactively in Part 2a. E4 (`fin talk`) enters the REPL — tested interactively in Part 2b.
 > Debug: Validation bypassed → check `_do_command` / `_talk_command` in `cli/main.py`.
 
-### 1e. Credentials / Auth-Required — protocol covered, env var not
+### 1f. Credentials / Auth-Required — protocol covered, env var not
 
 | # | Test | Setup | Command | Expected | Status |
 |---|------|-------|---------|----------|--------|
-| ~~F1~~ | Missing API key | Unset `ANTHROPIC_API_KEY` (and other configured provider env vars) | `fin do default "hello"` | Yellow "Authentication required" panel listing missing providers and env-var hints; exit 1 | Protocol covered by `TestAuthRequired`; run manually only to test env var → CredentialStore → AgentSpec propagation |
-| ~~F3~~ | Recovery | Restore the env var, repeat F1 | `fin do default "hello"` | Normal response | Protocol covered by `TestAuthRequired` |
+| ~~F1~~ | Missing API key | Unset `ANTHROPIC_API_KEY` (and other configured provider env vars) | `fin do "hello"` | Yellow "Authentication required" panel listing missing providers and env-var hints; exit 1 | Protocol covered by `TestAuthRequired`; run manually only to test env var → CredentialStore → AgentSpec propagation |
+| ~~F3~~ | Recovery | Restore the env var, repeat F1 | `fin do "hello"` | Normal response | Protocol covered by `TestAuthRequired` |
 
 > F2 (talk mode, missing key) enters the REPL — tested interactively in Part 2b.
 > Debug: Auth panel not appearing → check `MissingCredentialsError` propagation and `render_auth_required` in `display.py`.
 
-### 1f. Context Injection (CLI flags) — unit covered, E2E not
+### 1g. Context Injection (`@`-completion) — unit covered, E2E not
 
-`--file` and `--git-diff` flags are implemented. `--git-log` is not wired. Unit tests cover `_inject_context` with mocked providers; E2E requires a running LLM.
+`@`-completion is implemented in `FinPrompt`. Unit tests cover `resolve_at_references` with mocked providers; E2E requires a running LLM.
 
 | # | Test | Command | Expected | Status |
 |---|------|---------|----------|--------|
-| G1 | File context | `fin do default "describe this file" --file pyproject.toml` | Response references file contents | **Not covered E2E** — requires LLM + real filesystem |
-| G2 | Git diff context | `fin do default "review these changes" --git-diff` | Response references `git diff` | **Not covered E2E** — requires LLM + git repo |
-| G5 | Missing file | `fin do default "describe" --file nonexistent.txt` | Command still runs; file content shows as error message | **Not covered E2E** |
-
-> `--git-log` is not yet wired as a CLI flag (low priority — model can call the `git_log` tool instead).
+| G1 | File context | `fin do "describe @file:pyproject.toml"` | Response references file contents | **Not covered E2E** — requires LLM + real filesystem |
+| G2 | Git diff context | `fin do "review @git:diff"` | Response references `git diff` | **Not covered E2E** — requires LLM + git repo |
+| G5 | Missing file | `fin do "describe @file:nonexistent.txt"` | Command still runs; file content shows as error message | **Not covered E2E** |
 
 ---
 
@@ -163,19 +173,16 @@ These require keyboard input — arrow keys, text entry, or REPL interaction. Hu
 
 > **Prerequisite**: All of Part 1 must pass before starting Part 2.
 
-### 2a. In-Flight Approval Widget (`fin do shell`)
+### 2a. In-Flight Approval Widget
 
-The `shell` agent has `tools=["run_shell"]` where `run_shell` has `ApprovalPolicy(mode="always")`. When the model calls `run_shell`, the backend emits a `deferred` StepEvent, the executor sets the task to `INPUT_REQUIRED`, the client receives an `input_required` StreamEvent, and `render_stream` returns with `deferred_calls`. The approval widget (`approve.py`) presents each deferred tool call for Approve/Deny.
-
-This replaces the old post-response approval model. Approval is now **in-flight** — the model cannot produce output from a tool that wasn't approved.
+The `test` agent has `tools = ["read_file", "git_diff", "run_shell"]` where `run_shell` has `ApprovalPolicy(mode="always")`. When the model calls `run_shell`, the backend emits a `deferred` StepEvent, the executor sets the task to `INPUT_REQUIRED`, the client receives an `input_required` StreamEvent, and `render_stream` returns with `deferred_calls`. The approval widget (`approve.py`) presents each deferred tool call for Approve/Deny.
 
 > **Critical**: This flow spans 8 files and has NO integration test coverage. It is the highest-risk interactive test.
 
 | # | Test | Action | Expected |
 |---|------|--------|----------|
-| A3 | Do shell | `fin do shell "list files in the current directory"` | Model calls `run_shell`, approval widget appears showing tool name (`run_shell`), args (the command), and reason ("Shell command execution requires approval") |
-| E1 | Shell supports do | `fin do shell "echo hello"` | Same as A3 — verifies serving mode allows `do` for `shell` (command reaches approval, not rejected by mode check) |
-| B1 | Approve (default) | `fin do shell "echo hi"`, press Enter immediately | Approve is the default selection; command runs server-side, output displayed, exit 0 |
+| A3 | Do with approval | `fin do "list files in the current directory"` | Model calls `run_shell`, approval widget appears showing tool name (`run_shell`), args (the command), and reason ("Shell command execution requires approval") |
+| B1 | Approve (default) | `fin do "echo hi"`, press Enter immediately at approval | Approve is the default selection; command runs server-side, output displayed, exit 0 |
 | B2 | Approve (navigate) | Arrow-key to Approve (already there), press Enter | Same as B1 |
 | B3 | Deny | Arrow-down to Deny, press Enter | `[dim]Tool call cancelled[/dim]`, no command execution, exit 0 |
 | B4 | Ctrl+C | During approval prompt | Cancels (same as B3), exits cleanly |
@@ -185,7 +192,7 @@ This replaces the old post-response approval model. Approval is now **in-flight*
 
 > **Debug**: Widget issues → `cli/interaction/approve.py`. Deferred flow → `hub/executor.py:_handle_deferred_event` + `_extract_approval_results`. Client → `cli/client.py:stream_agent` + `_extract_deferred_calls`. Backend → `agents/backend.py:_PydanticAIStepHandle` deferred detection + `build_deferred_results`.
 
-### 2b. REPL (`fin talk <agent>`)
+### 2b. REPL (`fin talk`)
 
 Tests the full chat loop with FinPrompt, streaming, session persistence, and resume.
 
@@ -193,9 +200,8 @@ Tests the full chat loop with FinPrompt, streaming, session persistence, and res
 
 | # | Test | Action | Expected |
 |---|------|--------|----------|
-| A6 | Default agent shortcut (talk) | `fin talk` (no agent arg) | Enters REPL as `default` agent |
-| E4 | Default supports talk | `fin talk default` | Works, enters REPL — verifies serving mode allows `talk` for `default` |
-| C1 | Basic chat (streaming) | `fin talk default`, type a message, Enter | Response streams progressively via `Live` + Markdown; final panel rendered |
+| A6 | Default agent shortcut (talk) | `fin talk` (no agent arg) | Enters REPL using `[general] default_agent` from config |
+| C1 | Basic chat (streaming) | `fin talk`, type a message, Enter | Response streams progressively via `Live` + Markdown; final panel rendered |
 | C2 | Exit with /exit | Type `/exit` (after at least one turn) | Chat ends, `[dim]Session saved: <slug>[/dim]` where `<slug>` is a coolname (e.g. `swift-harbor`) |
 | C3 | Unknown slash command | Type `/bad` | `[yellow]Unknown command: /bad[/yellow]`, then `Type /help for available commands` |
 | C4 | Empty input | Press Enter with nothing typed | No message sent, prompt returns |
@@ -203,79 +209,53 @@ Tests the full chat loop with FinPrompt, streaming, session persistence, and res
 | C6 | Ctrl+C exits | Press Ctrl+C at prompt | `[dim]Exiting chat[/dim]`, chat loop ends |
 | C7 | Ctrl+D exits | Press Ctrl+D at prompt | Same as C6 |
 | C8 | Exit without chatting | `/exit` immediately after starting `talk` (no turns sent) | Chat ends, **no** `Session saved` message (nothing to save) |
-| C9 | Session file exists | After C2, check `~/.local/share/fin/sessions/default/<slug>.json` | File exists, JSON with `context_id` and metadata |
-| C10 | Resume session | `fin talk default --resume <slug>` (use slug from C2) | Chat resumes; prior context is in history; no new `Session saved` message on exit |
-| C11 | Resume nonexistent | `fin talk default --resume ghost-banana` | `Error: Session ghost-banana not found`, exit 1 |
-| C12 | List sessions (--list) | `fin talk default --list` | Lists saved sessions for `default`: `<slug> (context: <cid[:8]>...)`. Or `No sessions for default` if empty. |
-| C13 | Initial message | `fin talk default "what time is it"` | First turn auto-sent, response streams, then enters REPL for follow-up |
+| C9 | Session file exists | After C2, check `~/.local/share/fin/sessions/<agent>/<slug>.json` | File exists, JSON with `context_id` and metadata |
+| C10 | Resume session | `fin talk --resume <slug>` (use slug from C2) | Chat resumes; prior context is in history; no new `Session saved` message on exit |
+| C11 | Resume nonexistent | `fin talk --resume ghost-banana` | `Error: Session ghost-banana not found`, exit 1 |
+| C12 | List sessions (--list) | `fin talk --list` | Lists saved sessions: `<slug> (context: <cid[:8]>...)`. Or `No sessions for <agent>` if empty. |
+| C13 | Initial message | `fin talk "what time is it"` | First turn auto-sent, response streams, then enters REPL for follow-up |
 | C14 | `/sessions` slash command | Inside REPL, type `/sessions` | Lists saved sessions for the current agent (same format as `--list`) |
 | C15 | `/help` slash command | Inside REPL, type `/help` | Prints available slash commands |
-| C16 | `--show-thinking` | `fin talk default --show-thinking`, chat once | Thinking blocks (if the model emits them) appear in the output |
-| F2 | Talk mode, missing key | Unset `ANTHROPIC_API_KEY`, then `fin talk default`, send one message | Yellow "Authentication required" panel; then `[dim]Fix credentials and try again.[/dim]`; chat loop exits |
+| C16 | `--show-thinking` | `fin talk --show-thinking`, chat once | Thinking blocks (if the model emits them) appear in the output |
+| F2 | Talk mode, missing key | Unset `ANTHROPIC_API_KEY`, then `fin talk`, send one message | Yellow "Authentication required" panel; then `[dim]Fix credentials and try again.[/dim]`; chat loop exits |
 
 > **Debug**: REPL issues → `cli/interaction/chat.py`, `FinPrompt`. Streaming issues → `_PydanticAIStepHandle` in `agents/backend.py`. Session issues → session persistence code.
 
 ### 2c. In-Flight Approval in Talk Mode
 
-Tests the deferred approval flow within the chat loop. When the default agent (or any agent with approval-gated tools) calls a tool requiring approval mid-conversation, the chat loop should show the approval widget, then resume streaming after the decision.
+Tests the deferred approval flow within the chat loop. When the agent calls a tool requiring approval mid-conversation, the chat loop should show the approval widget, then resume streaming after the decision.
 
 > **Prerequisite**: B1 and C1 must pass first.
 
 | # | Test | Action | Expected |
 |---|------|--------|----------|
-| I1 | Approval in talk (approve) | `fin talk default`, ask it to run a shell command (e.g. "run ls using the run_shell tool") | Model calls `run_shell` → approval widget appears → approve → command runs server-side → output displayed → chat continues |
+| I1 | Approval in talk (approve) | `fin talk`, ask it to run a shell command (e.g. "run ls using the run_shell tool") | Model calls `run_shell` → approval widget appears → approve → command runs server-side → output displayed → chat continues |
 | I2 | Approval in talk (deny) | Same as I1, but deny | `[dim]Tool call cancelled[/dim]` → chat continues (can send more messages) |
 | I3 | Approval in talk (cancel) | Same as I1, but Ctrl+C | `[dim]Tool call cancelled[/dim]` → chat continues |
 | I4 | Multi-turn after denial | Deny a tool call, then send another message | Chat loop continues normally; context preserved |
 | I5 | Approval + session save | Approve a tool call, then `/exit` | Session saved with the full conversation including the approved tool result |
 
-> **Note**: The default agent doesn't have `run_shell` in its tools by default, and the `shell` agent only supports `do` mode. To test I1–I5, create a dedicated test agent in your TOML config:
->
-> ```toml
-> [agents.test-approval]
-> description = "Agent for testing in-flight approval"
-> system_prompt = "You can run shell commands when asked."
-> output_type = "text"
-> serving_modes = ["do", "talk"]
-> tools = ["run_shell"]
-> ```
->
-> Then use `fin talk test-approval` for I1–I5. This makes the tests reproducible without modifying the default or shell agent configs.
-
 ### 2d. Prompt Completions & History
 
-Tests FinPrompt features: fuzzy slash completion and persistent history. Run after C1/C2 confirm the basic REPL works.
+Tests FinPrompt features: fuzzy slash completion, `@`-completion, and persistent history. Run after C1/C2 confirm the basic REPL works.
 
 | # | Test | Action | Expected |
 |---|------|--------|----------|
-| D1 | Slash trigger | Type `/` then Tab | Completion menu shows `/exit`, `/help`, `/sessions` + agent names (`default`, `shell`) |
+| D1 | Slash trigger | Type `/` then Tab | Completion menu shows `/exit`, `/help`, `/sessions` + agent names |
 | D2 | Fuzzy /exit | Type `/ex`, Tab | Completes to `/exit` |
 | D3 | Fuzzy /help | Type `/he`, Tab | Completes to `/help` |
 | D4 | Fuzzy /sessions | Type `/se`, Tab | Completes to `/sessions` |
+| H1 | `@` trigger | Type `@` then Tab | Shows context-type options (`file:`, `git:diff`, `git:log`, `history:`) |
+| H2 | `@file:` completion | Type `@file:` + partial path + Tab | Shows matching files |
+| H3 | `@git:` completion | Type `@git:` + Tab | Shows `diff`, `log` |
+| H4 | `@history:` completion | Type `@history:` + Tab | Shows recent shell history |
 | D5 | History up | Press Up arrow in an empty prompt | Previous input recalled |
 | D6 | History down | Press Down after Up | Next/empty |
-| D7 | History persists | Exit (`/exit`), re-launch `fin talk default`, press Up | Previous session's input available |
+| D7 | History persists | Exit (`/exit`), re-launch `fin talk`, press Up | Previous session's input available |
 | D8 | History file | `cat ~/.local/share/fin/history` | File exists; format is prompt_toolkit `FileHistory` (entries prefixed with `+`, timestamp comments with `#`) — not bare lines |
 
 > Debug: Completion issues → cli/interaction/prompt.py completion config. History issues → FileHistory wiring in same file.
 > Note: Slash commands that used to be planned (`/quit`, `/q`, `/switch`) do **not** exist. Don't test them.
-
----
-
-## Not Yet Implemented
-
-### Chunk H — `@`-Completion in Talk
-
-*Planned for Step 8 of the config-driven redesign.*
-
-> **Status**: No `@`-trigger logic exists in `cli/interaction/prompt.py`. See `handoff.md`.
-
-| # | Test | Action | Expected |
-|---|------|--------|----------|
-| H1 | `@` trigger | Type `@` | Shows context-type options (`file:`, `git:`, `history:`) |
-| H2 | `@file:` completion | Type `@file:` + partial path + Tab | Shows matching files |
-| H3 | `@git:` completion | Type `@git:` + Tab | Shows git context options (`diff`, `log`, `status`) |
-| H4 | `@history:` completion | Type `@history:` + Tab | Shows recent shell history |
 
 ---
 
@@ -290,16 +270,16 @@ Known gaps in automated test coverage that should be addressed before or alongsi
 | `_do_command` deferred approval resume | `cli/main.py:253-266` | **High** — same as chat.py but for the `do` command path | Add unit test with mocked `client.stream_agent` and `run_approval_widget`. |
 | `stream_agent` with `approval_decisions` | `cli/client.py:330-338` | **Medium** — the `approval_result` Part construction is untested | Add unit test verifying Part metadata construction. |
 | Executor `tool_call`/`tool_result` dispatch | `hub/executor.py:229-266` | **Low** — unit tests verify artifact content, metadata, and append semantics; `tool_result` content fallback paths untested | Covered by `TestExecutorToolCallDispatch` and `TestExecutorArtifactAppendSemantics` |
-| `ApprovalPolicy.condition` callable | `agents/tools.py:38` | **Low** — dead code; `conditional` mode is defined but never used | Either implement a test or remove the dead code path. Filed as potential cleanup. |
+| `_CONTEXT_TYPE_MAP` centralization | `agents/spec.py:51-56` | **Low** — private class attribute hardcodes tool→context mappings; tests read the private attribute | Move to shared location or derive from `ToolRegistry` + `ContextProvider` metadata. |
 
 ---
 
 ## Running Order
 
 ```text
-just test  ←  635 tests, 91% coverage
+just test  ←  704 tests, 91% coverage
                Covers: types, config, context (mocked), agent spec, context store,
-                       factory, credentials, display, prompt, response,
+                       factory, credentials, display, prompt, @-completion, response,
                        integration: discovery, dispatch, auth, streaming, multi-turn
 
 just test-cov  ←  per-file coverage report (identifies gaps above)
@@ -307,26 +287,24 @@ just test-cov  ←  per-file coverage report (identifies gaps above)
 Part 1 (Manual) — agent runs only the uncovered tests
 ┌──────────────────────────────────────────────────────────┐
 │ 1a. Server Lifecycle (A7-A15) — all manual               │
-│ A5  (default agent shortcut — CLI arg parse)             │
-│ E2  (shell rejects talk — CLI validation)                │
-│ G1, G2, G5 (context injection — requires LLM)           │
+│ 1c. Platform Capabilities (L1-L4) — local, no hub       │
+│ A5  (default agent from config — CLI arg parse)          │
+│ G1, G2, G5 (@-completion — requires LLM)                │
 │ F1/F3 (optional — env var propagation only)              │
 └────────────────────────┬─────────────────────────────────┘
                          │ all pass
                          ▼
 Part 2 (Interactive) — human at TTY
 ┌──────────────────────────────────────────────────────────┐
-│ 2a. In-Flight Approval (A3, E1, B1-B7)  ← HIGHEST RISK │
+│ 2a. In-Flight Approval (A3, B1-B7)        ← HIGHEST RISK│
 │                                                          │
-│ 2b. REPL (A6, E4, C1-C16, F2)                           │
+│ 2b. REPL (A6, C1-C16, F2)                               │
 │     │                                                    │
 │     ├── 2c. Approval in Talk (I1-I5)  ← needs 2a + 2b  │
 │     │                                                    │
-│     └── 2d. Prompt Completions (D1-D8)                   │
+│     └── 2d. Completions + History (D1-D8, H1-H4)        │
 │         (after C1/C2 confirm REPL works)                 │
 └──────────────────────────────────────────────────────────┘
-
-Chunk H (@-completion) is NOT YET IMPLEMENTED — skip.
 ```
 
 ---
@@ -335,9 +313,9 @@ Chunk H (@-completion) is NOT YET IMPLEMENTED — skip.
 
 Before a big refactor, run the minimum set most likely to catch regressions:
 
-**Automated** (`just test`): 635 tests covering protocol layer + streaming + multi-turn + card extensions + auth + types + config + artifact append semantics
+**Automated** (`just test`): 704 tests covering protocol layer + streaming + multi-turn + card extensions + auth + types + config + @-completion + artifact append semantics
 
-**Manual (agent runs)**: A7–A15 (server lifecycle), A5 (default shortcut), E2 (shell rejects talk)
+**Manual (agent runs)**: A7–A15 (server lifecycle), L1–L4 (platform capabilities), A5 (default from config)
 
 **Interactive (human runs)**:
 - Approval: B1, B3, B4 (Approve-default, Deny, Ctrl+C) — **highest priority**
@@ -362,11 +340,9 @@ Before a big refactor, run the minimum set most likely to catch regressions:
 - Session slugs are coolnames from `coolname.generate_slug(2)` — e.g. `swift-harbor`, not UUIDs.
 - History file: `~/.local/share/fin/history`. Sessions dir: `~/.local/share/fin/sessions/<agent>/<slug>.json`.
 - The "Session saved" message only prints when (a) at least one turn completed, AND (b) the session is not a resume.
-- `fin do "prompt"` / `fin talk` (no agent arg) → `[agents.default]`.
-- `shell.serving_modes = ["do"]` — no talk mode.
-- `default.serving_modes = ["do", "talk"]`.
-- `shell` agent uses `output_type = "text"` with `tools = ["run_shell"]`. The model decides when to call `run_shell`; the platform gates it with `ApprovalPolicy(mode="always")`.
-- `default` agent uses `output_type = "text"` with `tools = ["read_file", "git_diff", "git_log", "shell_history"]`. All tools have `approval_policy=None` (no approval needed).
+- `fin do "prompt"` / `fin talk` (no `--agent`) → `[general] default_agent` from config.
+- All agents are config entries. The dev `test` agent uses `output_type = "text"` with `tools = ["read_file", "git_diff", "run_shell"]`.
+- Context injection uses `@`-completion in the input panel: `@file:path.py`, `@git:diff`, `@git:log`, `@history:query`. The `--file`/`--git-diff` CLI flags have been removed.
 - `fin serve` runs the hub in the foreground (distinct from `fin start` which daemonizes). Useful for development; see A15.
-- The approval model changed in Phase C: `requires_approval: bool` is gone. Approval is now `ApprovalPolicy` on `ToolDefinition`, enforced in-flight by the backend (deferred tools), verified by the Executor. The old post-response `handle_post_response` approval branch is removed.
-- `--file` and `--git-diff` CLI flags are implemented on `do`. `--git-log` is not wired (low priority — model can call the `git_log` tool).
+- The approval model uses `ApprovalPolicy` on `ToolDefinition`, enforced in-flight by the backend (deferred tools), verified by the Executor.
+- `fin list tools/prompts/output-types` shows platform registry contents without requiring a hub connection.

--- a/handoff.md
+++ b/handoff.md
@@ -2,204 +2,42 @@
 
 Rolling context for session handoffs. Updated as checkpoints are reached.
 
-**Current state (2026-04-26)**: 694 tests passing, CI green. PR #87 (`feature/tools-plus`) self-review triage complete — all 44 review threads resolved. Phase 1 quick wins, 5 real smells, `Executor.execute()` split, three Phase 3 bug audits, and small follow-ups (`cec3b08`) landed. Phase 4 architectural discussions filed as issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94).
+**Current state (2026-04-27)**: 704 tests passing, CI green. All Tier 1 features shipped: `@`-completion, `fin list`, input panel + `--edit`, remove built-in agents, client artifact-merge fix. Documentation synced with codebase. Phase 4 architectural discussions filed as issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94).
 
 **Core platform status:**
 
 | Area | Status |
 |------|--------|
-| Executor rework + tool calling | Complete (Phases A + B merged via PR #87) |
-| HITL approval | Complete (Phase C — `ApprovalPolicy`, deferred tool flow, approval widget) |
-| ContextProviders dual path | Both model-driven (tools) and user-driven (`--file`/`--git-diff`) work; UX redesign deferred |
-| Streaming UX (thinking + text deltas, `render_stream`) | Complete |
-| Observability / tracing | Design resolved (Phoenix + OTel); implementation deferred (Phase D) |
+| Executor rework + tool calling | ✅ Complete (Phases A + B merged via PR #87) |
+| HITL approval | ✅ Complete (Phase C — `ApprovalPolicy`, deferred tool flow, approval widget) |
+| ContextProviders dual path | ✅ Complete — model-driven (tools) + user-driven (`@`-completion) |
+| Streaming UX (thinking + text deltas, `render_stream`) | ✅ Complete |
+| `fin do` input panel + `--edit` | ✅ Complete — interactive input, pre-fill, `--agent` flag |
+| `@`-completion in FinPrompt | ✅ Complete — `AtCompleter`, `resolve_at_references`, `_CombinedCompleter` |
+| `fin list` capabilities | ✅ Complete — `tools`, `prompts`, `output-types` (local, no hub) |
+| Remove built-in agents | ✅ Complete — `_DEFAULT_AGENTS = {}`, all from config.toml |
+| Client artifact-merge fix | ✅ Complete — splice in both `stream_agent()` and `_send_and_wait()` |
+| Observability / tracing | 📐 Design resolved (Phoenix + OTel); implementation deferred (Phase D) |
 
-**Deferred / tracked elsewhere:**
+**Remaining tracked items:**
 
-- Context UX redesign — both paths work, user-driven path needs rethinking. See "Context UX" sketch below.
-- `@` completion in `FinPrompt` (replaces `--file`/`--git-diff` long-term) — sketch below.
-- `fin do` input panel + `--edit` flag + aggregation removal — sketch below.
+- `_CONTEXT_TYPE_MAP` centralization — `AgentSpec._CONTEXT_TYPE_MAP` hardcodes tool→context mappings; tests read the private attribute.
 - AgentBackend protocol simplification ([#80](https://github.com/ColeB1722/fin-assist/issues/80))
-- `_CONTEXT_TYPE_MAP` centralization — `AgentSpec._CONTEXT_TYPE_MAP` hardcodes tool→context mappings; tests read the private attribute. Also unblocks `hub/factory.py:124` which mutates private `_tool_registry`.
-- CLI capabilities listing ([#88](https://github.com/ColeB1722/fin-assist/issues/88)) — `fin list tools/prompts/output-types/backends`.
-- Remove built-in agents — make platform pure infrastructure; all agents defined in `config.toml`. Sketch below.
-
----
-
-## PR #87 Self-Review Triage (2026-04-26)
-
-45 review comments left on PR #87 as a notetaking mechanism (personal project, no GitHub review workflow). Worked through in phases. Handoff.md is the primary channel going forward — not posting new PR replies.
-
-### Phase 1 — Quick wins (landed, commit `6149a2b`)
-
-- Removed no-op `from __future__ import annotations` from `agents/__init__.py`, `cli/__init__.py`
-- Removed stale root-level `hub.log` from `.gitignore` (covered by `.fin/`)
-- `_key_arg_for_tool` in `streaming.py` → `match` on `(tool_name, args)` tuples
-- Removed 8 redundant `dest=` kwargs in `cli/main.py` argparse
-- Two if/elif chains in `cli/client.py::_stream_message` → `match meta.get("type")`
-- Added "Env var naming convention" subsection to `AGENTS.md` documenting `FIN_<NAME>` vs `FIN_<SECTION>__<FIELD>` (project-specific, not industry standard)
-
-### Phase 2 — Real smells (all landed)
-
-| # | Smell | Commit | Fix |
-|---|-------|--------|-----|
-| 1 | Duplicated version envelope (`backend.py` and `context_store.py`) | `3a35e39` | Extracted to new `agents/serialization.py`; both call `wrap_payload`/`unwrap_payload`. |
-| 2 | `conditional` approval mode was dead code (never dispatched) | `a30a987` | Dropped mode and `condition` field; `ApprovalPolicy.mode: Literal["never", "always"]`. pydantic-ai `Tool` has only `requires_approval: bool` — per-call predicates would require framework-specific wrapping, breaking platform neutrality. |
-| 3 | `deferred_calls: list[dict[str, Any]]` at approval widget boundary | `6196778` | Promoted `DeferredToolCall` through `StreamEvent` → `render_stream` → `run_approval_widget`. |
-| 4 | Logging coverage near-zero despite configured `RotatingFileHandler` | `cf2e258` | Lifecycle `logger.info` in executor (execute/cancel/pause/resume/auth) + factory (agent mount); AGENTS.md "Logging" section. |
-| 5 | `Executor.execute()` was 90+ lines with interleaved concerns | `b4d788e` | Split into `_setup_task` / `_load_history` / `_start_run` / `_consume_events` / `_pause_for_approval` / `_finalize` + `_ExecutionContext` dataclass. |
-
-### Phase 3 — Real bugs to audit
-
-| # | Issue | Commit | Notes |
-|---|-------|--------|-------|
-| 1 | Subprocess cleanup in `_run_shell` (`agents/tools.py`) — `subprocess.run()` in `loop.run_in_executor` leaks child processes on asyncio cancellation | `160c6fc` | Rewrote using `asyncio.create_subprocess_shell` with `asyncio.wait_for` for timeout + `_terminate_and_wait` helper. On `CancelledError` we terminate the child and re-raise; on timeout or I/O error we terminate and return a user-visible message. Added tests for spawn failure, I/O error, timeout-terminates-child, and cancellation-terminates-child-and-propagates. |
-| 2 | `factory.create_a2a_app` mutates `agent._tool_registry` post-construction (`hub/factory.py:127-128`) to make `AgentSpec.requires_approval` return correct value | `3f18230` | `AgentSpec.requires_approval` was unused in `src/` (only two tests read it). Dropped the property, the `tool_registry` constructor param on `AgentSpec`, and the factory mutation. If static per-agent approval info is ever needed, the right home is `AgentCardMeta` where the factory can compute it correctly. Backend still receives the registry directly via `PydanticAIBackend(tool_registry=...)` — that path is untouched. |
-| 3 | Duck-typed `hasattr('content')` dispatch on `event.content` in executor `tool_result` handler (`hub/executor.py`) leaks pydantic-ai types (`ToolReturnPart`, `RetryPromptPart`) into framework-agnostic `Executor` | `5ddeb72` | Normalised `StepEvent.content` to `str` for `tool_result` events. Added `_extract_tool_result_text()` in `PydanticAIBackend` — handles both `ToolReturnPart` (reads `.content`, stringifies if non-string) and `RetryPromptPart` (uses `.model_response()` for a human-readable retry description). Executor now just does `Part(text=event.content)`. Documented the `content` contract per `kind` on the `StepEvent` docstring. Added 5 new tests for the extraction helper + end-to-end verification. |
-
-### Phase 4 — Architectural discussions (filed as GitHub issues)
-
-Each brief contains file/symbol pointers, current-behavior summary, and the specific design questions. Pick one and open a fresh session against it.
-
-| Issue | Topic |
-|---|---|
-| [#89](https://github.com/ColeB1722/fin-assist/issues/89) | Hardcoded system prompts vs loadable markdown files |
-| [#90](https://github.com/ColeB1722/fin-assist/issues/90) | Consolidate scattered CLI rendering constants |
-| [#91](https://github.com/ColeB1722/fin-assist/issues/91) | Richer rendering for tool_result output (beyond 120-char truncation) |
-| [#92](https://github.com/ColeB1722/fin-assist/issues/92) | Simplify `render_stream` state machine (needs `exa` research spike first) |
-| [#93](https://github.com/ColeB1722/fin-assist/issues/93) | Repo-wide convention: protobuf struct `.attr` vs `MessageToDict + .get()` |
-| [#94](https://github.com/ColeB1722/fin-assist/issues/94) | `fin do` vs `fin prompt` — clarify semantics |
-
-### Workflow notes
-
-Full review-thread triage complete: all 44 threads resolved (0 unresolved). Approach was reply-with-reference + resolve. Replies link to the commit that addressed the concern (Phase 1–3 landed work, or the `cec3b08` follow-up refactors) or to the Phase 4 issue that captured the design discussion (#89–#94). Threads that were pure investigation/explanation got resolved without a new reply since the earlier investigation reply already answered them.
+- `build_user_message`/`format_context` helpers in `llm/prompts.py` are dead code
+- `git_status` provider orphaned — not exposed as a tool or `@`-completion
+- `supported_context_types` published in agent cards, never consumed by clients
+- Phase 4 architectural discussions — issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94)
 
 ---
 
 ## Next Session
 
-PR #87 triage is complete. Pick from:
+Pick from:
 
 1. **Phase 4 design discussions** — open issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94). Each issue body is a session-ready brief. `#92` has a research spike as pre-work.
-2. **Deferred feature work** — design sketches below: `fin do` input panel + `--edit`, `@` context completion, remove built-in agents, client artifact-merge fix.
-3. **Other open issues** — see `gh issue list` for the broader backlog.
-
----
-
-## Design Sketches (not started)
-
-### `fin do` Input Panel + `--edit` + Aggregation Removal (2026-04-26)
-
-**Problem.** `fin do` requires a prompt on the CLI — no interactive input path. `fin talk` has `FinPrompt`, but `do` only accepts raw CLI args. Multi-word `nargs="+"` + `" ".join()` creates ambiguity with the optional `agent` positional.
-
-**Goal.** Consistent `do`/`talk`:
-
-| Invocation | `do` | `talk` |
-|---|---|---|
-| `fin do/talk` | Blank input panel | Blank input panel |
-| `fin do/talk "prompt"` | Execute immediately | Send then loop |
-| `fin do/talk --agent shell "prompt"` | Execute with agent | Send with agent, loop |
-| `fin do/talk --edit "prompt"` | Panel pre-filled | Panel pre-filled |
-
-**Design.**
-
-1. Argparse: `do.prompt: nargs="?"`, `talk.message: nargs="?"`, add `--edit`, change `agent` to `--agent` flag.
-2. `_do_command` three branches: no prompt → `FinPrompt.ask("> ")`; `--edit` → `fp.ask(default=prompt)`; prompt only → current. All converge on `render_stream()` → approval → `handle_post_response()`.
-3. `_talk_command --edit` routes to `run_chat_loop(edit_message=prompt)`.
-4. `FinPrompt.ask(default: str | None = None)` — pass through to `prompt_async()`.
-5. `run_chat_loop(edit_message: str | None = None)` — first iteration pre-fills.
-6. Slash commands in `do`: `/help` only; `/exit` and `/sessions` don't apply.
-7. Keep `--file`/`--git-diff` as scripting fast paths until `@` completion lands.
-
-**Tests to add:** `ask()` with `default`; `run_chat_loop` with `edit_message`; `fin do` no prompt → panel → execute; `fin do --edit`; remove tests relying on `args.prompt = [...]` aggregation.
-
-### Context `@` Completion (2026-04-26)
-
-**Status.** Deferred. Blocked on nothing — start after input panel lands.
-
-**Problem.** Context injection via CLI flags (`--file`, `--git-diff`) isn't discoverable and can't be used from the input panel. `@`-completion would let users type `@file:path.py` or `@git:diff` inline in `FinPrompt`, with fuzzy completion. Works in both `do` and `talk`.
-
-**Plan.**
-
-1. **`@` completer in `FinPrompt`** — new `AtCompleter` (like `SlashCompleter`), triggers on `@`, calls `ContextProvider.search()`.
-2. **Inline context injection** — resolve `@type:ref` via matching `ContextProvider.get_item()`, inject content (same format as `_inject_context()`).
-3. **Deprecate `--file` / `--git-diff`** — add deprecation warning, remove in a later release.
-4. **`/` vs `@`** — slash for actions (`/help`, `/exit`), `@` for content injection. No overlap.
-
-**Why defer.** Input panel + `--edit` is independently valuable. `@` touches `FinPrompt`, `ContextProvider`, `_inject_context()`, and both handlers — better as a separate PR.
-
-### Remove Built-in Agents (2026-04-25)
-
-**Status.** Design sketch, not started. Depends on: nothing (paths sketch already landed — `FIN_DATA_DIR` in place).
-
-**Problem.** The platform ships two hardcoded agents (`default`, `shell`) in `_DEFAULT_AGENTS`. This conflates platform infrastructure with agent design. `fin do "prompt"` hardcodes the default agent name as `"default"` rather than reading from config.
-
-**Goal.** Empty `_DEFAULT_AGENTS`. All agents in `config.toml`. `fin do` routes to `[general] default_agent`. No default → clear error with setup guidance.
-
-**Design.**
-
-1. **Empty `_DEFAULT_AGENTS`** — `{}`. `Config.agents` default is empty.
-2. **`[general] default_agent` config field** — CLI resolves default name from config; errors with minimal TOML example if unset.
-3. **TOML agent merging — must fix.** pydantic-settings currently replaces `agents` dict wholesale. Fix in `loader.py` — merge TOML `config.agents` into defaults (TOML wins per-key). Add unit test.
-4. **Local `config.toml` with `test` agent** — exercises every pluggable axis (text output + thinking + both serving modes + one no-approval tool + one approval-gated tool):
-
-    ```toml
-    [general]
-    default_agent = "test"
-
-    [agents.test]
-    description = "Platform test agent — exercises every pluggable axis."
-    system_prompt = "test"
-    output_type = "text"
-    thinking = "medium"
-    serving_modes = ["do", "talk"]
-    tools = ["read_file", "run_shell", "git_diff"]
-    tags = ["test", "internal"]
-    ```
-
-5. **`test` system prompt** — deterministic tool-triggering prompt in `SYSTEM_PROMPTS` registry.
-6. **ContextSettings fix in tool callables** — one-line bug: `_read_file`, `_git_diff`, etc. instantiate providers without passing `ContextSettings`. User-driven path passes `config.context`; model-driven uses defaults. Fix: pass settings through.
-7. **Zero-agents error** — hub starts fine with no agents; CLI commands error clearly: "No agents configured. Add an `[agents.<name>]` section to your config file."
-8. **`CommandResult` and `SHELL_INSTRUCTIONS` stay in the registry** — framework features available to any user agent via config.
-9. **No code changes to shell agent** — it just ceases to exist as a built-in.
-
-**Tests to write first:** `test_default_agents_empty`, `test_loader_merges_toml_agents`, `test_loader_toml_agent_keys_merge`, `test_default_agent_from_config`, `test_no_default_agent_error`, `test_no_agents_configured_error`, `test_test_agent_config_parses`, `test_tool_callables_pass_context_settings`; integration `test_test_agent_streams_text`, `test_test_agent_triggers_approval`.
-
-### Context UX (2026-04-25) — Deferred
-
-**Status.** Two paths work today. Model-driven is strictly more capable. Redesigning the user-driven path is a UX decision deserving its own session.
-
-**Current state.**
-
-- **User-driven** (`--file`/`--git-diff` on `do`): CLI reads file/diff, prepends as `Context:\n[FILE: path]\ncontent` — one big string. Model can't distinguish reference from request. Respects `ContextSettings`. Only on `do`.
-- **Model-driven** (tools: `read_file`, `git_diff`, `git_log`, `shell_history`): Model decides when to fetch, gets structured results, can iterate. **Bug:** doesn't respect `ContextSettings` (tool callables miss settings). Works in both `do` and `talk`.
-
-**Gaps.**
-
-1. Prompt pollution in user-driven path.
-2. `ContextSettings` dual-path inconsistency (bug fix included in "Remove Built-in Agents" sketch).
-3. `supported_context_types` published in agent cards, never consumed.
-4. `build_user_message`/`format_context` in `llm/prompts.py` are dead code.
-5. Talk mode has zero user-driven context (no `@`-completion yet, no flags).
-6. `git_status` provider orphaned — not exposed as a tool or flag.
-7. `Environment` provider entirely unwired (intentionally, sensitive).
-
-**Key questions for future session:**
-
-- User-driven context as a *hint* (steer the model to call a tool) vs raw injection?
-- Does `@`-completion in talk still make sense, or is model-driven sufficient?
-- Do `--file`/`--git-diff` survive, evolve, or get replaced?
-- How to consume `supported_context_types` — validation, auto-suggestion, both?
-
-### Client Artifact-Merge Fix (2026-04-25)
-
-**Status.** Design sketch, not started. Depends on: Test Agent (for regression test to be agent-driven).
-
-**Problem.** `HubClient.stream_agent()` walks A2A response stream and yields `text_delta`/`thinking_delta` but never appends streamed artifacts into `task.artifacts`. When the task reaches terminal, `_extract_result(task)` walks empty `task.artifacts` and returns `AgentResult(output="")`. `_send_and_wait` (line 413-432) maintains a parallel artifact list and splices it back. Splice dropped in commit `b18f920`.
-
-**Symptoms.** `fin do shell "echo hello"` exits 0 with no rendered output. `default` renders on-screen but `result.output == ""` — session continuity broken. Deferred-approval flow: `input_required` fires but `deferred_calls = []`. Integration tests pass because they only check `kind == "completed"` and `success is True`.
-
-**Design.** Mirror `_send_and_wait`'s pattern: collect artifacts alongside yielding deltas, splice before `_extract_result` with `if not task.artifacts:` guard. Add tests asserting `result.output` and `len(deferred_calls)`.
+2. **Tech debt** — `_CONTEXT_TYPE_MAP` centralization, dead code cleanup in `llm/prompts.py`, AgentBackend simplification (#80).
+3. **Future phases** — Multiplexer, TUI, Skills/MCP, additional agents, multi-agent workflows.
+4. **Other open issues** — see `gh issue list` for the broader backlog.
 
 ---
 
@@ -208,7 +46,7 @@ PR #87 triage is complete. Pick from:
 | Phase | Description | Status |
 |-------|-------------|--------|
 | 1–8b | Core platform (repo setup → CLI REPL) | ✅ Complete |
-| — | Config-Driven Redesign | ✅ Steps 1-6 complete, Steps 7-9 deferred (context injection) |
+| — | Config-Driven Redesign (all steps including context injection) | ✅ Complete |
 | — | a2a-sdk migration (from fasta2a) | ✅ Complete (2026-04-20) |
 | — | Backend Extraction (AgentSpec pure config) | ✅ Complete (2026-04-21) |
 | — | Auth-Required Credential Pre-Check | ✅ Complete (2026-04-03) |
@@ -217,12 +55,17 @@ PR #87 triage is complete. Pick from:
 | — | Streaming UX Refactor (thinking in artifacts, `render_stream`) | ✅ Complete (2026-04-23) |
 | — | Unified Executor + Tools + HITL (PR #87 Phases A–C) | ✅ Complete (2026-04-24/26) |
 | — | `FIN_DATA_DIR` unified path | ✅ Complete |
-| — | `fin do` input panel + `--edit` + `@`-completion | ⬜ Sketched above |
-| — | Remove built-in agents | ⬜ Sketched above |
+| — | Remove built-in agents (`_DEFAULT_AGENTS = {}`) | ✅ Complete |
+| — | `fin do` input panel + `--edit` + `--agent` flag | ✅ Complete |
+| — | `@`-completion (AtCompleter + resolve_at_references) | ✅ Complete |
+| — | `fin list` capabilities (tools, prompts, output-types) | ✅ Complete |
+| — | Client artifact-merge fix (splice in stream_agent + _send_and_wait) | ✅ Complete |
+| — | ContextSettings forwarded to tool callables | ✅ Complete |
 | — | PR #87 self-review triage (Phases 1–3) | ✅ Complete (2026-04-26) |
 | — | Phase 4 architecture discussions | 📐 Filed as issues #89–#94 |
+| — | Documentation sync (README, architecture.md, manual-testing.md, handoff.md) | ✅ Complete (2026-04-27) |
 | 9b | Full SSE Streaming (was blocked on fasta2a) | ✅ Covered by a2a-sdk migration |
-| 10 | Non-blocking + interactive tasks | 📐 Sketched (superseded by deferred tools) |
+| 10 | Non-blocking + interactive tasks | 📐 Superseded by deferred tools |
 | 11 | Multiplexer Integration | ⬜ Not Started |
 | 12 | Fish Plugin | ⬜ Not Started |
 | 13 | TUI Client (A2A) | ⬜ Not Started |
@@ -231,7 +74,7 @@ PR #87 triage is complete. Pick from:
 | 16 | Additional Agents | ⬜ Not Started |
 | 17 | Multi-Agent Workflows | ⬜ Not Started |
 | 18 | Documentation | ⬜ Not Started |
-| — | Phoenix/OTel tracing | 📐 Sketched (config + instrumentation path identified) |
+| — | Phoenix/OTel tracing | 📐 Design resolved (Phase D) |
 | — | Nix/Home Manager packaging | 📐 Sketched |
 
 ---
@@ -240,43 +83,68 @@ PR #87 triage is complete. Pick from:
 
 Key completed milestones. See git log for full detail; code is the source of truth.
 
+### Tier 1 Features + Doc Sync (2026-04-27)
+
+All remaining Tier 1 features landed and documentation synchronized with codebase:
+
+- **`@`-completion**: `AtCompleter` in `prompt.py` triggers on `@`, offers `file:`, `git:diff`, `git:log`, `history:` types. `@file:` delegates to `FileFinder.search()`. `resolve_at_references()` replaces `@type:ref` tokens with resolved context content before sending. Works in both `do` and `talk`.
+- **`fin list`**: New `list` subcommand with positional `resource: Literal["tools", "prompts", "output-types"]`. Local registry lookups only — no hub connection. Prints name, description, approval status for tools; name + first line for prompts; name → type name for output-types.
+- **`--file`/`--git-diff` removed**: No deprecation path — codebase isn't stable, so the old CLI flags were simply dropped. `@`-completion is the sole user-driven context path.
+- **`fin do` input panel + `--edit`**: `fin do` without prompt opens FinPrompt input panel. `--edit` pre-fills with the prompt arg. `--agent` flag replaces positional agent arg.
+- **Remove built-in agents**: `_DEFAULT_AGENTS = {}`. All agents from config.toml. `GeneralSettings.default_agent` config field. Zero-agents error with TOML example.
+- **Client artifact-merge fix**: Splice collected artifacts into `task.artifacts` in both `stream_agent()` and `_send_and_wait()` before calling `_extract_result()`.
+- **ContextSettings forwarded to tool callables**: `_make_read_file()`, `_make_git_diff()`, etc. all pass `context_settings` to provider constructors.
+- **Doc sync**: README (duplicate Mermaid subgraph fixed, `@`-completion + `fin list` in status), architecture.md (directory tree updated, context section updated, `--file`/`--git-diff` references corrected to historical), manual-testing.md (test counts, `@`-completion tests, `fin list` tests), handoff.md (full rewrite to reflect current state).
+
 ### Unified Executor & Agent Platform (2026-04-24 → 2026-04-26, PR #87)
 
-Unified five structural gaps into one coherent abstraction: executor loop (multi-step turns), tool calling, dual-path context (user-driven `@`/flags + model-driven tools), HITL approval gates, and OTel-ready step boundaries.
+Unified five structural gaps into one coherent abstraction: executor loop (multi-step turns), tool calling, dual-path context (user-driven `@`-completion + model-driven tools), HITL approval gates, and OTel-ready step boundaries.
 
 **Guiding principle:** the platform owns the abstractions, backends adapt them. Tools, approval, and step events are platform concepts (zero framework imports); `PydanticAIBackend` maps them to pydantic-ai Deferred Tools / Hooks. Future `LangChainBackend` etc. would map the same platform types to their own primitives.
 
 **Phase A (Foundation) shipped.** ContextStore version byte; `StepEvent`/`StepHandle`/`_PydanticAIStepHandle`; Executor rewritten event-driven; all tests updated.
 
-**Phase B (Tool Calling) shipped.** `ToolDefinition`/`ToolRegistry` in `agents/tools.py`; `create_default_registry()` wraps `ContextProvider`s as async callables; `AgentConfig.tools` field; `AgentSpec.supports_context()` derived from tools; `AgentCardMeta.supported_context_types`; `PydanticAIBackend` resolves tools via `tool_registry.get_for_agent(spec.tools)`; CLI `--file`/`--git-diff` flags.
+**Phase B (Tool Calling) shipped.** `ToolDefinition`/`ToolRegistry` in `agents/tools.py`; `create_default_registry()` wraps `ContextProvider`s as async callables; `AgentConfig.tools` field; `AgentSpec.supports_context()` derived from tools; `AgentCardMeta.supported_context_types`; `PydanticAIBackend` resolves tools via `tool_registry.get_for_agent(spec.tools)`.
 
 **Phase C (HITL / Approval) shipped.** `ApprovalPolicy` on `ToolDefinition`; deferred tool flow end-to-end; `DeferredToolCall` dataclass; `run_approval_widget` in CLI.
 
 **Phase D (Observability).** Design only — Phoenix + OTel via `Agent.instrument_all()` aligned to step boundaries. Not yet implemented.
 
+### PR #87 Self-Review Triage (2026-04-26)
+
+45 review comments left on PR #87 as a notetaking mechanism. Worked through in phases:
+
+**Phase 1 — Quick wins** (commit `6149a2b`): Removed stale imports/ignores, `_key_arg_for_tool` → `match`, removed redundant `dest=` kwargs, if/elif → `match`, env var naming convention in AGENTS.md.
+
+**Phase 2 — Real smells** (5 items, all landed): Extracted version envelope to `agents/serialization.py`, dropped `conditional` approval mode, promoted `DeferredToolCall` dataclass, added lifecycle logging, split `Executor.execute()`.
+
+**Phase 3 — Real bugs** (3 items, all landed): Rewrote `_run_shell` with asyncio-native subprocess, dropped unused `AgentSpec.requires_approval`, normalized `StepEvent.content` for `tool_result`.
+
+**Phase 4 — Architectural discussions** filed as issues #89–#94.
+
 ### Streaming UX Refactor (2026-04-23)
 
-Backend streams typed `StreamDelta(kind, content)` via pydantic-ai `agent.iter()`. Executor routes thinking deltas as artifacts with `metadata.type = "thinking"` (replacing post-hoc status updates). Client yields `thinking_delta` events. Shared `cli/interaction/streaming.py::render_stream()` uses Rich `Live` with initial spinner, transitions to `Group(thinking_panel?, answer_markdown)`. Both `do` and `talk` use the same pipeline. Deleted: `streamed`/`skip_text`/`was_streamed` flags, `mode == "talk"` markdown branch, post-hoc thinking status-update loop.
+Backend streams typed `StreamDelta(kind, content)` via pydantic-ai `agent.iter()`. Executor routes thinking deltas as artifacts with `metadata.type = "thinking"`. Client yields `thinking_delta` events. Shared `render_stream()` uses Rich `Live` with initial spinner, transitions to `Group(thinking_panel?, answer_markdown)`. Both `do` and `talk` use the same pipeline.
 
 ### AgentBackend Extraction (2026-04-21)
 
-Extracted pydantic-ai coupling from hub into `AgentBackend` protocol. `AgentSpec` is now pure config (no `build_pydantic_agent`); all pydantic-ai knowledge in `PydanticAIBackend`. ContextStore takes `bytes` in/out — backend owns serialization. Executor takes `AgentBackend` and has zero pydantic-ai imports. `RunResult.new_message_parts: list[Part]` is the A2A domain type. Tracked simplification work as [#80](https://github.com/ColeB1722/fin-assist/issues/80).
+Extracted pydantic-ai coupling from hub into `AgentBackend` protocol. `AgentSpec` is now pure config (no `build_pydantic_agent`); all pydantic-ai knowledge in `PydanticAIBackend`. ContextStore takes `bytes` in/out — backend owns serialization. Executor takes `AgentBackend` and has zero pydantic-ai imports. Tracked simplification work as [#80](https://github.com/ColeB1722/fin-assist/issues/80).
 
 ### fasta2a → a2a-sdk Migration (2026-04-20)
 
-Full migration from `fasta2a` (pydantic's abandoned A2A impl) to `a2a-sdk` v1.0.0 (Google's official). Hub/executor uses `TaskUpdater` for all state transitions. `InMemoryTaskStore` (ephemeral) + SQLite `ContextStore` (conversation history). Agent card uses `AgentExtension(uri="fin_assist:meta")` replacing the old `Skill(id=...)` workaround. FastAPI parent app. Client uses `ClientFactory` + `send_message` async iterator; `_poll_task()` eliminated. Streaming via `add_artifact(append=True, last_chunk=)`.
+Full migration from `fasta2a` (pydantic's abandoned A2A impl) to `a2a-sdk` v1.0.0 (Google's official). Hub/executor uses `TaskUpdater` for all state transitions. `InMemoryTaskStore` (ephemeral) + SQLite `ContextStore` (conversation history). Agent card uses `AgentExtension(uri="fin_assist:meta")`. FastAPI parent app. Client uses `ClientFactory` + `send_message` async iterator. Streaming via `add_artifact(append=True, last_chunk=)`.
 
 ### Config-Driven Redesign (2026-04-11)
 
-Agents went from class-hierarchy (`DefaultAgent`, `ShellAgent` subclasses) to a single `ConfigAgent` driven by TOML. `AgentConfig` in `config/schema.py` with `system_prompt`, `output_type`, `thinking`, `serving_modes`, `requires_approval`, `tags`. `ServingMode = Literal["do", "talk"]` replaces `multi_turn: bool`. `OUTPUT_TYPES` and `SYSTEM_PROMPTS` registries. Direct `Worker[list[ModelMessage]]` (closed #68 — removed private `pydantic_ai._a2a` import). Default agent shortcut via `nargs="?"`. Steps 7-9 (context injection, `@`-completion, "add context" in talk) deferred.
+Agents went from class-hierarchy (`DefaultAgent`, `ShellAgent` subclasses) to a single `ConfigAgent` driven by TOML. `AgentConfig` in `config/schema.py`. `ServingMode = Literal["do", "talk"]` replaces `multi_turn: bool`. `OUTPUT_TYPES` and `SYSTEM_PROMPTS` registries. Direct `Worker[list[ModelMessage]]` (closed #68).
 
 ### Auth-Required Credential Pre-Check (2026-04-03)
 
-Graceful early detection of missing API keys using A2A `auth-required` state. `MissingCredentialsError` raised in `BaseAgent._build_model()` before any LLM call. `FinAssistWorker` (later replaced by a2a-sdk executor) catches it and sets task state. Client renders yellow panel with provider name, env vars, credentials path. Interactive recovery deferred.
+Graceful early detection of missing API keys using A2A `auth-required` state. `MissingCredentialsError` raised in backend before any LLM call. Client renders yellow panel with provider name, env vars, credentials path.
 
 ### Reliable Server Lifecycle (2026-04-09)
 
-Server-owned PID file with `fcntl.flock()` for its entire lifetime. `atexit` + custom SIGTERM handler cleans up. Lock-based stale detection — OS releases lock if server is SIGKILL'd. `stop_server` sends SIGTERM, waits up to 10s, escalates to SIGKILL.
+Server-owned PID file with `fcntl.flock()`. `atexit` + custom SIGTERM handler cleans up. Lock-based stale detection. `stop_server` sends SIGTERM, waits up to 10s, escalates to SIGKILL.
 
 ### Early Platform Setup (2026-03-25 → 2026-04-08)
 
@@ -317,3 +185,5 @@ Phases 1–8b: repo setup, core package structure, LLM module (pydantic-ai + cre
 - Server lifecycle: standalone via `fin serve`; auto-start from CLI; fcntl-locked PID file
 - `AgentSpec` is a pure config object (zero framework imports); all LLM coupling in `PydanticAIBackend`
 - Platform types in `agents/` have zero `hub/` imports by design (platform vs transport separation)
+- `@`-completion is the sole user-driven context path (`@file:`, `@git:diff`, `@git:log`, `@history:`); `--file`/`--git-diff` CLI flags removed
+- `fin list tools/prompts/output-types` lists platform registries locally (no hub connection)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "coolname>=2.0",
     "prompt-toolkit>=3.0",
     "rich>=13.0",
+    "rapidfuzz>=3.0",
+    "pathspec>=0.12",
 ]
 
 [dependency-groups]

--- a/src/fin_assist/agents/metadata.py
+++ b/src/fin_assist/agents/metadata.py
@@ -71,5 +71,6 @@ class AgentCardMeta(BaseModel):
 
     Derived from the agent's tool list — each tool maps to a context type
     via ``AgentSpec._CONTEXT_TYPE_MAP``.  Clients use this to decide which
-    CLI flags (``--file``, ``--git-diff``, etc.) are valid for this agent.
+    ``@``-completion references (``@file:``, ``@git:diff``, etc.) are
+    valid for this agent.
     """

--- a/src/fin_assist/cli/interaction/chat.py
+++ b/src/fin_assist/cli/interaction/chat.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal
 from rich.console import Console
 
 from fin_assist.cli.display import render_session_list
-from fin_assist.cli.interaction.prompt import SLASH_COMMANDS, FinPrompt
+from fin_assist.cli.interaction.prompt import SLASH_COMMANDS, FinPrompt, resolve_at_references
 from fin_assist.cli.interaction.response import PostResponseAction, handle_post_response
 from fin_assist.cli.interaction.streaming import render_stream
 
@@ -132,10 +132,12 @@ async def run_chat_loop(
         # not know what precedes it and starts printing immediately.
         console.print()
 
+        resolved_input = resolve_at_references(user_input, context_settings=fp._context_settings)
+
         # --- Stream and render response ---
         try:
             result, deferred_calls = await render_stream(
-                stream_fn(agent_name, user_input, ctx_id),
+                stream_fn(agent_name, resolved_input, ctx_id),
                 show_thinking=show_thinking,
             )
         except Exception as e:

--- a/src/fin_assist/cli/interaction/chat.py
+++ b/src/fin_assist/cli/interaction/chat.py
@@ -132,7 +132,7 @@ async def run_chat_loop(
         # not know what precedes it and starts printing immediately.
         console.print()
 
-        resolved_input = resolve_at_references(user_input, context_settings=fp._context_settings)
+        resolved_input = resolve_at_references(user_input, context_settings=fp.context_settings)
 
         # --- Stream and render response ---
         try:

--- a/src/fin_assist/cli/interaction/prompt.py
+++ b/src/fin_assist/cli/interaction/prompt.py
@@ -1,12 +1,21 @@
-"""FinPrompt — prompt_toolkit-backed input widget with fuzzy completion and history."""
+"""FinPrompt — prompt_toolkit-backed input widget with fuzzy completion and history.
+
+Supports two completion modes:
+
+- ``/`` triggers **slash commands** (actions like /exit, /help, /sessions).
+- ``@`` triggers **context injection** (@file:path, @git:diff, @git:log,
+  @history:query).  After the user submits, ``resolve_at_references``
+  replaces ``@type:ref`` tokens with resolved context content.
+"""
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.completion import Completer, FuzzyCompleter, WordCompleter
+from prompt_toolkit.completion import Completer, Completion, FuzzyCompleter, WordCompleter
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.styles import Style
 
@@ -15,6 +24,8 @@ if TYPE_CHECKING:
 
     from prompt_toolkit.completion import CompleteEvent
     from prompt_toolkit.document import Document
+
+    from fin_assist.config.schema import ContextSettings
 
 from fin_assist.paths import HISTORY_PATH
 
@@ -50,12 +61,156 @@ class SlashCompleter(Completer):
         yield from self.inner.get_completions(document, complete_event)
 
 
+_AT_CONTEXT_TYPES: dict[str, str] = {
+    "file:": "Inject file contents",
+    "git:diff": "Inject git diff",
+    "git:log": "Inject git log",
+    "history:": "Inject shell history",
+}
+
+
+class AtCompleter(Completer):
+    """Completer that activates when the input contains ``@`` at the cursor.
+
+    Yields context-type completions (``file:``, ``git:diff``, etc.) and,
+    for ``@file:``, delegates to ``FileFinder.search()`` for path-based
+    file completion.
+    """
+
+    def __init__(self, context_settings: ContextSettings | None = None) -> None:
+        self._context_settings = context_settings
+
+    def get_completions(self, document: Document, complete_event: CompleteEvent):  # noqa: ANN201
+        text = document.text_before_cursor
+        at_pos = text.rfind("@")
+        if at_pos == -1:
+            return
+
+        after_at = text[at_pos + 1 :]
+        prefix_len = len(after_at)
+
+        if not after_at or ":" not in after_at:
+            for name, desc in _AT_CONTEXT_TYPES.items():
+                if name.startswith(after_at):
+                    yield Completion(
+                        name,
+                        start_position=-prefix_len,
+                        display=name,
+                        display_meta=desc,
+                    )
+            return
+
+        if after_at.startswith("file:"):
+            file_prefix = after_at[len("file:") :]
+            yield from self._file_completions(file_prefix)
+
+    def _file_completions(self, prefix: str):  # type: ignore[no-untyped-def]
+        from fin_assist.context.files import FileFinder
+
+        finder = FileFinder(settings=self._context_settings)  # type: ignore[arg-type]
+        results = finder.search(prefix if prefix else "")
+        for item in results:
+            if item.status == "available":
+                yield Completion(
+                    item.id,
+                    start_position=-len(prefix) if prefix else 0,
+                    display=item.id,
+                    display_meta="file",
+                )
+
+
+_AT_PATTERN = re.compile(r"@(\w+:\S*)")
+
+
+def resolve_at_references(
+    text: str,
+    context_settings: ContextSettings | None = None,
+) -> str:
+    """Replace ``@type:ref`` tokens in *text* with resolved context content.
+
+    Supported references:
+
+    - ``@file:<path>`` — file contents via ``FileFinder``
+    - ``@git:diff`` — git diff via ``GitContext``
+    - ``@git:log`` — git log via ``GitContext``
+    - ``@history:`` or ``@history:<query>`` — shell history
+
+    Unrecognised ``@type:ref`` tokens are left as-is (not an error).
+    """
+    context_sections: list[str] = []
+    remaining = text
+
+    for match in _AT_PATTERN.finditer(text):
+        ref = match.group(1)
+        resolved = _resolve_single_ref(ref, context_settings)
+        if resolved is not None:
+            remaining = remaining.replace(match.group(0), "", 1)
+            context_sections.append(resolved)
+
+    if not context_sections:
+        return text
+
+    context_block = "\n\n".join(context_sections)
+    prompt = remaining.strip()
+    if prompt:
+        return f"Context:\n{context_block}\n\nUser request:\n{prompt}"
+    return f"Context:\n{context_block}"
+
+
+def _resolve_single_ref(
+    ref: str,
+    context_settings: ContextSettings | None,
+) -> str | None:
+    """Resolve a single ``type:ref`` string.  Returns None for unknown types."""
+    if ref.startswith("file:"):
+        path = ref[len("file:") :]
+        from fin_assist.context.files import FileFinder
+
+        finder = FileFinder(settings=context_settings)
+        item = finder.get_item(path)
+        if item.status == "available":
+            return f"[FILE: {path}]\n{item.content}"
+        return f"[FILE: {path}] Error: {item.error_reason}"
+
+    if ref == "git:diff":
+        from fin_assist.context.git import GitContext
+
+        ctx = GitContext(settings=context_settings)
+        item = ctx.get_item("git_diff:diff")
+        if item.status == "available":
+            return f"[GIT DIFF]\n{item.content}"
+        return f"[GIT DIFF] Error: {item.error_reason}"
+
+    if ref == "git:log":
+        from fin_assist.context.git import GitContext
+
+        ctx = GitContext(settings=context_settings)
+        item = ctx.get_item("git_log:log")
+        if item.status == "available":
+            return f"[GIT LOG]\n{item.content}"
+        return f"[GIT LOG] Error: {item.error_reason}"
+
+    if ref.startswith("history:"):
+        from fin_assist.context.history import ShellHistory
+
+        history = ShellHistory(settings=context_settings)
+        query = ref[len("history:") :]
+        items = history.search(query) if query else history.get_all()
+        if items:
+            content = "\n".join(item.content for item in items)
+            return f"[SHELL HISTORY]\n{content}"
+        return "[SHELL HISTORY] No history available"
+
+    return None
+
+
 class FinPrompt:
     """Reusable prompt_toolkit session with slash-command fuzzy completion.
 
     Features:
     - Fuzzy completion for slash commands (defined in SLASH_COMMANDS)
     - Tab completion for agent names when configured
+    - ``@``-completion for context injection (file, git, history)
     - Persistent history across sessions
     - Readline-style keybindings
     """
@@ -64,14 +219,18 @@ class FinPrompt:
         self,
         agents: list[str] | None = None,
         history_path: Path = HISTORY_PATH,
+        context_settings: ContextSettings | None = None,
     ) -> None:
         self.agents = agents or []
         self.history_path = history_path
+        self._context_settings = context_settings
 
-    def _build_completer(self) -> SlashCompleter:
+    def _build_completer(self) -> Completer:
         words = [cmd.name for cmd in SLASH_COMMANDS] + self.agents
         word_completer = WordCompleter(words, ignore_case=True)
-        return SlashCompleter(FuzzyCompleter(word_completer))
+        slash_completer = SlashCompleter(FuzzyCompleter(word_completer))
+        at_completer = AtCompleter(context_settings=self._context_settings)
+        return _CombinedCompleter(slash_completer, at_completer)
 
     def _build_session(self) -> PromptSession[str]:
         return PromptSession(
@@ -96,3 +255,22 @@ class FinPrompt:
         """
         session = self._build_session()
         return await session.prompt_async(prompt_text, default=default or "")
+
+
+class _CombinedCompleter(Completer):
+    """Delegate to the first completer that yields results.
+
+    Tries slash completer first (for ``/`` prefix), then at completer
+    (for ``@`` prefix).  If neither matches, yields nothing.
+    """
+
+    def __init__(self, slash: Completer, at: Completer) -> None:
+        self._slash = slash
+        self._at = at
+
+    def get_completions(self, document: Document, complete_event: CompleteEvent):  # noqa: ANN201
+        text = document.text_before_cursor.lstrip()
+        if text.startswith("/"):
+            yield from self._slash.get_completions(document, complete_event)
+        elif "@" in document.text_before_cursor:
+            yield from self._at.get_completions(document, complete_event)

--- a/src/fin_assist/cli/interaction/prompt.py
+++ b/src/fin_assist/cli/interaction/prompt.py
@@ -15,9 +15,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.completion import Completer, Completion, FuzzyCompleter, WordCompleter
+from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.styles import Style
+from rapidfuzz import fuzz, process
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
     from prompt_toolkit.document import Document
 
     from fin_assist.config.schema import ContextSettings
+    from fin_assist.context.files import FileFinder
 
 from fin_assist.paths import HISTORY_PATH
 
@@ -43,22 +45,48 @@ SLASH_COMMANDS: list[SlashCommand] = [
 ]
 
 
-class SlashCompleter(Completer):
-    """Completer that only activates when the input starts with ``/``.
+_SLASH_MIN_SCORE = 40
+_SLASH_MAX_RESULTS = 20
 
-    Delegates to *inner* (typically a ``FuzzyCompleter``) for the actual
-    completion candidates — but yields nothing when the user is typing
-    ordinary chat text.
+
+class SlashCompleter(Completer):
+    """Fuzzy completer for slash commands and optional agent names.
+
+    Activates only when the current line (after leading whitespace)
+    starts with ``/``.  Uses rapidfuzz for ranking so ``/ex`` → ``/exit``,
+    ``/hlp`` → ``/help``, etc.  Agent names are also candidates and can
+    be typed without the leading ``/``.
     """
 
-    def __init__(self, inner: Completer) -> None:
-        self.inner = inner
+    def __init__(self, commands: list[SlashCommand], agents: list[str]) -> None:
+        self._candidates: list[tuple[str, str]] = [(cmd.name, cmd.description) for cmd in commands]
+        self._candidates.extend((name, "agent") for name in agents)
 
     def get_completions(self, document: Document, complete_event: CompleteEvent):  # noqa: ANN201
-        """Yield completions only when the current line starts with ``/``."""
-        if not document.text_before_cursor.lstrip().startswith("/"):
+        """Yield fuzzy-matched slash commands for the current word."""
+        text = document.text_before_cursor.lstrip()
+        if not text.startswith("/"):
             return
-        yield from self.inner.get_completions(document, complete_event)
+
+        word = document.get_word_before_cursor(WORD=True)
+        # Fuzzy-match against candidate names.  process.extract returns
+        # (choice, score, index) tuples; index lets us recover metadata.
+        names = [name for name, _ in self._candidates]
+        matches = process.extract(
+            word,
+            names,
+            scorer=fuzz.WRatio,
+            limit=_SLASH_MAX_RESULTS,
+            score_cutoff=_SLASH_MIN_SCORE if word else 0,
+        )
+        for name, _score, idx in matches:
+            _, desc = self._candidates[idx]
+            yield Completion(
+                name,
+                start_position=-len(word),
+                display=name,
+                display_meta=desc,
+            )
 
 
 _AT_CONTEXT_TYPES: dict[str, str] = {
@@ -73,12 +101,19 @@ class AtCompleter(Completer):
     """Completer that activates when the input contains ``@`` at the cursor.
 
     Yields context-type completions (``file:``, ``git:diff``, etc.) and,
-    for ``@file:``, delegates to ``FileFinder.search()`` for path-based
-    file completion.
+    for ``@file:``, delegates to a shared ``FileFinder`` instance for
+    fuzzy path matching.  The finder's cache is reused across keystrokes,
+    so only the first keystroke after an ``invalidate()`` pays the scan
+    cost.
     """
 
-    def __init__(self, context_settings: ContextSettings | None = None) -> None:
+    def __init__(
+        self,
+        context_settings: ContextSettings | None = None,
+        file_finder: FileFinder | None = None,
+    ) -> None:
         self._context_settings = context_settings
+        self._file_finder: FileFinder | None = file_finder
 
     def get_completions(self, document: Document, complete_event: CompleteEvent):  # noqa: ANN201
         text = document.text_before_cursor
@@ -105,18 +140,28 @@ class AtCompleter(Completer):
             yield from self._file_completions(file_prefix)
 
     def _file_completions(self, prefix: str):  # type: ignore[no-untyped-def]
-        from fin_assist.context.files import FileFinder
+        finder = self._get_file_finder()
+        paths = finder.search_paths(prefix if prefix else "")
+        for path in paths:
+            yield Completion(
+                path,
+                start_position=-len(prefix) if prefix else 0,
+                display=path,
+                display_meta="file",
+            )
 
-        finder = FileFinder(settings=self._context_settings)  # type: ignore[arg-type]
-        results = finder.search(prefix if prefix else "")
-        for item in results:
-            if item.status == "available":
-                yield Completion(
-                    item.id,
-                    start_position=-len(prefix) if prefix else 0,
-                    display=item.id,
-                    display_meta="file",
-                )
+    def _get_file_finder(self) -> FileFinder:
+        """Return the shared FileFinder, lazily creating one if needed.
+
+        Lazy creation keeps import costs off the hot path for users who
+        never type ``@file:`` and makes the ``AtCompleter`` usable in
+        tests without wiring a finder.
+        """
+        if self._file_finder is None:
+            from fin_assist.context.files import FileFinder
+
+            self._file_finder = FileFinder(settings=self._context_settings)
+        return self._file_finder
 
 
 _AT_PATTERN = re.compile(r"@(\w+:\S*)")
@@ -205,14 +250,16 @@ def _resolve_single_ref(
 
 
 class FinPrompt:
-    """Reusable prompt_toolkit session with slash-command fuzzy completion.
+    """Reusable prompt_toolkit session with fuzzy completion + history.
 
     Features:
-    - Fuzzy completion for slash commands (defined in SLASH_COMMANDS)
-    - Tab completion for agent names when configured
+    - Fuzzy slash-command completion via rapidfuzz (``SlashCompleter``)
     - ``@``-completion for context injection (file, git, history)
+    - Shared ``FileFinder`` with per-``ask()`` cache invalidation so
+      file-list scans don't repeat mid-prompt
+    - Completion runs in a background thread (``complete_in_thread``) so
+      the UI stays responsive even on cold scans
     - Persistent history across sessions
-    - Readline-style keybindings
     """
 
     def __init__(
@@ -224,27 +271,42 @@ class FinPrompt:
         self.agents = agents or []
         self.history_path = history_path
         self._context_settings = context_settings
+        self._file_finder: FileFinder | None = None
 
     @property
     def context_settings(self) -> ContextSettings | None:
         return self._context_settings
 
+    def _get_file_finder(self) -> FileFinder:
+        """Lazily construct and reuse a single ``FileFinder``."""
+        if self._file_finder is None:
+            from fin_assist.context.files import FileFinder
+
+            self._file_finder = FileFinder(settings=self._context_settings)
+        return self._file_finder
+
     def _build_completer(self) -> Completer:
-        words = [cmd.name for cmd in SLASH_COMMANDS] + self.agents
-        word_completer = WordCompleter(words, ignore_case=True)
-        slash_completer = SlashCompleter(FuzzyCompleter(word_completer))
-        at_completer = AtCompleter(context_settings=self._context_settings)
+        slash_completer = SlashCompleter(SLASH_COMMANDS, self.agents)
+        at_completer = AtCompleter(
+            context_settings=self._context_settings,
+            file_finder=self._get_file_finder(),
+        )
         return _CombinedCompleter(slash_completer, at_completer)
 
     def _build_session(self) -> PromptSession[str]:
         return PromptSession(
             completer=self._build_completer(),
+            complete_in_thread=True,
             history=FileHistory(self.history_path),
             style=Style.from_dict({"": "#ansibrightgreen"}),
         )
 
     async def ask(self, prompt_text: str, *, default: str | None = None) -> str:
         """Prompt for input with completion and history.
+
+        Invalidates the ``FileFinder`` cache at the start of each call so
+        files added between prompts are picked up.  During a single prompt
+        the cache is reused across keystrokes.
 
         Args:
             prompt_text: The prompt text to display.
@@ -257,6 +319,7 @@ class FinPrompt:
             KeyboardInterrupt: When the user presses Ctrl+C.
             EOFError: When the user presses Ctrl+D.
         """
+        self._get_file_finder().invalidate()
         session = self._build_session()
         return await session.prompt_async(prompt_text, default=default or "")
 

--- a/src/fin_assist/cli/interaction/prompt.py
+++ b/src/fin_assist/cli/interaction/prompt.py
@@ -225,6 +225,10 @@ class FinPrompt:
         self.history_path = history_path
         self._context_settings = context_settings
 
+    @property
+    def context_settings(self) -> ContextSettings | None:
+        return self._context_settings
+
     def _build_completer(self) -> Completer:
         words = [cmd.name for cmd in SLASH_COMMANDS] + self.agents
         word_completer = WordCompleter(words, ignore_case=True)

--- a/src/fin_assist/cli/main.py
+++ b/src/fin_assist/cli/main.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from fin_assist.cli.client import DiscoveredAgent, HubClient
-    from fin_assist.config.schema import ContextSettings
 
 from fin_assist.cli.display import (
     console,
@@ -66,54 +65,6 @@ def _save_session(agent: str, session_id: str, context_id: str) -> None:
         "context_id": context_id,
     }
     path.write_text(json.dumps(session, indent=2))
-
-
-# ---------------------------------------------------------------------------
-# Context injection helpers
-# ---------------------------------------------------------------------------
-
-
-def _inject_context(
-    prompt: str,
-    *,
-    files: list[str] | None = None,
-    git_diff: bool = False,
-    context_settings: ContextSettings | None = None,
-) -> str:
-    """Prepend user-driven context to a prompt string.
-
-    Reads files via ``FileFinder`` and/or git diff via ``GitContext``,
-    then formats them above the user's prompt so the model sees them
-    before the request.
-    """
-    context_sections: list[str] = []
-
-    if files:
-        from fin_assist.context.files import FileFinder
-
-        finder = FileFinder(settings=context_settings)
-        for path in files:
-            item = finder.get_item(path)
-            if item.status == "available":
-                context_sections.append(f"[FILE: {path}]\n{item.content}")
-            else:
-                context_sections.append(f"[FILE: {path}] Error: {item.error_reason}")
-
-    if git_diff:
-        from fin_assist.context.git import GitContext
-
-        git_ctx = GitContext(settings=context_settings)
-        item = git_ctx.get_item("git_diff:diff")
-        if item.status == "available":
-            context_sections.append(f"[GIT DIFF]\n{item.content}")
-        else:
-            context_sections.append(f"[GIT DIFF] Error: {item.error_reason}")
-
-    if not context_sections:
-        return prompt
-
-    context_block = "\n\n".join(context_sections)
-    return f"Context:\n{context_block}\n\nUser request:\n{prompt}"
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +191,7 @@ def _serve_command(args: argparse.Namespace, config, config_path: Path | None = 
 
 async def _do_command(args: argparse.Namespace, config, config_path: Path | None = None) -> int:
     """Handle `fin-assist do <agent> <prompt>`."""
-    from fin_assist.cli.interaction.prompt import FinPrompt
+    from fin_assist.cli.interaction.prompt import FinPrompt, resolve_at_references
     from fin_assist.cli.interaction.response import handle_post_response
     from fin_assist.cli.interaction.streaming import render_stream
 
@@ -260,7 +211,10 @@ async def _do_command(args: argparse.Namespace, config, config_path: Path | None
             prompt = args.prompt
 
             if prompt is None:
-                fp = FinPrompt(agents=[a.name for a in agents])
+                fp = FinPrompt(
+                    agents=[a.name for a in agents],
+                    context_settings=config.context,
+                )
                 try:
                     prompt = (await fp.ask("> ")).strip()
                 except (KeyboardInterrupt, EOFError):
@@ -269,7 +223,10 @@ async def _do_command(args: argparse.Namespace, config, config_path: Path | None
                 if not prompt:
                     return 0
             elif args.edit:
-                fp = FinPrompt(agents=[a.name for a in agents])
+                fp = FinPrompt(
+                    agents=[a.name for a in agents],
+                    context_settings=config.context,
+                )
                 try:
                     prompt = (await fp.ask("> ", default=prompt)).strip()
                 except (KeyboardInterrupt, EOFError):
@@ -278,9 +235,7 @@ async def _do_command(args: argparse.Namespace, config, config_path: Path | None
                 if not prompt:
                     return 0
 
-            prompt = _inject_context(
-                prompt, files=args.files, git_diff=args.git_diff, context_settings=config.context
-            )
+            prompt = resolve_at_references(prompt, context_settings=config.context)
             result, deferred_calls = await render_stream(
                 client.stream_agent(args.agent, prompt),
                 show_thinking=args.show_thinking,
@@ -307,7 +262,6 @@ async def _do_command(args: argparse.Namespace, config, config_path: Path | None
             response = await handle_post_response(result)
             return response.exit_code
     except Exception:
-        # ``_hub_client`` already rendered the error message before re-raising.
         return 1
 
 
@@ -344,7 +298,10 @@ async def _talk_command(args: argparse.Namespace, config, config_path: Path | No
                 )
                 return 1
 
-            fp = FinPrompt(agents=[a.name for a in agents])
+            fp = FinPrompt(
+                agents=[a.name for a in agents],
+                context_settings=config.context,
+            )
             message = args.message
             final_context_id = await run_chat_loop(
                 client.stream_agent,
@@ -356,7 +313,6 @@ async def _talk_command(args: argparse.Namespace, config, config_path: Path | No
                 show_thinking=args.show_thinking,
             )
     except Exception:
-        # ``_hub_client`` already rendered the error message before re-raising.
         return 1
 
     if final_context_id and not args.resume:
@@ -373,11 +329,54 @@ async def _agents_command(args: argparse.Namespace, config, config_path: Path | 
         async with _hub_client(config, config_path) as client:
             agents = await client.discover_agents()
     except Exception:
-        # ``_hub_client`` already rendered the error message before re-raising.
         return 1
 
     render_agents_list(agents)
     return 0
+
+
+def _list_command(args: argparse.Namespace, config) -> int:
+    """Handle `fin-assist list <resource>` — show platform registry contents."""
+    resource = args.resource
+
+    if resource == "tools":
+        from fin_assist.agents.tools import create_default_registry
+
+        registry = create_default_registry(context_settings=config.context)
+        tools = registry.list_tools()
+        if not tools:
+            render_info("No tools registered.")
+            return 0
+        for tool in tools:
+            approval = " (approval required)" if tool.approval_policy else ""
+            console.print(f"  [bold]{tool.name}[/bold]{approval}")
+            console.print(f"    {tool.description}")
+        return 0
+
+    if resource == "prompts":
+        from fin_assist.agents.registry import SYSTEM_PROMPTS
+
+        if not SYSTEM_PROMPTS:
+            render_info("No prompts registered.")
+            return 0
+        for name, prompt_text in SYSTEM_PROMPTS.items():
+            first_line = prompt_text.strip().split("\n", 1)[0]
+            console.print(f"  [bold]{name}[/bold]")
+            console.print(f"    {first_line[:80]}")
+        return 0
+
+    if resource == "output-types":
+        from fin_assist.agents.registry import OUTPUT_TYPES
+
+        if not OUTPUT_TYPES:
+            render_info("No output types registered.")
+            return 0
+        for name, type_obj in OUTPUT_TYPES.items():
+            console.print(f"  [bold]{name}[/bold]  →  {type_obj.__name__}")
+        return 0
+
+    render_error(f"Unknown resource '{resource}'. Choose from: tools, prompts, output-types")
+    return 1
 
 
 # ---------------------------------------------------------------------------
@@ -417,18 +416,6 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Show agent thinking/reasoning in the output.",
     )
-    do_parser.add_argument(
-        "--file",
-        dest="files",  # action="append" + singular flag → plural attribute
-        action="append",
-        default=[],
-        help="Inject file contents as context (may be specified multiple times).",
-    )
-    do_parser.add_argument(
-        "--git-diff",
-        action="store_true",
-        help="Inject git diff as context.",
-    )
 
     talk_parser = subparsers.add_parser(
         "talk",
@@ -452,7 +439,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     talk_parser.add_argument(
         "--list",
-        dest="list_sessions",  # avoid shadowing builtin `list`
+        dest="list_sessions",
         action="store_true",
         help="List saved sessions for the agent.",
     )
@@ -465,6 +452,16 @@ def main(argv: list[str] | None = None) -> int:
         "--show-thinking",
         action="store_true",
         help="Show agent thinking/reasoning in the chat output.",
+    )
+
+    list_parser = subparsers.add_parser(
+        "list",
+        help="List platform capabilities (tools, prompts, output-types).",
+    )
+    list_parser.add_argument(
+        "resource",
+        choices=["tools", "prompts", "output-types"],
+        help="Which platform resource to list.",
     )
 
     subparsers.add_parser("start", help="Start the agent hub server in the background.")
@@ -525,6 +522,8 @@ def main(argv: list[str] | None = None) -> int:
             return asyncio.run(_do_command(args, config, config_path))
         case "talk":
             return asyncio.run(_talk_command(args, config, config_path))
+        case "list":
+            return _list_command(args, config)
         case "start":
             try:
                 base_url = asyncio.run(ensure_server_running(config, config_path))

--- a/src/fin_assist/context/__init__.py
+++ b/src/fin_assist/context/__init__.py
@@ -1,22 +1,20 @@
 """Context providers — files, git, shell history, environment.
 
-Status (2026-04-24): **Partially integrated.**
+Both context paths are fully wired:
 
-Model-driven path (tool calls) is wired: ``read_file``, ``git_diff``,
-``git_log``, ``shell_history`` are registered in the ``ToolRegistry``
-via ``create_default_registry()`` in ``agents/tools.py``.  The default
-agent config includes all four tools.
+- **Model-driven** (tool calls): ``read_file``, ``git_diff``,
+  ``git_log``, ``shell_history`` are registered in the ``ToolRegistry``
+  via ``create_default_registry()`` in ``agents/tools.py``.
 
-User-driven path (CLI flags) is partially wired: ``--file`` and
-``--git-diff`` flags on the ``do`` command inject context into the
-prompt via ``_inject_context()`` in ``cli/main.py``.
+- **User-driven** (``@``-completion): ``@file:``, ``@git:diff``,
+  ``@git:log``, ``@history:`` tokens in FinPrompt are resolved by
+  ``resolve_at_references()`` in ``cli/interaction/prompt.py``.
+  Works in both ``do`` and ``talk`` modes.
 
-Still not wired:
-- ``--git-log`` CLI flag (low priority — model can call the tool).
+Not yet wired:
 - ``Environment`` provider not exposed as a tool (intentional — sensitive).
-- ``@``-triggered completion in ``FinPrompt`` for talk mode.
 - ``build_user_message``/``format_context`` helpers in ``llm/prompts.py``
-  not called from the request path (CLI injection bypasses them).
+  not called from the request path (``@``-completion bypasses them).
 """
 
 from __future__ import annotations

--- a/src/fin_assist/context/environment.py
+++ b/src/fin_assist/context/environment.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import os
 import re
-from typing import TYPE_CHECKING
 
+from fin_assist.config.schema import ContextSettings
 from fin_assist.context.base import ContextItem, ContextProvider, ContextType
-
-if TYPE_CHECKING:
-    from fin_assist.config.schema import ContextSettings
 
 SENSITIVE_ENV_VAR_PATTERNS = [
     re.compile(r"API[_-]?KEY", re.IGNORECASE),
@@ -27,17 +24,12 @@ def _is_env_var_sensitive(name: str) -> bool:
 
 class Environment(ContextProvider):
     def __init__(self, settings: ContextSettings | None = None) -> None:
-        self._settings = settings
+        self._settings = settings or ContextSettings()
         self._cache: list[ContextItem] | None = None
 
     def _supported_types(self) -> set[ContextType]:
         types: set[ContextType] = {"env"}
         return types
-
-    def _get_env_vars(self) -> list[str]:
-        if self._settings:
-            return self._settings.include_env_vars
-        return ["PATH", "HOME", "USER", "PWD"]
 
     def search(self, query: str) -> list[ContextItem]:
         return []
@@ -57,7 +49,7 @@ class Environment(ContextProvider):
     def get_all(self) -> list[ContextItem]:
         if self._cache is not None:
             return self._cache
-        env_vars = self._get_env_vars()
+        env_vars = self._settings.include_env_vars
         items = []
         cwd = os.getcwd()
         items.append(

--- a/src/fin_assist/context/files.py
+++ b/src/fin_assist/context/files.py
@@ -1,8 +1,30 @@
+"""File discovery + fuzzy path matching for ``@file:`` completion.
+
+Replaces an earlier ``find(1)`` subprocess approach which blocked the
+prompt_toolkit event loop on every keystroke and scanned the full tree
+including ``.venv``, ``.git``, etc.
+
+Design:
+
+- Walk the tree once with ``os.walk``, honouring ``.gitignore`` via
+  ``pathspec`` and a minimal hardcoded floor (``.git``, ``__pycache__``,
+  ``.venv``, ``node_modules``, ``.direnv``, ``.devenv``, ``.fin``).
+- Cache the resulting path list on the ``FileFinder`` instance.
+- Fuzzy-match queries with ``rapidfuzz.process.extract`` (``WRatio``
+  scorer) for path-aware ranking.
+
+Callers should instantiate a single ``FileFinder`` per REPL turn (or
+longer) and call ``invalidate()`` to force a re-scan.
+"""
+
 from __future__ import annotations
 
-import subprocess
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import pathspec
+from rapidfuzz import fuzz, process
 
 from fin_assist.context.base import ContextItem, ContextProvider, ContextType
 
@@ -10,22 +32,85 @@ if TYPE_CHECKING:
     from fin_assist.config.schema import ContextSettings
 
 
+# Directories always pruned even when no .gitignore is present.  Kept small
+# on purpose: .gitignore is the source of truth; this is the floor for
+# directories (caches, VCS metadata, virtualenvs) that almost always want
+# to be hidden regardless.
+_FALLBACK_PRUNE_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "node_modules",
+        ".direnv",
+        ".devenv",
+        ".fin",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+    }
+)
+
+# Cap on completion results returned per query.  Enough to be useful,
+# small enough that prompt_toolkit renders instantly.
+_MAX_COMPLETION_RESULTS = 50
+
+# rapidfuzz score floor for a match to be returned (0-100).  Empirically
+# 40 keeps out noise while allowing loose matches like ``cfg`` → ``config.toml``.
+_MIN_MATCH_SCORE = 40
+
+
 class FileFinder(ContextProvider):
-    def __init__(self, settings: ContextSettings | None = None) -> None:
+    """Provider for ``@file:`` references.
+
+    Scans the working directory once, caches the result, and serves
+    fuzzy-matched path queries from the in-memory list.
+    """
+
+    def __init__(
+        self,
+        settings: ContextSettings | None = None,
+        root: Path | None = None,
+    ) -> None:
         self._settings = settings
+        self._root = root or Path.cwd()
+        self._paths_cache: list[str] | None = None
+
+    # ------------------------------------------------------------------ API
 
     def _supported_types(self) -> set[ContextType]:
-        types: set[ContextType] = {"file"}
-        return types
+        return {"file"}
 
-    def _get_max_file_size(self) -> int:
-        if self._settings:
-            return self._settings.max_file_size
-        return 100_000
+    def invalidate(self) -> None:
+        """Drop the cached file list so the next search rescans the tree."""
+        self._paths_cache = None
 
     def search(self, query: str) -> list[ContextItem]:
-        results = self._run_find(query)
-        return [self._file_result_to_context_item(r) for r in results]
+        paths = self.search_paths(query)
+        return [self.get_item(p) for p in paths]
+
+    def search_paths(self, query: str) -> list[str]:
+        """Return matching file paths without reading contents.
+
+        Used by completion menus.  With an empty query returns all paths
+        (capped at ``_MAX_COMPLETION_RESULTS``).  Otherwise fuzzy-matches
+        with rapidfuzz and returns results ranked by score.
+        """
+        paths = self._get_paths()
+        if not query:
+            return paths[:_MAX_COMPLETION_RESULTS]
+
+        matches = process.extract(
+            query,
+            paths,
+            scorer=fuzz.WRatio,
+            limit=_MAX_COMPLETION_RESULTS,
+            score_cutoff=_MIN_MATCH_SCORE,
+        )
+        return [match[0] for match in matches]
 
     def get_item(self, id: str) -> ContextItem:
         path = Path(id)
@@ -83,33 +168,82 @@ class FileFinder(ContextProvider):
         )
 
     def get_all(self) -> list[ContextItem]:
-        results = self._run_find("")
-        return [self._file_result_to_context_item(r) for r in results]
+        return [self.get_item(p) for p in self._get_paths()]
 
-    def _run_find(self, query: str) -> list[str]:
-        max_size_bytes = self._get_max_file_size()
-        cmd = ["find", ".", "-type", "f", "-size", f"-{max_size_bytes}c"]
-        if query:
-            cmd.append("-name")
-            cmd.append(query)
+    # --------------------------------------------------------------- internal
+
+    def _get_max_file_size(self) -> int:
+        if self._settings:
+            return self._settings.max_file_size
+        return 100_000
+
+    def _get_paths(self) -> list[str]:
+        if self._paths_cache is None:
+            self._paths_cache = self._scan_paths()
+        return self._paths_cache
+
+    def _scan_paths(self) -> list[str]:
+        """Walk the tree, pruning directories via ``.gitignore`` + fallback set.
+
+        ``.gitignore`` is applied to *directories only* — individual
+        gitignored files (``config.toml``, ``hub.log``, ``.env``) are
+        intentionally included so users can ``@file:`` them in prompts.
+        Directory-level pruning is where the perf win lives; file-level
+        gitignore adds noise without meaningful speedup.
+
+        Returns relative POSIX paths sorted for stability.  Silently
+        drops entries we can't stat — completion is best-effort UX.
+        """
+        root = self._root
+        spec = self._load_gitignore_spec(root)
+        max_size = self._get_max_file_size()
+        results: list[str] = []
+
+        for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+            rel_dir = Path(dirpath).relative_to(root)
+
+            # Prune in-place so os.walk skips these subtrees entirely.
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if d not in _FALLBACK_PRUNE_DIRS
+                and not _matches_spec(spec, rel_dir / d, is_dir=True)
+            ]
+
+            for fname in filenames:
+                rel_path = rel_dir / fname
+                try:
+                    if (Path(dirpath) / fname).stat().st_size > max_size:
+                        continue
+                except OSError:
+                    continue
+                results.append(rel_path.as_posix())
+
+        results.sort()
+        return results
+
+    @staticmethod
+    def _load_gitignore_spec(root: Path) -> pathspec.PathSpec | None:
+        """Load ``<root>/.gitignore`` as a ``PathSpec`` if present."""
+        gitignore = root / ".gitignore"
+        if not gitignore.is_file():
+            return None
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=30,
-                cwd=Path.cwd(),
-            )
-            if result.returncode != 0:
-                return []
-            paths = []
-            for line in result.stdout.splitlines():
-                if line and line != ".":
-                    rel_path = line[2:] if line.startswith("./") else line
-                    paths.append(rel_path)
-            return paths
-        except (subprocess.SubprocessError, OSError):
-            return []
+            with gitignore.open() as f:
+                return pathspec.PathSpec.from_lines("gitignore", f)
+        except OSError:
+            return None
 
-    def _file_result_to_context_item(self, filepath: str) -> ContextItem:
-        return self.get_item(filepath)
+
+def _matches_spec(spec: pathspec.PathSpec | None, path: Path, *, is_dir: bool) -> bool:
+    """Return True if *path* is ignored by *spec*.
+
+    Appends ``/`` to the path string for directories — pathspec treats
+    trailing-slash patterns as directory-only matches.
+    """
+    if spec is None:
+        return False
+    path_str = path.as_posix()
+    if is_dir:
+        path_str += "/"
+    return spec.match_file(path_str)

--- a/src/fin_assist/context/files.py
+++ b/src/fin_assist/context/files.py
@@ -21,16 +21,12 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pathspec
 from rapidfuzz import fuzz, process
 
+from fin_assist.config.schema import ContextSettings
 from fin_assist.context.base import ContextItem, ContextProvider, ContextType
-
-if TYPE_CHECKING:
-    from fin_assist.config.schema import ContextSettings
-
 
 # Directories always pruned even when no .gitignore is present.  Kept small
 # on purpose: .gitignore is the source of truth; this is the floor for
@@ -75,7 +71,7 @@ class FileFinder(ContextProvider):
         settings: ContextSettings | None = None,
         root: Path | None = None,
     ) -> None:
-        self._settings = settings
+        self._settings = settings or ContextSettings()
         self._root = root or Path.cwd()
         self._paths_cache: list[str] | None = None
 
@@ -123,7 +119,7 @@ class FileFinder(ContextProvider):
                 status="not_found",
                 error_reason="file does not exist",
             )
-        max_size = self._get_max_file_size()
+        max_size = self._settings.max_file_size
         file_size = path.stat().st_size
         if file_size > max_size:
             return ContextItem(
@@ -172,11 +168,6 @@ class FileFinder(ContextProvider):
 
     # --------------------------------------------------------------- internal
 
-    def _get_max_file_size(self) -> int:
-        if self._settings:
-            return self._settings.max_file_size
-        return 100_000
-
     def _get_paths(self) -> list[str]:
         if self._paths_cache is None:
             self._paths_cache = self._scan_paths()
@@ -196,7 +187,7 @@ class FileFinder(ContextProvider):
         """
         root = self._root
         spec = self._load_gitignore_spec(root)
-        max_size = self._get_max_file_size()
+        max_size = self._settings.max_file_size
         results: list[str] = []
 
         for dirpath, dirnames, filenames in os.walk(root, followlinks=False):

--- a/src/fin_assist/context/history.py
+++ b/src/fin_assist/context/history.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import re
 import subprocess
-from typing import TYPE_CHECKING
 
+from fin_assist.config.schema import ContextSettings
 from fin_assist.context.base import ContextItem, ContextProvider, ContextType
-
-if TYPE_CHECKING:
-    from fin_assist.config.schema import ContextSettings
 
 SENSITIVE_PATTERNS = [
     re.compile(r"export\s+\w*(?:API|TOKEN|KEY|SECRET|PASSWORD|PASS)\w*=", re.IGNORECASE),
@@ -23,7 +20,7 @@ def _is_command_sensitive(command: str) -> bool:
 
 class ShellHistory(ContextProvider):
     def __init__(self, settings: ContextSettings | None = None) -> None:
-        self._settings = settings
+        self._settings = settings or ContextSettings()
         self._fish_available: bool | None = None
         self._cache: list[ContextItem] | None = None
 
@@ -43,11 +40,6 @@ class ShellHistory(ContextProvider):
             except (subprocess.SubprocessError, OSError):
                 self._fish_available = False
         return self._fish_available
-
-    def _get_max_history_items(self) -> int:
-        if self._settings:
-            return self._settings.max_history_items
-        return 50
 
     def search(self, query: str) -> list[ContextItem]:
         if not self._is_fish_available():
@@ -96,7 +88,7 @@ class ShellHistory(ContextProvider):
             if result.returncode != 0:
                 return []
             lines = result.stdout.splitlines()
-            max_items = self._get_max_history_items()
+            max_items = self._settings.max_history_items
             items = []
             for idx, line in enumerate(lines[:max_items]):
                 line = line.strip()

--- a/tests/test_cli/interaction/test_prompt.py
+++ b/tests/test_cli/interaction/test_prompt.py
@@ -188,4 +188,4 @@ class TestFinPromptAgents:
         from fin_assist.cli.interaction.prompt import FinPrompt
 
         fp = FinPrompt(context_settings=MagicMock())
-        assert fp._context_settings is not None
+        assert fp.context_settings is not None

--- a/tests/test_cli/interaction/test_prompt.py
+++ b/tests/test_cli/interaction/test_prompt.py
@@ -9,56 +9,62 @@ from prompt_toolkit.document import Document
 
 
 class TestSlashCompleter:
-    """SlashCompleter only yields completions when input starts with /."""
+    """SlashCompleter fuzzy-matches slash commands when input starts with /."""
 
-    def _make_completer(self):
-        from fin_assist.cli.interaction.prompt import SlashCompleter
+    def _make_completer(self, agents: list[str] | None = None):
+        from fin_assist.cli.interaction.prompt import SLASH_COMMANDS, SlashCompleter
 
-        inner = MagicMock()
-        inner.get_completions = MagicMock(return_value=[MagicMock(text="/exit")])
-        return SlashCompleter(inner), inner
+        return SlashCompleter(SLASH_COMMANDS, agents or [])
 
-    def test_yields_completions_when_slash_prefix(self):
-        completer, inner = self._make_completer()
+    def test_yields_exit_for_exact_prefix(self):
+        completer = self._make_completer()
         doc = Document("/ex", cursor_position=3)
         results = list(completer.get_completions(doc, MagicMock()))
-        assert len(results) == 1
-        inner.get_completions.assert_called_once()
+        texts = [c.text for c in results]
+        # /exit should be ranked first; others may or may not appear under cutoff.
+        assert texts[0] == "/exit"
 
     def test_yields_nothing_for_plain_text(self):
-        completer, inner = self._make_completer()
+        completer = self._make_completer()
         doc = Document("hello", cursor_position=5)
-        results = list(completer.get_completions(doc, MagicMock()))
-        assert results == []
-        inner.get_completions.assert_not_called()
+        assert list(completer.get_completions(doc, MagicMock())) == []
 
     def test_yields_nothing_for_empty_input(self):
-        completer, inner = self._make_completer()
+        completer = self._make_completer()
         doc = Document("", cursor_position=0)
-        results = list(completer.get_completions(doc, MagicMock()))
-        assert results == []
-        inner.get_completions.assert_not_called()
+        assert list(completer.get_completions(doc, MagicMock())) == []
 
-    def test_yields_completions_for_bare_slash(self):
-        completer, inner = self._make_completer()
+    def test_yields_all_commands_for_bare_slash(self):
+        completer = self._make_completer()
         doc = Document("/", cursor_position=1)
-        results = list(completer.get_completions(doc, MagicMock()))
-        assert len(results) == 1
-        inner.get_completions.assert_called_once()
+        texts = [c.text for c in completer.get_completions(doc, MagicMock())]
+        assert "/exit" in texts
+        assert "/help" in texts
+        assert "/sessions" in texts
 
     def test_yields_nothing_when_slash_not_at_start(self):
-        completer, inner = self._make_completer()
+        completer = self._make_completer()
         doc = Document("hello /ex", cursor_position=9)
-        results = list(completer.get_completions(doc, MagicMock()))
-        assert results == []
-        inner.get_completions.assert_not_called()
+        assert list(completer.get_completions(doc, MagicMock())) == []
 
     def test_handles_leading_whitespace_before_slash(self):
-        completer, inner = self._make_completer()
+        completer = self._make_completer()
         doc = Document("  /ex", cursor_position=5)
-        results = list(completer.get_completions(doc, MagicMock()))
-        assert len(results) == 1
-        inner.get_completions.assert_called_once()
+        texts = [c.text for c in completer.get_completions(doc, MagicMock())]
+        assert "/exit" in texts
+
+    def test_fuzzy_matches_typos(self):
+        """rapidfuzz should still rank /help first for /hlp."""
+        completer = self._make_completer()
+        doc = Document("/hlp", cursor_position=4)
+        texts = [c.text for c in completer.get_completions(doc, MagicMock())]
+        assert texts[0] == "/help"
+
+    def test_includes_agent_names(self):
+        completer = self._make_completer(agents=["shell", "coder"])
+        doc = Document("/sh", cursor_position=3)
+        texts = [c.text for c in completer.get_completions(doc, MagicMock())]
+        assert "shell" in texts
 
 
 class TestSlashCommand:

--- a/tests/test_cli/interaction/test_prompt.py
+++ b/tests/test_cli/interaction/test_prompt.py
@@ -177,3 +177,9 @@ class TestFinPromptAgents:
 
         fp = FinPrompt()
         assert fp.agents == []
+
+    def test_context_settings_stored(self):
+        from fin_assist.cli.interaction.prompt import FinPrompt
+
+        fp = FinPrompt(context_settings=MagicMock())
+        assert fp._context_settings is not None

--- a/tests/test_cli/test_context_injection.py
+++ b/tests/test_cli/test_context_injection.py
@@ -44,12 +44,8 @@ class TestAtCompleter:
 
     def test_yields_file_completions_after_file_prefix(self):
         completer = self._make_completer()
-        items = [
-            ContextItem(id="src/main.py", type="file", content="code", status="available"),
-            ContextItem(id="src/util.py", type="file", content="code", status="available"),
-        ]
         with patch("fin_assist.context.files.FileFinder") as mock_cls:
-            mock_cls.return_value.search.return_value = items
+            mock_cls.return_value.search_paths.return_value = ["src/main.py", "src/util.py"]
             doc = Document("@file:src/", cursor_position=10)
             results = list(completer.get_completions(doc, MagicMock()))
 
@@ -57,20 +53,16 @@ class TestAtCompleter:
         assert "src/main.py" in texts
         assert "src/util.py" in texts
 
-    def test_excludes_unavailable_files_from_completion(self):
+    def test_all_paths_shown_in_completion(self):
         completer = self._make_completer()
-        items = [
-            ContextItem(id="ok.py", type="file", content="code", status="available"),
-            ContextItem(id="bad.py", type="file", content="", status="not_found"),
-        ]
         with patch("fin_assist.context.files.FileFinder") as mock_cls:
-            mock_cls.return_value.search.return_value = items
+            mock_cls.return_value.search_paths.return_value = ["ok.py", "bad.py"]
             doc = Document("@file:", cursor_position=6)
             results = list(completer.get_completions(doc, MagicMock()))
 
         texts = [c.text for c in results]
         assert "ok.py" in texts
-        assert "bad.py" not in texts
+        assert "bad.py" in texts
 
 
 class TestResolveAtReferences:

--- a/tests/test_cli/test_context_injection.py
+++ b/tests/test_cli/test_context_injection.py
@@ -18,14 +18,14 @@ class TestAtCompleter:
         return AtCompleter(context_settings=None)
 
     def test_yields_context_types_for_bare_at(self):
+        from fin_assist.cli.interaction.prompt import _AT_CONTEXT_TYPES
+
         completer = self._make_completer()
         doc = Document("@", cursor_position=1)
         results = list(completer.get_completions(doc, MagicMock()))
         texts = [c.text for c in results]
-        assert "file:" in texts
-        assert "git:diff" in texts
-        assert "git:log" in texts
-        assert "history:" in texts
+        for name in _AT_CONTEXT_TYPES:
+            assert name in texts
 
     def test_yields_nothing_without_at(self):
         completer = self._make_completer()

--- a/tests/test_cli/test_context_injection.py
+++ b/tests/test_cli/test_context_injection.py
@@ -1,101 +1,178 @@
-"""Tests for _inject_context helper and CLI --file/--git-diff flags."""
+"""Tests for @-completion and resolve_at_references in cli/interaction/prompt.py."""
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-import pytest
+from prompt_toolkit.document import Document
 
-from fin_assist.cli.main import _inject_context
 from fin_assist.context.base import ContextItem
 
 
-class TestInjectContextNoFlags:
-    def test_returns_prompt_unchanged_when_no_flags(self) -> None:
-        assert _inject_context("hello") == "hello"
+class TestAtCompleter:
+    """AtCompleter only yields completions when input contains @."""
 
-    def test_returns_prompt_unchanged_when_empty_lists(self) -> None:
-        assert _inject_context("hello", files=[], git_diff=False) == "hello"
+    def _make_completer(self):
+        from fin_assist.cli.interaction.prompt import AtCompleter
+
+        return AtCompleter(context_settings=None)
+
+    def test_yields_context_types_for_bare_at(self):
+        completer = self._make_completer()
+        doc = Document("@", cursor_position=1)
+        results = list(completer.get_completions(doc, MagicMock()))
+        texts = [c.text for c in results]
+        assert "file:" in texts
+        assert "git:diff" in texts
+        assert "git:log" in texts
+        assert "history:" in texts
+
+    def test_yields_nothing_without_at(self):
+        completer = self._make_completer()
+        doc = Document("hello", cursor_position=5)
+        results = list(completer.get_completions(doc, MagicMock()))
+        assert results == []
+
+    def test_filters_by_prefix_after_at(self):
+        completer = self._make_completer()
+        doc = Document("@gi", cursor_position=3)
+        results = list(completer.get_completions(doc, MagicMock()))
+        texts = [c.text for c in results]
+        assert "git:diff" in texts
+        assert "git:log" in texts
+        assert "file:" not in texts
+
+    def test_yields_file_completions_after_file_prefix(self):
+        completer = self._make_completer()
+        items = [
+            ContextItem(id="src/main.py", type="file", content="code", status="available"),
+            ContextItem(id="src/util.py", type="file", content="code", status="available"),
+        ]
+        with patch("fin_assist.context.files.FileFinder") as mock_cls:
+            mock_cls.return_value.search.return_value = items
+            doc = Document("@file:src/", cursor_position=10)
+            results = list(completer.get_completions(doc, MagicMock()))
+
+        texts = [c.text for c in results]
+        assert "src/main.py" in texts
+        assert "src/util.py" in texts
+
+    def test_excludes_unavailable_files_from_completion(self):
+        completer = self._make_completer()
+        items = [
+            ContextItem(id="ok.py", type="file", content="code", status="available"),
+            ContextItem(id="bad.py", type="file", content="", status="not_found"),
+        ]
+        with patch("fin_assist.context.files.FileFinder") as mock_cls:
+            mock_cls.return_value.search.return_value = items
+            doc = Document("@file:", cursor_position=6)
+            results = list(completer.get_completions(doc, MagicMock()))
+
+        texts = [c.text for c in results]
+        assert "ok.py" in texts
+        assert "bad.py" not in texts
 
 
-class TestInjectContextFileFlag:
-    def test_prepends_file_content(self) -> None:
+class TestResolveAtReferences:
+    """resolve_at_references replaces @type:ref tokens with context content."""
+
+    def test_returns_text_unchanged_when_no_at_refs(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
+
+        assert resolve_at_references("hello world") == "hello world"
+
+    def test_unknown_at_type_left_as_is(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
+
+        result = resolve_at_references("check @unknown:thing")
+        assert "@unknown:thing" in result
+
+    def test_resolves_file_reference(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
+
         mock_item = ContextItem(
             id="test.py", type="file", content="print('hi')", status="available"
         )
         with patch("fin_assist.context.files.FileFinder") as mock_cls:
             mock_cls.return_value.get_item.return_value = mock_item
-            result = _inject_context("explain this", files=["test.py"])
+            result = resolve_at_references("explain @file:test.py")
 
         assert "[FILE: test.py]" in result
         assert "print('hi')" in result
-        assert "explain this" in result
-
-    def test_handles_missing_file(self) -> None:
-        mock_item = ContextItem(
-            id="missing.py",
-            type="file",
-            content="",
-            status="not_found",
-            error_reason="file does not exist",
-        )
-        with patch("fin_assist.context.files.FileFinder") as mock_cls:
-            mock_cls.return_value.get_item.return_value = mock_item
-            result = _inject_context("explain", files=["missing.py"])
-
-        assert "Error:" in result
         assert "explain" in result
 
-    def test_multiple_files(self) -> None:
-        items = {
-            "a.py": ContextItem(id="a.py", type="file", content="code_a", status="available"),
-            "b.py": ContextItem(id="b.py", type="file", content="code_b", status="available"),
-        }
-        with patch("fin_assist.context.files.FileFinder") as mock_cls:
-            mock_cls.return_value.get_item = lambda path: items[path]
-            result = _inject_context("review", files=["a.py", "b.py"])
+    def test_resolves_git_diff_reference(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
 
-        assert "[FILE: a.py]" in result
-        assert "[FILE: b.py]" in result
-        assert "code_a" in result
-        assert "code_b" in result
-
-
-class TestInjectContextGitDiff:
-    def test_prepends_git_diff(self) -> None:
         mock_item = ContextItem(
             id="git_diff", type="git_diff", content="diff --git a/file", status="available"
         )
         with patch("fin_assist.context.git.GitContext") as mock_cls:
             mock_cls.return_value.get_item.return_value = mock_item
-            result = _inject_context("review changes", git_diff=True)
+            result = resolve_at_references("review @git:diff")
 
         assert "[GIT DIFF]" in result
         assert "diff --git a/file" in result
-        assert "review changes" in result
+        assert "review" in result
 
-    def test_handles_git_error(self) -> None:
+    def test_resolves_git_log_reference(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
+
         mock_item = ContextItem(
-            id="git_diff",
-            type="git_diff",
-            content="",
-            status="error",
-            error_reason="git_not_available",
+            id="git_log", type="git_log", content="abc123 commit msg", status="available"
         )
         with patch("fin_assist.context.git.GitContext") as mock_cls:
             mock_cls.return_value.get_item.return_value = mock_item
-            result = _inject_context("review", git_diff=True)
+            result = resolve_at_references("@git:log recent changes")
 
-        assert "Error:" in result
+        assert "[GIT LOG]" in result
+        assert "abc123 commit msg" in result
+        assert "recent changes" in result
 
-    def test_git_diff_false_does_not_inject(self) -> None:
-        result = _inject_context("hello", git_diff=False)
-        assert "[GIT DIFF]" not in result
+    def test_resolves_history_reference(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
 
+        items = [
+            ContextItem(id="0", type="history", content="git status", status="available"),
+            ContextItem(id="1", type="history", content="ls -la", status="available"),
+        ]
+        with patch("fin_assist.context.history.ShellHistory") as mock_cls:
+            mock_cls.return_value.get_all.return_value = items
+            result = resolve_at_references("@history: similar to")
 
-class TestInjectContextCombined:
-    def test_file_and_git_diff_together(self) -> None:
-        file_item = ContextItem(id="f.py", type="file", content="code", status="available")
+        assert "[SHELL HISTORY]" in result
+        assert "git status" in result
+        assert "ls -la" in result
+
+    def test_resolves_history_with_query(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
+
+        items = [
+            ContextItem(id="0", type="history", content="git commit", status="available"),
+        ]
+        with patch("fin_assist.context.history.ShellHistory") as mock_cls:
+            mock_cls.return_value.search.return_value = items
+            result = resolve_at_references("@history:commit what did I do")
+
+        mock_cls.return_value.search.assert_called_once_with("commit")
+        assert "[SHELL HISTORY]" in result
+
+    def test_handles_missing_file_gracefully(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
+
+        mock_item = ContextItem(
+            id="missing.py", type="file", content="", status="not_found", error_reason="not found"
+        )
+        with patch("fin_assist.context.files.FileFinder") as mock_cls:
+            mock_cls.return_value.get_item.return_value = mock_item
+            result = resolve_at_references("explain @file:missing.py")
+
+        assert "[FILE: missing.py] Error:" in result
+
+    def test_multiple_refs_resolved(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
+
+        file_item = ContextItem(id="a.py", type="file", content="code_a", status="available")
         diff_item = ContextItem(id="git_diff", type="git_diff", content="diff", status="available")
         with (
             patch("fin_assist.context.files.FileFinder") as file_cls,
@@ -103,8 +180,20 @@ class TestInjectContextCombined:
         ):
             file_cls.return_value.get_item.return_value = file_item
             git_cls.return_value.get_item.return_value = diff_item
-            result = _inject_context("explain", files=["f.py"], git_diff=True)
+            result = resolve_at_references("review @file:a.py and @git:diff")
 
-        assert "[FILE: f.py]" in result
+        assert "[FILE: a.py]" in result
         assert "[GIT DIFF]" in result
-        assert "explain" in result
+        assert "code_a" in result
+        assert "review" in result
+
+    def test_prompt_only_text_preserved_when_all_refs_resolved(self):
+        from fin_assist.cli.interaction.prompt import resolve_at_references
+
+        mock_item = ContextItem(id="f.py", type="file", content="code", status="available")
+        with patch("fin_assist.context.files.FileFinder") as mock_cls:
+            mock_cls.return_value.get_item.return_value = mock_item
+            result = resolve_at_references("explain @file:f.py")
+
+        assert "Context:" in result
+        assert "User request:" in result

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -977,3 +977,32 @@ class TestDoInputPanel:
 
         assert result == 0
         mock_client.stream_agent.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# `list` command
+# ---------------------------------------------------------------------------
+
+
+class TestListCommand:
+    def test_list_tools_prints_all_tools(self):
+        result = _run_main("list", "tools")
+        assert result == 0
+
+    def test_list_prompts_prints_all_prompts(self):
+        result = _run_main("list", "prompts")
+        assert result == 0
+
+    def test_list_output_types_prints_all_types(self):
+        result = _run_main("list", "output-types")
+        assert result == 0
+
+    def test_list_invalid_resource_returns_nonzero(self):
+        with pytest.raises(SystemExit):
+            _run_main("list", "bogus")
+
+    def test_list_tools_no_hub_connection_needed(self):
+        with patch("fin_assist.cli.main.ensure_server_running") as mock_ensure:
+            result = _run_main("list", "tools")
+        mock_ensure.assert_not_called()
+        assert result == 0

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -986,16 +986,32 @@ class TestDoInputPanel:
 
 class TestListCommand:
     def test_list_tools_prints_all_tools(self):
-        result = _run_main("list", "tools")
+        captured: list[str] = []
+        with patch("fin_assist.cli.main.console") as mock_console:
+            mock_console.print.side_effect = lambda msg="": captured.append(str(msg))
+            result = _run_main("list", "tools")
         assert result == 0
+        # At least one known built-in tool should be rendered.
+        assert any("read_file" in line for line in captured)
 
     def test_list_prompts_prints_all_prompts(self):
-        result = _run_main("list", "prompts")
+        captured: list[str] = []
+        with patch("fin_assist.cli.main.console") as mock_console:
+            mock_console.print.side_effect = lambda msg="": captured.append(str(msg))
+            result = _run_main("list", "prompts")
         assert result == 0
+        # Registered prompts include at least "shell" (see agents/registry.py).
+        assert any("shell" in line for line in captured)
 
     def test_list_output_types_prints_all_types(self):
-        result = _run_main("list", "output-types")
+        captured: list[str] = []
+        with patch("fin_assist.cli.main.console") as mock_console:
+            mock_console.print.side_effect = lambda msg="": captured.append(str(msg))
+            result = _run_main("list", "output-types")
         assert result == 0
+        # Registered output types include "text" and "command".
+        assert any("text" in line for line in captured)
+        assert any("command" in line for line in captured)
 
     def test_list_invalid_resource_returns_nonzero(self):
         with pytest.raises(SystemExit):

--- a/tests/test_context/test_environment.py
+++ b/tests/test_context/test_environment.py
@@ -91,18 +91,23 @@ class TestEnvironment:
                 result2 = env2.get_all()
                 assert result1 is not result2
 
-    def test_get_env_vars_defaults(self) -> None:
+    def test_default_env_vars_include_path_home_user_pwd(self) -> None:
         env = Environment()
-        result = env._get_env_vars()
-        assert "PATH" in result
-        assert "HOME" in result
-        assert "USER" in result
-        assert "PWD" in result
+        with patch.dict(
+            "os.environ",
+            {"HOME": "/home", "USER": "me", "PATH": "/usr/bin"},
+            clear=False,
+        ):
+            ids = {item.id for item in env.get_all()}
+        assert {"PATH", "HOME", "USER", "PWD"} <= ids
 
-    def test_get_env_vars_from_settings(self) -> None:
+    def test_settings_override_default_env_vars(self) -> None:
         from fin_assist.config.schema import ContextSettings
 
         settings = ContextSettings(include_env_vars=["CUSTOM_VAR"])
         env = Environment(settings=settings)
-        result = env._get_env_vars()
-        assert result == ["CUSTOM_VAR"]
+        with patch.dict("os.environ", {"CUSTOM_VAR": "hello"}, clear=False):
+            ids = {item.id for item in env.get_all()}
+        # PWD/HOME/USER are always emitted; only CUSTOM_VAR comes from the override.
+        assert "CUSTOM_VAR" in ids
+        assert "PATH" not in ids  # not in override list

--- a/tests/test_context/test_files.py
+++ b/tests/test_context/test_files.py
@@ -1,88 +1,211 @@
+"""Tests for FileFinder — os.walk + pathspec + rapidfuzz implementation.
+
+These are behavioural tests against a real temporary directory tree, not
+mocks of ``subprocess.run``.  If you're here because a test failed, start
+by verifying the behaviour the test names in plain English — don't
+reach for mocks.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
+from fin_assist.config.schema import ContextSettings
 from fin_assist.context.files import FileFinder
 
 
-class TestFileFinder:
-    def test_supported_types(self) -> None:
-        finder = FileFinder()
-        assert finder._supported_types() == {"file"}
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """Build a small repo-like tree for FileFinder to walk.
 
-    def test_supports_file_context(self) -> None:
+    Layout:
+        tmp_path/
+            .gitignore               (ignores ``secret.txt`` and ``build/``)
+            README.md
+            secret.txt               (gitignored — but should still appear,
+                                      since we ignore gitignore for files)
+            config.toml              (not gitignored)
+            src/
+                main.py
+                util.py
+            build/
+                output.bin           (pruned: directory matches gitignore)
+            .venv/
+                site-packages/
+                    junk.py          (pruned: fallback directory prune)
+            __pycache__/
+                cache.pyc            (pruned: fallback directory prune)
+    """
+    (tmp_path / ".gitignore").write_text("secret.txt\nbuild/\n")
+    (tmp_path / "README.md").write_text("hello")
+    (tmp_path / "secret.txt").write_text("shh")
+    (tmp_path / "config.toml").write_text("[a]\nb = 1\n")
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("print('main')")
+    (src / "util.py").write_text("def f(): pass")
+
+    build = tmp_path / "build"
+    build.mkdir()
+    (build / "output.bin").write_text("binary")
+
+    venv = tmp_path / ".venv" / "site-packages"
+    venv.mkdir(parents=True)
+    (venv / "junk.py").write_text("junk")
+
+    pycache = tmp_path / "__pycache__"
+    pycache.mkdir()
+    (pycache / "cache.pyc").write_text("bytecode")
+
+    return tmp_path
+
+
+class TestSupportedTypes:
+    def test_supports_file(self) -> None:
         finder = FileFinder()
         assert finder.supports_context("file") is True
+
+    def test_does_not_support_history(self) -> None:
+        finder = FileFinder()
         assert finder.supports_context("history") is False
 
-    def test_search_with_find(self) -> None:
-        finder = FileFinder()
-        with patch("subprocess.run") as mock_run:
-            mock_result = MagicMock()
-            mock_result.returncode = 0
-            mock_result.stdout = "./path/to/file1.py\n./path/to/file2.py"
-            mock_run.return_value = mock_result
 
-            with patch.object(finder, "get_item") as mock_get_item:
-                mock_item = MagicMock()
-                mock_get_item.return_value = mock_item
+class TestScan:
+    def test_walks_tree_and_returns_relative_paths(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        paths = finder.search_paths("")
+        assert "README.md" in paths
+        assert "config.toml" in paths
+        assert "src/main.py" in paths
+        assert "src/util.py" in paths
 
-                result = finder.search("*.py")
-                assert len(result) == 2
-                mock_run.assert_called_once()
+    def test_prunes_gitignored_directories(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        paths = finder.search_paths("")
+        assert not any(p.startswith("build/") for p in paths)
 
-    def test_get_item_nonexistent_file(self) -> None:
-        finder = FileFinder()
-        result = finder.get_item("/nonexistent/file.py")
-        assert result is not None
+    def test_prunes_fallback_dirs_without_gitignore(self, tmp_path: Path) -> None:
+        """With no .gitignore, directory floor still prunes .venv + __pycache__."""
+        (tmp_path / "real.py").write_text("x")
+        venv = tmp_path / ".venv"
+        venv.mkdir()
+        (venv / "junk.py").write_text("x")
+        pycache = tmp_path / "__pycache__"
+        pycache.mkdir()
+        (pycache / "a.pyc").write_text("x")
+
+        finder = FileFinder(root=tmp_path)
+        paths = finder.search_paths("")
+        assert "real.py" in paths
+        assert not any(".venv" in p for p in paths)
+        assert not any("__pycache__" in p for p in paths)
+
+    def test_includes_gitignored_files(self, tree: Path) -> None:
+        """Individual files in .gitignore are still listed (design choice)."""
+        finder = FileFinder(root=tree)
+        paths = finder.search_paths("")
+        assert "secret.txt" in paths
+
+    def test_excludes_files_over_max_size(self, tmp_path: Path) -> None:
+        (tmp_path / "small.txt").write_text("x")
+        (tmp_path / "big.txt").write_text("x" * 500)
+        settings = ContextSettings(max_file_size=100)
+
+        finder = FileFinder(settings=settings, root=tmp_path)
+        paths = finder.search_paths("")
+        assert "small.txt" in paths
+        assert "big.txt" not in paths
+
+
+class TestFuzzySearch:
+    def test_empty_query_returns_all(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        all_paths = finder.search_paths("")
+        assert len(all_paths) > 0
+
+    def test_exact_match_ranks_first(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        paths = finder.search_paths("config.toml")
+        assert paths[0] == "config.toml"
+
+    def test_substring_match(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        paths = finder.search_paths("main")
+        assert "src/main.py" in paths
+
+    def test_fuzzy_match_tolerates_gaps(self, tree: Path) -> None:
+        """rapidfuzz should match ``cfg`` against ``config.toml``-ish names."""
+        finder = FileFinder(root=tree)
+        paths = finder.search_paths("config")
+        assert "config.toml" in paths
+
+    def test_no_false_positives_for_unrelated_query(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        paths = finder.search_paths("zzznopesuchthing")
+        assert paths == []
+
+
+class TestCache:
+    def test_second_call_reuses_cache(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        finder.search_paths("")
+        # Add a new file — without invalidate it should not appear.
+        (tree / "new.txt").write_text("new")
+        paths = finder.search_paths("")
+        assert "new.txt" not in paths
+
+    def test_invalidate_rescans(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        finder.search_paths("")
+        (tree / "new.txt").write_text("new")
+        finder.invalidate()
+        paths = finder.search_paths("")
+        assert "new.txt" in paths
+
+
+class TestGetItem:
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        finder = FileFinder(root=tmp_path)
+        result = finder.get_item(str(tmp_path / "nope.py"))
         assert result.status == "not_found"
         assert result.error_reason == "file does not exist"
 
-    def test_get_item_readable_file(self) -> None:
-        finder = FileFinder()
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("pathlib.Path.is_file", return_value=True):
-                with patch("pathlib.Path.stat") as mock_stat:
-                    mock_stat.return_value.st_size = 100
-                    with patch("pathlib.Path.read_text", return_value="print('hello')"):
-                        result = finder.get_item("/test/file.py")
-                        assert result is not None
-                        assert result.type == "file"
-                        assert result.content == "print('hello')"
+    def test_reads_existing_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "hello.py"
+        path.write_text("print('hi')")
+        finder = FileFinder(root=tmp_path)
+        result = finder.get_item(str(path))
+        assert result.status == "available"
+        assert result.type == "file"
+        assert result.content == "print('hi')"
 
-    def test_get_item_too_large(self) -> None:
-        from fin_assist.config.schema import ContextSettings
-
+    def test_excludes_files_over_size_limit(self, tmp_path: Path) -> None:
+        path = tmp_path / "big.py"
+        path.write_text("x" * 1000)
         settings = ContextSettings(max_file_size=50)
-        finder = FileFinder(settings=settings)
+        finder = FileFinder(settings=settings, root=tmp_path)
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("pathlib.Path.is_file", return_value=True):
-                with patch("pathlib.Path.stat") as mock_stat:
-                    mock_stat.return_value.st_size = 1000
-                    result = finder.get_item("/test/large_file.py")
-                    assert result is not None
-                    assert result.type == "file"
-                    assert result.status == "excluded"
-                    assert result.metadata["size_exceeded"] is True
-                    assert result.metadata["size"] == 1000
-                    assert result.metadata["limit"] == 50
-                    assert result.content == ""
+        result = finder.get_item(str(path))
+        assert result.status == "excluded"
+        assert result.error_reason == "file_size_exceeded"
+        assert result.metadata["size"] == 1000
+        assert result.metadata["limit"] == 50
+        assert result.content == ""
 
-    def test_get_all(self) -> None:
-        finder = FileFinder()
-        with patch("subprocess.run") as mock_run:
-            mock_result = MagicMock()
-            mock_result.returncode = 0
-            mock_result.stdout = "./file1.py\n./file2.py"
-            mock_run.return_value = mock_result
 
-            with patch.object(finder, "get_item") as mock_get_item:
-                mock_item = MagicMock()
-                mock_get_item.return_value = mock_item
+class TestSearchAndGetAll:
+    def test_search_returns_context_items(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        items = finder.search("main")
+        assert len(items) > 0
+        assert all(item.type == "file" for item in items)
 
-                result = finder.get_all()
-                assert len(result) == 2
+    def test_get_all_returns_every_file(self, tree: Path) -> None:
+        finder = FileFinder(root=tree)
+        items = finder.get_all()
+        ids = {item.id for item in items}
+        assert "README.md" in ids
+        assert "config.toml" in ids

--- a/tests/test_context/test_files.py
+++ b/tests/test_context/test_files.py
@@ -139,7 +139,7 @@ class TestFuzzySearch:
     def test_fuzzy_match_tolerates_gaps(self, tree: Path) -> None:
         """rapidfuzz should match ``cfg`` against ``config.toml``-ish names."""
         finder = FileFinder(root=tree)
-        paths = finder.search_paths("config")
+        paths = finder.search_paths("cfg")
         assert "config.toml" in paths
 
     def test_no_false_positives_for_unrelated_query(self, tree: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -852,9 +852,11 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "keyring" },
+    { name = "pathspec" },
     { name = "prompt-toolkit" },
     { name = "pydantic-ai" },
     { name = "pydantic-settings" },
+    { name = "rapidfuzz" },
     { name = "rich" },
 ]
 
@@ -874,9 +876,11 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.100" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "keyring", specifier = ">=25.0" },
+    { name = "pathspec", specifier = ">=0.12" },
     { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "pydantic-ai", specifier = ">=1.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "rapidfuzz", specifier = ">=3.0" },
     { name = "rich", specifier = ">=13.0" },
 ]
 
@@ -1855,6 +1859,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2473,6 +2486,69 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/252803f2010ba699618cdc048b6e1f7cc1f433c08b4a9a17579b92ab0142/rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6", size = 1940205, upload-time = "2026-04-07T11:14:40.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/59/b2afd98e41af9cd54554a4c1c423d84cdd60e6b1c0a09496f033b55f60ec/rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609", size = 1159639, upload-time = "2026-04-07T11:14:42.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f", size = 1367194, upload-time = "2026-04-07T11:14:44.25Z" },
+    { url = "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7", size = 3151805, upload-time = "2026-04-07T11:14:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/17/54/0c83508f2683ea70e2d05f8527eb07328acf7bb1e9d97a3bece5702378e7/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e", size = 1455667, upload-time = "2026-04-07T11:14:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1b/070175e873177814d58850a01ebe80e20ae11e93eb4da894d563988660fa/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610", size = 2388246, upload-time = "2026-04-07T11:14:50.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/77caf7aaf9c2be050ad1f128d7c24ff0f59079aa62c5f62f9df41c0af45e/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8", size = 2494333, upload-time = "2026-04-07T11:14:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/dd7e1f2aa31a8fbbfc16b0610af1d770ffaf1287490f3c8c5b1c52da264f/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98", size = 4258579, upload-time = "2026-04-07T11:14:54.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0a/ac99e1ba347ba0e85e0bb60b74231d55fb93c0eff43f2920ccb413d0be08/rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc", size = 1709231, upload-time = "2026-04-07T11:14:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cb/0e251d731b3166378644238e8f0cf9e89858c024e19f75ca9f7e3ae83fd5/rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35", size = 1538519, upload-time = "2026-04-07T11:14:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/4548132acc947db6d5346a248e44a8b3a22d608ef30e770fb578caaf2d00/rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd", size = 812628, upload-time = "2026-04-07T11:15:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/00/60/69b177577290c5eab892c6f75fe89c3aff3f9ae80298a78d9372b1cecb9a/rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8", size = 1970231, upload-time = "2026-04-07T11:15:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/48/38/2fd790052659cc4e2907b63c25433f0987864b445c1aeec1a302ef5ad948/rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9", size = 1194394, upload-time = "2026-04-07T11:15:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/28430ad8472fc3536e8ebd51a864a226e979cfe924c6e3f83d111373aa74/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d", size = 1377051, upload-time = "2026-04-07T11:15:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7e/9aeacabcfd1e77397968362e5b98fe14248b8307011136b17daf99752a8e/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074", size = 3160565, upload-time = "2026-04-07T11:15:08.667Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f4/db4dd7be0cd2f2022117ac5407d905f435d60e48baaea313a567ad27e865/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3", size = 1442113, upload-time = "2026-04-07T11:15:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/0e9f6aa57f3e32a767216f797e56dc96b720fcecfb9d8ee907ecc82f8d66/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09", size = 2396618, upload-time = "2026-04-07T11:15:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/44a78e39ffce17cbdd3e2b53b696acc751d5d153be0f499d052b07a4d904/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa", size = 2478220, upload-time = "2026-04-07T11:15:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/454311469a09a507e9d784a35796742bec22e4cebe75551e2da4e0e290fd/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1", size = 4265027, upload-time = "2026-04-07T11:15:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/01/175465a9ab3e3b70ba669058372f009d1d49c1746e2dcd56b69df188d3a5/rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f", size = 1766814, upload-time = "2026-04-07T11:15:19.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a9b84a47af06ebed94a1439eb2f02adebfb8628bcd30af1fe3e02f5ef56c/rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a", size = 1582448, upload-time = "2026-04-07T11:15:21.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/5937800238b3f8248e70860d79f69ba8f73e764fff47e36bc9e2f26dbcc6/rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895", size = 832932, upload-time = "2026-04-07T11:15:24.358Z" },
+    { url = "https://files.pythonhosted.org/packages/81/41/aa3ffb3355e62e1bf91f6599b3092e866bc88487a07c524004943c7676df/rapidfuzz-3.14.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1a31cc6d7d03e7318a0974c038959c59e19c752b81115f2e9138b3331cd64d45", size = 1943327, upload-time = "2026-04-07T11:15:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e1/c2141f1840a41e07ad2db6f724945f8f8ff3065463899a22939152dd6e09/rapidfuzz-3.14.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0298d357e2bc59d572da4db0bc631009b6f8f6c9bc8c11e99a12b833f16b6575", size = 1161755, upload-time = "2026-04-07T11:15:28.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/07/66e753eeaa353161d1d331b7dd517bb349b0bacfebe8496d7b26be26f81f/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59b3dba758661a318995655435c6ab20a04ade79fa51e75bc8dc107cac8df280", size = 1376571, upload-time = "2026-04-07T11:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/85/9535df0b78ba51f478c9ce7eb6d1f85535cc31fe356773b48fd9d3e563ca/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4900143d82071bdda533b00300c40b14b963ff826b3642cc463b6dd0f036585e", size = 3156468, upload-time = "2026-04-07T11:15:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ee/b667eb93bba6dc4e0de658edd778e1619dc4d6aab68fa5e5c7f075152735/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a", size = 1458311, upload-time = "2026-04-07T11:15:35.557Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ce/479074f5624364a48df3403c538797ef22d3ac49c19dc76c3f79fcdcc70c/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:419e4397a36e2665ec992d8d64c20ba4b2a42500c76ecadeca78a4f19cb9cc32", size = 2398228, upload-time = "2026-04-07T11:15:37.669Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/a8982f649150fffbdcd6f17565974501f6ab33b2795267bffbd4a7ba905b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:97131ab2be39043054ee28d99e09efe316e6d53449b7e962dfcf3c2de8b2b246", size = 2497226, upload-time = "2026-04-07T11:15:39.857Z" },
+    { url = "https://files.pythonhosted.org/packages/19/52/5267c03ef6759831b7d4625a0c9c06e87baa2fae084b61ac9c388858317b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:593c00dac4e30231c35bf3b4f1da8ec0998762e9e94425586a5d636fcd57f9d0", size = 4262283, upload-time = "2026-04-07T11:15:42.279Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c0/2579f343a97f5254c43bb5853baccc01488357dcb64a27bcb869b7888a4a/rapidfuzz-3.14.5-cp314-cp314-win32.whl", hash = "sha256:0084b687b02b4e569b46d8d6d4ad25659528e6081cd6d067ca453a69035f07e4", size = 1744614, upload-time = "2026-04-07T11:15:44.498Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/8edfed1e80119dc9c35b11df4bc701eea85622ad681fff0263b6961d3224/rapidfuzz-3.14.5-cp314-cp314-win_amd64.whl", hash = "sha256:5dfa89d78f22cd773054caff44827b846161a29f2dcf7e78b8f90d086621e502", size = 1588971, upload-time = "2026-04-07T11:15:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/04/5676df93c85cfa57a3045d8047318df9f3cd58c7b8a99340dd95f874795e/rapidfuzz-3.14.5-cp314-cp314-win_arm64.whl", hash = "sha256:67f3f9d2b444268ab53e47d31bab89954888d23c04c6789f2c727e51fe4b1d13", size = 834985, upload-time = "2026-04-07T11:15:49.411Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/4a8988cea658fe335048ddef8c876addff1b6daa3c9ca8ad65a5a2196e69/rapidfuzz-3.14.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:77eac0526899b3c3ad1454bb2b03cdb491d67358ec8ef0c9c48bd61b632b431d", size = 1972517, upload-time = "2026-04-07T11:15:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a3/f5cfd9965a9d9a9e32249159797c47b5d6299ea6d1629f9126b25f1c10a3/rapidfuzz-3.14.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b9c6bd754d11f6e78ac54e3d86b4b11dc1ba2f13e5fc958899574532897f5a99", size = 1196056, upload-time = "2026-04-07T11:15:54.292Z" },
+    { url = "https://files.pythonhosted.org/packages/64/07/561c2e40cfd10e6630a7b0ac5a2a813aef50d944bcd1f3d260319d659d5b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:738c96944d076deeaff70e92b65696ab4f7ecb8081d7791c5403a3257dfaf8ff", size = 1374732, upload-time = "2026-04-07T11:15:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/39/123bb94fee40e2fb3b7c49b80827c7ef42d838e18def3fc2fef5a3cf817a/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3", size = 3166902, upload-time = "2026-04-07T11:15:58.768Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/45716fafc9fd2e028cf20b5ac5bc704887081cd312f84edb0e325599414b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:af6a90a4ed2a48fa1a2d17e9d824e6c7c950bea5bad0b707c77fd55751e6bfef", size = 1452130, upload-time = "2026-04-07T11:16:01.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/49/4e96c413114398481c0a5b0086af32c364a18613c9a2ea578d17c4bea4ee/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bf5018938208d4597b2e679a4f8cff9fd252f1df53583130ae56281a21801b64", size = 2396308, upload-time = "2026-04-07T11:16:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b7/49fea9fc6878d59bd259d01dd1972d9b86117992b1c66d9b16f0a65273c3/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c0919d1f89ddf91129906705723118ea09754171e4116f5a5dbc667c7bc9b261", size = 2488210, upload-time = "2026-04-07T11:16:05.871Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/44/a1f732b93ffacbdad077b7c801149549b2938e1bece6addb5ad85ed74df8/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:93d8da883a35116d6813432177f35e570db5b0a5e30ecb0cbd7cb39c815735df", size = 4270621, upload-time = "2026-04-07T11:16:08.483Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/ff942d19fce5385054650bb71a58495ddda299d94661ccc4e6e7fa44868b/rapidfuzz-3.14.5-cp314-cp314t-win32.whl", hash = "sha256:0f23e37019ec07712d58976b1ab2b889f8649a7f7c2f626a2f34ea9139e79279", size = 1803950, upload-time = "2026-04-07T11:16:10.873Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0f/9aafc63f9661222b819b391c187eed29fc90ad5935f9690e5ecc2d2047a4/rapidfuzz-3.14.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7d5ca9c7832e6879a707296d1463685f7c243a27846227044504741640caec66", size = 1632357, upload-time = "2026-04-07T11:16:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/51fc1b0e61e3326e1c68a61cfd0c6b3c34c843681c4b1eefbf0596f59162/rapidfuzz-3.14.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3e91dcd2549b8f8d843f98ba03a17e01f3d8b72ce942adbbb6761bc58ffce813", size = 855409, upload-time = "2026-04-07T11:16:15.787Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `@`-completion in FinPrompt for inline context injection (`@file:`, `@git:diff`, `@git:log`, `@history:`), replacing former `--file`/`--git-diff` CLI flags
- Add `fin list` subcommand (tools, prompts, output-types) for platform capability introspection
- Add interactive input panel (`fin do` with no prompt), `--edit` flag, and `--agent` flag
- Expose `FinPrompt.context_settings` as a public read-only property instead of accessing private `_context_settings`
- Derive test assertions from centralized `_AT_CONTEXT_TYPES` constant to prevent drift
- Update architecture docs, README, manual-testing guide, and handoff to reflect completed work

## Changes

| Area | Change |
|------|--------|
| `cli/interaction/prompt.py` | `AtCompleter`, `resolve_at_references`, `_AT_CONTEXT_TYPES`, `FinPrompt.context_settings` property |
| `cli/interaction/chat.py` | Wire `@`-resolution through `fp.context_settings` |
| `cli/main.py` | `fin list` subcommand, input panel, `--edit`/`--agent` flags |
| `context/__init__.py` | Public re-exports for context providers |
| `agents/metadata.py` | Minor update |
| `tests/test_cli/` | `test_context_injection.py` (derived from `_AT_CONTEXT_TYPES`), `test_prompt.py`, `test_main.py` |
| `docs/` | architecture.md, manual-testing.md, README, handoff.md sync |

Closes #88