### PR TITLE
feat: git agent + scoped CLI tools + workflow config (#79)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -451,7 +451,7 @@ Agents are defined entirely in `config.toml`, not as separate Python classes. A 
 #### Current Agent: `test` (`[agents.test]`)
 
 - **Purpose**: Development test agent with file, shell, and git tools
-- **Config**: `system_prompt = "test"`, `output_type = "text"`, `serving_modes = ["do", "talk"]`, `thinking = "medium"`, `tools = ["read_file", "git_diff", "run_shell"]`
+- **Config**: `system_prompt = "test"`, `output_type = "text"`, `serving_modes = ["do", "talk"]`, `thinking = "medium"`, `tools = ["read_file", "git", "run_shell"]`
 - **Output**: `str` (free-form text response)
 
 #### SDD Agent (`[agents.sdd]`) — future
@@ -478,7 +478,78 @@ system_prompt = "test"
 output_type = "text"
 thinking = "medium"
 serving_modes = ["do", "talk"]
-tools = ["read_file", "git_diff", "run_shell"]
+tools = ["read_file", "git", "run_shell"]
+```
+
+### Git Agent (`[agents.git]`)
+
+The git agent is the first real end-user agent and the first to use **scoped CLI tools** and **workflows**.
+
+- **Purpose**: Git workflows — commit, PR, summarize
+- **Config**: `system_prompt = "git"`, `output_type = "text"`, `serving_modes = ["do"]`, `tools = ["read_file", "git", "gh", "run_shell"]`
+- **Workflows**: `commit`, `pr`, `summarize` — each with its own `entry_prompt` and `prompt_template`
+- **Output**: `str` (free-form text response)
+
+#### Scoped CLI Tools
+
+Instead of per-subcommand tool wrappers (`git_diff`, `git_log`), the platform provides **scoped CLI tools** that wrap a command prefix:
+
+| Tool | Prefix | Approval | Description |
+|------|--------|----------|-------------|
+| `git` | `git` | `always` | Run any git subcommand |
+| `gh` | `gh` | `always` | Run any GitHub CLI subcommand |
+
+The LLM chooses the subcommand/args — one tool definition per CLI instead of one per subcommand. This saves prompt tokens and maps naturally to the **API + CLI + Skills** pattern (see Phase 15).
+
+> **Note**: Approval is currently `always` for all scoped CLI tools. Per-subcommand approval (e.g. `git diff` → never, `git push` → always) is a planned Skills API enhancement. See the Skills API issue for details.
+
+#### Workflows
+
+Workflows are config-driven prompt-steering primitives. They allow an agent to expose named sub-tasks with their own entry prompts and system prompt templates:
+
+```toml
+[agents.git.workflows.commit]
+description = "Generate a conventional commit message from current changes."
+prompt_template = "git-commit"
+entry_prompt = "Analyze the current staged and unstaged changes and generate a conventional commit message."
+```
+
+- `fin do git commit` → agent=git, workflow=commit (entry_prompt sent as user message, prompt_template injected as context)
+- `fin do git --workflow commit` → same, explicit workflow flag
+- `fin do git` → agent=git, no workflow (LLM routes based on user input)
+
+This is level 2 of the workflow spectrum (prompt steering). Future extensions may add tool scoping and per-subcommand approval overrides — see the Skills API vision below.
+
+```toml
+[agents.test]
+system_prompt = "test"
+output_type = "text"
+thinking = "medium"
+serving_modes = ["do", "talk"]
+tools = ["read_file", "git", "shell_history", "run_shell"]
+
+[agents.git]
+system_prompt = "git"
+output_type = "text"
+thinking = "medium"
+serving_modes = ["do"]
+tools = ["read_file", "git", "gh", "run_shell"]
+
+[agents.git.workflows.commit]
+description = "Generate a conventional commit message from current changes."
+prompt_template = "git-commit"
+entry_prompt = "Analyze the current staged and unstaged changes and generate a conventional commit message."
+
+[agents.git.workflows.pr]
+description = "Create a pull request from current branch to main."
+prompt_template = "git-pr"
+entry_prompt = "Analyze the current branch changes and create a pull request."
+
+[agents.git.workflows.summarize]
+description = "Summarize current changes without executing any commands."
+prompt_template = "git-summarize"
+entry_prompt = "Summarize the current staged and unstaged changes."
+serving_modes = ["do", "talk"]
 ```
 
 ### Output Type Registry
@@ -768,7 +839,7 @@ system_prompt = "test"
 output_type = "text"
 thinking = "medium"
 serving_modes = ["do", "talk"]
-tools = ["read_file", "git_diff", "run_shell"]
+tools = ["read_file", "git", "shell_history", "run_shell"]
 
 [providers.anthropic]
 # API key stored separately in credentials
@@ -919,11 +990,24 @@ Credentials stored separately from config (0600 permissions). Supports env var -
 
 ### Phase 15: Skills + MCP Integration ⬜
 - [ ] Skills framework (configurable behaviors per agent)
+- [ ] Per-subcommand approval policies (e.g. `git diff` → never, `git push` → always)
+- [ ] Context templates: markdown files encoding domain knowledge injected when a skill is activated
+- [ ] Skill auto-discovery from `~/.config/fin/skills/` or MCP servers
 - [ ] MCP client integration
 - [ ] CLI/TUI components for skill/MCP configuration
 - [ ] Per-project skill/MCP configuration
 
+The Skills API generalizes the scoped CLI tools + workflow config pattern established by the git agent. A "skill" is the full package: a scoped CLI tool (capability), workflow definitions (behavior), and context templates (knowledge). This follows the **API + CLI + Skills** architectural pattern — CLI tools provide deterministic execution, skills provide workflow intelligence.
+
+Progression:
+1. **Now**: Agent-scoped `WorkflowConfig` + scoped CLI tools (`git`, `gh`) with `approval=always`
+2. **Next**: Per-subcommand approval policies, global workflow registry for cross-agent reuse
+3. **Full Skills API**: Declarative skill registration, context injection, auto-discovery, skill composition
+
+See the Skills API GitHub issue for the full vision.
+
 ### Phase 16: Additional Agents ⬜
+- [x] Git agent (`[agents.git]`) — commit, PR, summarize workflows with scoped `git`/`gh` tools
 - [ ] Create `agents/sdd.py` (design brainstorming)
 - [ ] Define `SketchResult` model
 - [ ] Implement tools: `read_file`, `write_file`, `list_docs`
@@ -1027,7 +1111,7 @@ url = "http://127.0.0.1:5002"
 **Why defer:** No external agents exist yet. The change is small and well-understood (~50 lines), but designing the config schema without a real external process to validate against risks over-fitting. Once a toy Rust/Gleam agent exists, the schema will be obvious. The discovery endpoint is already forward-compatible — agent entries include a `url` field that can point externally.
 
 ### Near-term (Phases 13-15)
-- **Skills framework** — Configurable behaviors (e.g., brainstorming mode, terse mode)
+- **Skills API** — Scoped CLI tools + workflow config + context templates + per-subcommand approval (generalizes git agent pattern)
 - **MCP integration** — Natural language interface to configurable MCP tools/servers
 - **Additional agents** — SDD, TDD, code review, shell completion, computer use, journaling
 - **Multi-agent workflows** — Agent-to-agent via A2A, orchestration patterns

--- a/handoff.md
+++ b/handoff.md
@@ -27,7 +27,7 @@ Rolling context for session handoffs. Updated as checkpoints are reached.
 - `build_user_message`/`format_context` helpers in `llm/prompts.py` are dead code
 - `supported_context_types` published in agent cards, never consumed by clients
 - Phase 4 architectural discussions — issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94)
-- Scoped CLI tools approval=always is not final state — per-subcommand approval is a planned Skills API enhancement (see Skills API issue)
+- Scoped CLI tools approval=always is not final state — per-subcommand approval is Phase A of the sequenced Skills API plan (see "Design Sketches: Skills API" below)
 
 ---
 
@@ -88,12 +88,208 @@ Design is resolved (see architecture.md and handoff.md historical notes). Now th
 | 12 | Fish Plugin | ⬜ Not Started |
 | 13 | TUI Client (A2A) | ⬜ Not Started |
 | 14 | Testing Infrastructure (Deep Evals) — per-agent eval harness, rides on Phoenix traces | ⬜ Queued after tracing — see "Sequenced roadmap" in Next Session |
-| 15 | Skills + MCP Integration | 📐 Scoped CLI tools + WorkflowConfig shipped (git agent); full Skills API + MCP pending |
+| 15 | Skills + MCP Integration | 📐 Scoped CLI tools + WorkflowConfig shipped (git agent); sequenced Phase A/B/C sketch resolved 2026-04-27 — see "Design Sketches" below |
 | 16 | Additional Agents | 🔄 Git agent shipped; SDD/TDD/code review pending |
 | 17 | Multi-Agent Workflows | ⬜ Not Started |
 | 18 | Documentation | ⬜ Not Started |
 | — | Phoenix/OTel tracing | 📐 Design resolved; queued as next session |
 | — | Nix/Home Manager packaging | 📐 Sketched |
+
+---
+
+## Design Sketches
+
+### Skills API: sequenced refactor (Phase 15 breakdown)
+
+**Status:** Sketch resolved 2026-04-27. Ready to start Phase A in a fresh session.
+
+**Why this exists:** the scoped CLI + WorkflowConfig pattern from the git agent (2026-04-27) is a prototype for the broader Skills API (`architecture.md:991`, Phase 15). Rather than landing Skills as one big refactor, split into three sequenced phases, each independently shippable with a real user-visible exit gate.
+
+**Grounding citations** (in-repo, so this sketch stays honest):
+
+- Scoped CLI prototype + TODO for per-subcommand approval: `src/fin_assist/agents/tools.py:213`, `src/fin_assist/agents/tools.py:295`
+- Current `ApprovalPolicy` shape (only `never`/`always`, no rules): `src/fin_assist/agents/tools.py:40`
+- `AgentConfig.tools` flat list of names: `src/fin_assist/config/schema.py:99`
+- Empty `skills/` + `mcp/` placeholder folders: `architecture.md:291`, `architecture.md:294`
+- Skills API vision (API + CLI + Skills pattern): `docs/architecture.md:991`–`:1007`
+- Existing note: "Scoped CLI tools approval=always is not final state": this file, "Remaining tracked items"
+
+---
+
+#### Phase A — Subcommand approval rules
+
+**Goal:** `git diff` runs un-gated; `git push` still asks. Highest-value slice of the user's idea, aligned with the explicit TODO at `tools.py:213`.
+
+**Design:**
+
+```python
+# src/fin_assist/agents/tools.py
+@dataclass
+class ApprovalRule:
+    pattern: str            # fnmatch-style glob against the full args string
+    mode: Literal["never", "always"]
+    reason: str | None = None
+
+@dataclass
+class ApprovalPolicy:
+    mode: Literal["never", "always"]        # fallback when no rule matches
+    rules: list[ApprovalRule] = field(default_factory=list)
+    reason: str | None = None
+
+    def evaluate(self, args: str) -> tuple[Literal["never", "always"], str | None]:
+        for r in self.rules:
+            if fnmatch(args, r.pattern):
+                return r.mode, r.reason
+        return self.mode, self.reason
+```
+
+**Touchpoints:**
+
+- `src/fin_assist/agents/tools.py:40` — extend `ApprovalPolicy` (above)
+- `src/fin_assist/agents/tools.py:295` — `_make_scoped_cli` callable becomes aware of its policy so the backend can query `policy.evaluate(args)` per call
+- Backend adapter (pydantic-ai glue that reads `approval_policy`) — switch from static `requires_approval` flag to per-call evaluation via pydantic-ai's `approval_required()` toolset wrapper pattern
+- **Rules still Python-defined in `create_default_registry()`** — no config schema change yet. Config authoring lands in Phase B.
+
+**TDD tests (before implementation, per `AGENTS.md`):**
+
+- `test_approval_policy_evaluate.py`: pattern matching, first-match-wins, fallback to `mode`, empty rules behaves like current `ApprovalPolicy`
+- `test_tools_scoped_cli_approval.py`: `git diff` → never, `git push origin main` → always, `git log --oneline -5` → never, unknown subcommand → fallback
+- Executor integration: deferred `StepEvent` emitted only when `evaluate()` returns `always`
+
+**Exit gate:** through the git agent, `git diff` runs without an approval prompt; `git push` still pauses. Manual demo + tests.
+
+**Files touched (estimate):** ~4 source, ~2 new test files, ~200 LOC + tests.
+
+---
+
+#### Phase B — Skill bundling (ToolDefinition → SkillDefinition)
+
+**Goal:** one TOML object bundles a scoped CLI + its approval rules + named scripts + workflows. Makes skills authorable end-to-end in config.
+
+**Design (TOML shape):**
+
+```toml
+[skills.git]
+type = "cli"                         # preps the tool-type taxonomy in Phase C
+prefix = "git"
+description = "Run any git subcommand."
+
+[skills.git.approval]
+default = "always"
+rules = [
+  { pattern = "diff*",   mode = "never" },
+  { pattern = "status*", mode = "never" },
+  { pattern = "log*",    mode = "never" },
+  { pattern = "show*",   mode = "never" },
+]
+
+[skills.git.scripts.pr-checklist]
+description = "Print the PR review checklist from scripts/git/pr-checklist.sh"
+path = "scripts/git/pr-checklist.sh"
+approval = "never"
+
+# Workflows move under skills (decided 2026-04-27) to unlock cross-agent reuse.
+# The existing [agents.<name>.workflows.<w>] keys MUST be migrated; no dual-read.
+[skills.git.workflows.commit]
+description = "Generate a conventional commit message from current changes."
+prompt_template = "git-commit"
+entry_prompt = "Analyze the current staged and unstaged changes and generate a conventional commit message."
+```
+
+**Touchpoints:**
+
+- **New:** `src/fin_assist/skills/` package (currently empty placeholder at `architecture.md:291`). Contains:
+  - `definition.py` — `SkillDefinition`, `SkillConfig` (pydantic model)
+  - `loader.py` — reads `config.skills`, instantiates `SkillDefinition`s
+  - `registration.py` — adapter that expands a skill into N `ToolDefinition`s (the CLI itself + one per named script), all sharing the skill's approval policy, and registers them into `ToolRegistry`
+- `src/fin_assist/config/schema.py:85` — add `skills: dict[str, SkillConfig]` at root `Config` level. **Remove** `workflows` from `AgentConfig`; migrate to `SkillConfig.workflows`. `AgentConfig.tools` now references either raw tool names or skill names (skill name expands to "CLI tool + its scripts").
+- `src/fin_assist/hub/app.py:create_hub_app` — load skills and register into the shared `ToolRegistry` before `AgentSpec` construction (so `spec.tools` resolution sees them).
+- `config.toml` — migrate `[agents.git.workflows.*]` to `[skills.git.workflows.*]`. Agent still references the skill via `tools = ["git", "gh"]`.
+- `src/fin_assist/cli/main.py` — workflow resolution (`fin do git commit`) now looks up the workflow via the agent's skills, not `AgentConfig.workflows` directly.
+
+**What Phase B explicitly does NOT do:**
+
+- No tool-type dispatch beyond validation. `type = "cli"` is required and parsed, but only the CLI branch is wired. Second branch (`mcp`, `function`, `browser`) waits for Phase C with a real consumer.
+- No KG / NL-over-docs discoverability. Current `description` is sufficient (and `fin list tools` already surfaces it).
+- No cross-project skill auto-discovery from `~/.config/fin/skills/`. Phase 15 stretch goal.
+
+**TDD tests:**
+
+- `test_skills_config.py`: TOML parsing for skill + approval rules + scripts + workflows
+- `test_skills_registration.py`: a skill with `scripts = {foo, bar}` registers 3 `ToolDefinition`s (`git`, `git.foo`, `git.bar`) all sharing the approval policy
+- `test_skills_workflow_resolution.py`: `fin do git commit` resolves to `[skills.git.workflows.commit]`, not the old `[agents.git.workflows.commit]`
+- Migration test: loading a config with the legacy `[agents.*.workflows.*]` shape raises a clear error pointing to the new location (no silent fallback)
+
+**Exit gate:** `config.toml` defines `skills.git` with subcommand rules and at least one named script; `[agents.git] tools = ["git"]` auto-resolves to the Skill; behavior identical to Phase A but config-driven. A **second** skill authored end-to-end in TOML (candidate: `just`, `gh`, or `docker` — pick at implementation time based on what's most useful for the dev loop) as the config-path validation.
+
+**Files touched (estimate):** ~3 new source files, ~3 modified source files, ~4 new test files, ~400 LOC + tests + config migration.
+
+---
+
+#### Phase C — Tool-type primitive
+
+**Goal:** `type: Literal["cli", "mcp", ...]` as a first-class field, with type-specific OTel span attributes and a self-documenting registry.
+
+**Gate for starting Phase C:** a second tool type has a concrete consumer. Most likely trigger: MCP integration (`architecture.md:294`, `tools.py:22`). Secondary candidates: browser-use, Python-script-exec-in-sandbox. **Do not start Phase C speculatively** — the primitive is premature generalization without a second consumer.
+
+**Design:**
+
+```python
+# src/fin_assist/agents/tool_types.py  (new)
+class ToolTypeAdapter(Protocol):
+    """How a tool of type <T> is invoked, traced, and loaded from config."""
+
+    type_name: str  # "cli", "mcp", "function", "browser", ...
+
+    def span_attributes(self) -> list[str]:
+        """OTel attribute names this type emits. Powers `fin list tool-types`."""
+
+    async def invoke(
+        self, definition: ToolDefinition, args: dict[str, Any]
+    ) -> str:
+        """Run the tool and emit a type-shaped OTel span around the callable."""
+
+    def load_from_config(self, skill_config: SkillConfig) -> list[ToolDefinition]:
+        """Turn TOML config into ToolDefinitions. Phase B's CLI loader moves here."""
+```
+
+- `ToolDefinition.type: str` — required field (default `"cli"` for backward compat at first, made required once all skills declare explicitly)
+- OTel instrumentation lives in the adapter, **not** in the tool callable. Preserves "platform types zero framework deps" invariant at `agents/tools.py:1`
+- Global `ToolTypeRegistry` (alongside `ToolRegistry`) maps `type_name` → adapter
+
+**Expanded exit gate (per 2026-04-27 discussion):**
+
+1. **Type-adapter pattern codified.** `ToolTypeAdapter` protocol lands with the `cli` adapter as the first implementation. The existing `_make_scoped_cli` logic moves behind the adapter interface; all current CLI-typed skills flow through it unchanged. Span attributes for `cli`: `cli.prefix`, `cli.args`, `cli.exit_code`, `cli.duration_ms`, `cli.timed_out`.
+2. **Second adapter lands end-to-end.** Most likely `mcp` — `MCPToolsetAdapter` connects to one configured MCP server, enumerates its tools via the MCP client protocol, and registers each as a `ToolDefinition(type="mcp", ...)`. Span attributes for `mcp`: `mcp.server`, `mcp.tool_name`, `mcp.request_id`, `mcp.duration_ms`. Ships with one real MCP server working end-to-end (candidate: `mcp-server-git` or a filesystem server; decide at implementation time based on ecosystem state).
+3. **`fin list tool-types` CLI surface.** New subcommand matching the existing `fin list tools/prompts/output-types` pattern (from handoff Tier 1 work). Output shape:
+   ```
+   cli        span attrs: cli.prefix, cli.args, cli.exit_code, cli.duration_ms, cli.timed_out
+              skills: git, gh, just
+   mcp        span attrs: mcp.server, mcp.tool_name, mcp.request_id, mcp.duration_ms
+              skills: mcp.filesystem, mcp.github
+   ```
+   Self-documenting: adding a new type means its span schema is discoverable without reading adapter source. Enforces the invariant that types are semantically distinct (if two types have identical `span_attributes()`, one of them is decorative).
+4. **Span semantics verified in Phoenix.** By the time Phase C starts, Phoenix/OTel has shipped (next-session work per `handoff.md:36`). Exit criterion: open Phoenix, see `cli`-type and `mcp`-type invocations side-by-side with their type-specific attributes, and be able to filter traces by `tool.type`. **This is the gate that proves the primitive has real semantic weight rather than being a decorative enum.**
+
+**Files touched (estimate):** ~5 new source files (tool_types module, MCP adapter, MCP client wrapper), ~4 modified (ToolDefinition field, backend adapter wiring, CLI `list` command, Phoenix instrumentation hooks), ~5 new test files, ~600 LOC + tests + MCP integration test.
+
+---
+
+#### Explicitly parked (from the original brainstorm)
+
+- **Knowledge-graph–backed tool discoverability** (NL Q&A over man pages / docs). Revisit post-Skills as a new `ContextProvider` implementation if a real pain point appears — LLMs already know `git`'s surface area, and Context7 covers library docs. Not on Phase A/B/C critical path.
+- **"One `bash` supertool" framing.** Rejected in favor of distinct prefix-scoped Skills. The codebase direction (`tools.py:14`) is explicitly away from generic shell as primary surface; scoped CLIs are the replacement.
+- **"Agents orchestrate many CLIs" as new design.** Already the shape (`[agents.git] tools = ["git", "gh", "run_shell", ...]`); Skills make it more structured but don't change the conceptual model.
+
+#### Sequencing summary
+
+| Phase | Ship | Blocks on | Real consumer |
+|---|---|---|---|
+| A | Per-subcommand approval (Python-defined rules) | — | Git agent UX today |
+| B | Skill object (TOML-authored skills, script bundling, workflows migrated under skills) | Phase A | User-authored skills; replaces agent-scoped workflows |
+| C | Tool-type taxonomy + adapter pattern + `fin list tool-types` | Phase B + Phoenix/OTel + a real second type (MCP likely) | MCP integration or browser-use |
+
+**Start here in next session:** Phase A, TDD-first per `AGENTS.md`. Open the failing `test_approval_policy_evaluate.py` first.
 
 ---
 

--- a/handoff.md
+++ b/handoff.md
@@ -2,7 +2,7 @@
 
 Rolling context for session handoffs. Updated as checkpoints are reached.
 
-**Current state (2026-04-27)**: 704 tests passing, CI green. All Tier 1 features shipped: `@`-completion, `fin list`, input panel + `--edit`, remove built-in agents, client artifact-merge fix. Documentation synced with codebase. Phase 4 architectural discussions filed as issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94).
+**Current state (2026-04-27)**: 729 tests passing, CI green. Git agent (#79) shipped with scoped CLI tools (`git`, `gh`) and workflow config. All Tier 1 features shipped. Documentation synced with codebase. Phase 4 architectural discussions filed as issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94).
 
 **Core platform status:**
 
@@ -17,25 +17,42 @@ Rolling context for session handoffs. Updated as checkpoints are reached.
 | `fin list` capabilities | ✅ Complete — `tools`, `prompts`, `output-types` (local, no hub) |
 | Remove built-in agents | ✅ Complete — `_DEFAULT_AGENTS = {}`, all from config.toml |
 | Client artifact-merge fix | ✅ Complete — splice in both `stream_agent()` and `_send_and_wait()` |
-| Observability / tracing | 📐 Design resolved (Phoenix + OTel); implementation deferred (Phase D) |
+| Git agent (#79) | ✅ Complete — scoped `git`/`gh` CLI tools, `WorkflowConfig`, three workflows (commit/pr/summarize) |
+| Observability / tracing | 📐 Design resolved (Phoenix + OTel); queued as next session — see "Sequenced roadmap" |
 
 **Remaining tracked items:**
 
 - `_CONTEXT_TYPE_MAP` centralization — `AgentSpec._CONTEXT_TYPE_MAP` hardcodes tool→context mappings; tests read the private attribute.
 - AgentBackend protocol simplification ([#80](https://github.com/ColeB1722/fin-assist/issues/80))
 - `build_user_message`/`format_context` helpers in `llm/prompts.py` are dead code
-- `git_status` provider orphaned — not exposed as a tool or `@`-completion
 - `supported_context_types` published in agent cards, never consumed by clients
 - Phase 4 architectural discussions — issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94)
+- Scoped CLI tools approval=always is not final state — per-subcommand approval is a planned Skills API enhancement (see Skills API issue)
 
 ---
 
 ## Next Session
 
-Pick from:
+**Planned: Tracing — Phoenix + OTel.**
+
+Design is resolved (see architecture.md and handoff.md historical notes). Now that the git agent provides real multi-step tool-call + deferred-approval flows to observe, the tracing signal will be meaningful. Wire OTel spans to `StepEvent`/`StepHandle` boundaries from PR #87, ship Phoenix as the observability backend.
+
+### Sequenced roadmap (why this order)
+
+| # | Work | Rationale |
+|---|------|-----------|
+| 1 | **Tracing: Phoenix + OTel** (next session) | Design resolved but zero code in `src/`. Git agent provides real multi-step tool-call + deferred-approval flows to observe. `StepEvent`/`StepHandle` boundaries from PR #87 are fresh — cheapest time to wire instrumentation. Phoenix gives us an eval UI for free once traces are clean. |
+| 2 | **Eval harness (per-agent, not platform-level)** | Evals are downstream of observability when using Phoenix. Two real agents exist (test + git) — eval criteria are meaningful. Platform stance: evals live at the agent level (`tests/evals/<agent>/`). Closes [#14](https://github.com/ColeB1722/fin-assist/issues/14). Likely surfaces [#80](https://github.com/ColeB1722/fin-assist/issues/80) (AgentBackend simplification). |
+| 3 | **Skills API** | Generalizes the scoped CLI tools + workflow config pattern from the git agent. Per-subcommand approval, context templates, skill auto-discovery. See the Skills API GitHub issue for the full vision. |
+
+**Why not tracing first:** tracing one agent (the `test` agent) gives ~10% of the learnings of tracing a real agent with non-trivial tool calls. The scaffolding would ship but the signal wouldn't.
+
+**Why not evals first:** without tracing, eval failures are opaque — you know an eval failed but not why the agent went wrong in the middle of a 3-step tool loop. Phoenix eval primitives specifically consume OTel traces, so doing them in the other order duplicates work.
+
+### Alternative picks if priorities change
 
 1. **Phase 4 design discussions** — open issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94). Each issue body is a session-ready brief. `#92` has a research spike as pre-work.
-2. **Tech debt** — `_CONTEXT_TYPE_MAP` centralization, dead code cleanup in `llm/prompts.py`, AgentBackend simplification (#80).
+2. **Tech debt** — `_CONTEXT_TYPE_MAP` centralization, dead code cleanup in `llm/prompts.py`, AgentBackend simplification ([#80](https://github.com/ColeB1722/fin-assist/issues/80)).
 3. **Future phases** — Multiplexer, TUI, Skills/MCP, additional agents, multi-agent workflows.
 4. **Other open issues** — see `gh issue list` for the broader backlog.
 
@@ -64,17 +81,18 @@ Pick from:
 | — | PR #87 self-review triage (Phases 1–3) | ✅ Complete (2026-04-26) |
 | — | Phase 4 architecture discussions | 📐 Filed as issues #89–#94 |
 | — | Documentation sync (README, architecture.md, manual-testing.md, handoff.md) | ✅ Complete (2026-04-27) |
+| — | Git agent (#79): scoped `git`/`gh` CLI tools, `WorkflowConfig`, three workflows | ✅ Complete (2026-04-27) |
 | 9b | Full SSE Streaming (was blocked on fasta2a) | ✅ Covered by a2a-sdk migration |
 | 10 | Non-blocking + interactive tasks | 📐 Superseded by deferred tools |
 | 11 | Multiplexer Integration | ⬜ Not Started |
 | 12 | Fish Plugin | ⬜ Not Started |
 | 13 | TUI Client (A2A) | ⬜ Not Started |
-| 14 | Testing Infrastructure (Deep Evals) | ⬜ Not Started |
-| 15 | Skills + MCP Integration | ⬜ Not Started |
-| 16 | Additional Agents | ⬜ Not Started |
+| 14 | Testing Infrastructure (Deep Evals) — per-agent eval harness, rides on Phoenix traces | ⬜ Queued after tracing — see "Sequenced roadmap" in Next Session |
+| 15 | Skills + MCP Integration | 📐 Scoped CLI tools + WorkflowConfig shipped (git agent); full Skills API + MCP pending |
+| 16 | Additional Agents | 🔄 Git agent shipped; SDD/TDD/code review pending |
 | 17 | Multi-Agent Workflows | ⬜ Not Started |
 | 18 | Documentation | ⬜ Not Started |
-| — | Phoenix/OTel tracing | 📐 Design resolved (Phase D) |
+| — | Phoenix/OTel tracing | 📐 Design resolved; queued as next session |
 | — | Nix/Home Manager packaging | 📐 Sketched |
 
 ---
@@ -82,6 +100,16 @@ Pick from:
 ## Historical Reference
 
 Key completed milestones. See git log for full detail; code is the source of truth.
+
+### Git Agent + Scoped CLI Tools (#79, 2026-04-27)
+
+First real end-user agent. Introduced three concepts that generalize to the Skills API:
+
+- **Scoped CLI tools**: `git` and `gh` tools that wrap a command prefix (`git {args}`, `gh {args}`). Replaced per-subcommand wrappers (`git_diff`, `git_log`) — one tool per CLI instead of one per subcommand, saving prompt tokens. Approval is `always` for all scoped CLI tools; per-subcommand approval is a planned Skills API enhancement.
+- **WorkflowConfig**: Agent-scoped config primitive for prompt-steered sub-tasks. Each workflow has a description, prompt_template (system prompt override), entry_prompt (sent as user message), and optional serving_modes override. CLI resolves workflows via `fin do git commit` (positional) or `--workflow commit` (explicit flag).
+- **Git agent system prompt**: Covers three workflows (commit, PR, summarize) with step-by-step instructions. Each workflow has a dedicated prompt template in `SYSTEM_PROMPTS` for focused steering.
+
+Files changed: `tools.py` (scoped CLI factory, remove `git_diff`/`git_log`), `spec.py` (`_CONTEXT_TYPE_MAP` update), `prompts.py` (git instructions), `registry.py` (prompt registration), `schema.py` (`WorkflowConfig`), `config.toml` (git agent + workflows), `main.py` (workflow resolution + `--workflow` flag), `streaming.py` (emoji map + key arg for scoped tools).
 
 ### Tier 1 Features + Doc Sync (2026-04-27)
 
@@ -187,3 +215,5 @@ Phases 1–8b: repo setup, core package structure, LLM module (pydantic-ai + cre
 - Platform types in `agents/` have zero `hub/` imports by design (platform vs transport separation)
 - `@`-completion is the sole user-driven context path (`@file:`, `@git:diff`, `@git:log`, `@history:`); `--file`/`--git-diff` CLI flags removed
 - `fin list tools/prompts/output-types` lists platform registries locally (no hub connection)
+- Scoped CLI tools (`git`, `gh`) are the prototype for the Skills API — one tool per CLI, LLM picks subcommand/args
+- WorkflowConfig is agent-scoped prompt steering; full Skills API will generalize to global registry + context templates + per-subcommand approval

--- a/src/fin_assist/agents/registry.py
+++ b/src/fin_assist/agents/registry.py
@@ -18,7 +18,9 @@ OUTPUT_TYPES: dict[str, type] = {
     "command": CommandResult,
 }
 
-PromptName = Literal["chain-of-thought", "shell", "test"]
+PromptName = Literal[
+    "chain-of-thought", "shell", "test", "git", "git-commit", "git-pr", "git-summarize"
+]
 
 SYSTEM_PROMPTS: dict[str, str] = {}
 
@@ -26,6 +28,10 @@ SYSTEM_PROMPTS: dict[str, str] = {}
 def _init_prompts() -> None:
     from fin_assist.llm.prompts import (
         CHAIN_OF_THOUGHT_INSTRUCTIONS,
+        GIT_COMMIT_INSTRUCTIONS,
+        GIT_INSTRUCTIONS,
+        GIT_PR_INSTRUCTIONS,
+        GIT_SUMMARIZE_INSTRUCTIONS,
         SHELL_INSTRUCTIONS,
         TEST_INSTRUCTIONS,
     )
@@ -33,6 +39,10 @@ def _init_prompts() -> None:
     SYSTEM_PROMPTS["chain-of-thought"] = CHAIN_OF_THOUGHT_INSTRUCTIONS
     SYSTEM_PROMPTS["shell"] = SHELL_INSTRUCTIONS
     SYSTEM_PROMPTS["test"] = TEST_INSTRUCTIONS
+    SYSTEM_PROMPTS["git"] = GIT_INSTRUCTIONS
+    SYSTEM_PROMPTS["git-commit"] = GIT_COMMIT_INSTRUCTIONS
+    SYSTEM_PROMPTS["git-pr"] = GIT_PR_INSTRUCTIONS
+    SYSTEM_PROMPTS["git-summarize"] = GIT_SUMMARIZE_INSTRUCTIONS
 
 
 _init_prompts()

--- a/src/fin_assist/agents/spec.py
+++ b/src/fin_assist/agents/spec.py
@@ -50,8 +50,8 @@ class AgentSpec:
 
     _CONTEXT_TYPE_MAP: dict[str, str] = {
         "read_file": "file",
-        "git_diff": "git_diff",
-        "git_log": "git_log",
+        "git": "git",
+        "gh": "gh",
         "shell_history": "history",
     }
 

--- a/src/fin_assist/agents/tools.py
+++ b/src/fin_assist/agents/tools.py
@@ -7,9 +7,17 @@ mechanism (e.g., pydantic-ai's ``Tool`` dataclass or ``@agent.tool``
 decorator).
 
 Tools are **shareable between agents** — agents opt in via config
-(``tools = ["read_file", "git_diff"]``).  The registry is global; each
+(``tools = ["read_file", "git"]``).  The registry is global; each
 agent's ``AgentSpec`` references tool names, and the backend registers
 only the tools the agent needs.
+
+**Scoped CLI tools** (``git``, ``gh``) are the prototype for the future
+Skills API.  Each wraps a command prefix and lets the LLM choose the
+subcommand/args — one tool definition per CLI instead of one per
+subcommand.  This saves prompt tokens and maps naturally to the
+API + CLI + Skills pattern (see architecture.md).  Approval is currently
+``always`` for all scoped CLI tools; per-subcommand approval is a planned
+Skills API enhancement.
 
 MCP integration (#84): A future ``MCPToolset`` would wrap an MCP client
 and register discovered tools into the ``ToolRegistry`` with appropriate
@@ -180,25 +188,62 @@ def create_default_registry(
 
     registry.register(
         ToolDefinition(
-            name="git_diff",
-            description="Show unstaged and staged changes in the current git repository.",
-            callable=_make_git_diff(context_settings),
+            name="git",
+            description=(
+                "Run a git subcommand and return its output. "
+                "The argument is passed directly to git (e.g. 'diff', 'log --oneline -5', "
+                "'status --porcelain'). Requires user approval before execution."
+            ),
+            callable=_make_scoped_cli("git"),
             parameters_schema={
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "args": {
+                        "type": "string",
+                        "description": (
+                            "Arguments to pass to git (e.g. 'diff', 'status', 'log --oneline -10')."
+                        ),
+                    },
+                },
+                "required": ["args"],
             },
+            approval_policy=ApprovalPolicy(
+                mode="always",
+                reason=(
+                    "Git commands require approval (per-subcommand approval planned in Skills API)"
+                ),
+            ),
         )
     )
 
     registry.register(
         ToolDefinition(
-            name="git_log",
-            description="Show recent git commit history (last 10 commits).",
-            callable=_make_git_log(context_settings),
+            name="gh",
+            description=(
+                "Run a GitHub CLI (gh) subcommand and return its output. "
+                "The argument is passed directly to gh (e.g. 'pr create', 'issue list'). "
+                "Requires user approval before execution."
+            ),
+            callable=_make_scoped_cli("gh"),
             parameters_schema={
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "args": {
+                        "type": "string",
+                        "description": (
+                            "Arguments to pass to gh (e.g. 'pr create --title X', 'pr list')."
+                        ),
+                    },
+                },
+                "required": ["args"],
             },
+            approval_policy=ApprovalPolicy(
+                mode="always",
+                reason=(
+                    "GitHub CLI commands require approval "
+                    "(per-subcommand approval planned in Skills API)"
+                ),
+            ),
         )
     )
 
@@ -247,6 +292,50 @@ def create_default_registry(
     return registry
 
 
+def _make_scoped_cli(prefix: str, timeout: int = 30):
+    """Create an async callable that runs ``<prefix> {args}`` via subprocess.
+
+    The returned function enforces the prefix — the LLM only chooses the
+    subcommand and arguments.  This is the foundation for scoped CLI tools
+    (``git``, ``gh``) and the future Skills API.
+    """
+
+    async def _scoped_cli(args: str) -> str:
+        command = f"{prefix} {args}"
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except Exception as e:  # noqa: BLE001
+            return f"Error executing {prefix}: {e}"
+
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            await _terminate_and_wait(proc)
+            return f"Command timed out after {timeout} seconds: {command}"
+        except asyncio.CancelledError:
+            await _terminate_and_wait(proc)
+            raise
+        except Exception as e:  # noqa: BLE001
+            await _terminate_and_wait(proc)
+            return f"Error executing {prefix}: {e}"
+
+        stdout = stdout_bytes.decode(errors="replace")
+        stderr = stderr_bytes.decode(errors="replace")
+        output = stdout
+        if stderr:
+            output += f"\nSTDERR: {stderr}"
+        if proc.returncode != 0:
+            output += f"\nExit code: {proc.returncode}"
+        return output or "(no output)"
+
+    _scoped_cli.__name__ = f"_{prefix}"
+    return _scoped_cli
+
+
 def _make_read_file(settings: ContextSettings | None):
     async def _read_file(path: str) -> str:
         from fin_assist.context.files import FileFinder
@@ -258,32 +347,6 @@ def _make_read_file(settings: ContextSettings | None):
         return item.content
 
     return _read_file
-
-
-def _make_git_diff(settings: ContextSettings | None):
-    async def _git_diff() -> str:
-        from fin_assist.context.git import GitContext
-
-        ctx = GitContext(settings=settings)
-        item = await asyncio.to_thread(ctx.get_item, "git_diff:diff")
-        if item.status != "available":
-            return f"Error getting git diff: {item.error_reason}"
-        return item.content
-
-    return _git_diff
-
-
-def _make_git_log(settings: ContextSettings | None):
-    async def _git_log() -> str:
-        from fin_assist.context.git import GitContext
-
-        ctx = GitContext(settings=settings)
-        item = await asyncio.to_thread(ctx.get_item, "git_log:log")
-        if item.status != "available":
-            return f"Error getting git log: {item.error_reason}"
-        return item.content
-
-    return _git_log
 
 
 def _make_shell_history(settings: ContextSettings | None):

--- a/src/fin_assist/cli/interaction/chat.py
+++ b/src/fin_assist/cli/interaction/chat.py
@@ -148,11 +148,11 @@ async def run_chat_loop(
 
         from fin_assist.cli.interaction.approve import run_approval_widget
 
-        if deferred_calls:
+        while deferred_calls:
             decisions = await run_approval_widget(deferred_calls)
             if decisions is not None:
                 try:
-                    result, _ = await render_stream(
+                    result, deferred_calls = await render_stream(
                         stream_fn(
                             agent_name,
                             "",
@@ -164,8 +164,10 @@ async def run_chat_loop(
                     ctx_id = result.context_id or ctx_id
                 except Exception as e:
                     console.print(f"[red]Error resuming: {e}[/red]")
+                    break
             else:
                 console.print("[dim]Tool call cancelled[/dim]")
+                deferred_calls = []
                 console.print()
                 continue
 

--- a/src/fin_assist/cli/interaction/streaming.py
+++ b/src/fin_assist/cli/interaction/streaming.py
@@ -40,8 +40,8 @@ if TYPE_CHECKING:
 _TOOL_ICONS: dict[str, str] = {
     "run_shell": "⚡",
     "read_file": "📄",
-    "git_diff": "📋",
-    "git_log": "📋",
+    "git": "📋",
+    "gh": "🐙",
     "shell_history": "📜",
 }
 
@@ -79,6 +79,8 @@ def _key_arg_for_tool(tool_name: str, args: dict[str, Any]) -> str:
             return str(command)
         case "read_file", {"path": path}:
             return str(path)
+        case "git" | "gh", {"args": tool_args}:
+            return str(tool_args)
         case "shell_history", {"query": query} if query:
             return str(query)
         case _:

--- a/src/fin_assist/cli/main.py
+++ b/src/fin_assist/cli/main.py
@@ -290,12 +290,12 @@ async def _do_command(args: argparse.Namespace, config, config_path: Path | None
                 show_thinking=args.show_thinking,
             )
 
-            if deferred_calls:
+            while deferred_calls:
                 from fin_assist.cli.interaction.approve import run_approval_widget
 
                 decisions = await run_approval_widget(deferred_calls)
                 if decisions is not None:
-                    result, _ = await render_stream(
+                    result, deferred_calls = await render_stream(
                         client.stream_agent(
                             args.agent,
                             "",

--- a/src/fin_assist/cli/main.py
+++ b/src/fin_assist/cli/main.py
@@ -120,6 +120,39 @@ async def _get_agent_or_error(
     return None, agents
 
 
+def _resolve_workflow(
+    agent_name: str,
+    workflow_name: str | None,
+    prompt: str,
+    config,
+) -> tuple[str, str | None]:
+    """Resolve a workflow for an agent and return (effective_prompt, system_prompt_override).
+
+    If ``workflow_name`` is given explicitly, look it up in the agent's config.
+    If no workflow is given but ``prompt`` matches a workflow name, use that
+    workflow's ``entry_prompt`` as the effective prompt.
+
+    Returns (effective_prompt, system_prompt_override).  If no workflow matches,
+    returns (prompt, None) — i.e. the prompt is used as-is with the default
+    system prompt.
+    """
+    agent_cfg = config.agents.get(agent_name)
+    if agent_cfg is None or not agent_cfg.workflows:
+        return prompt, None
+
+    target = workflow_name
+    if target is None and prompt in agent_cfg.workflows:
+        target = prompt
+
+    if target is None or target not in agent_cfg.workflows:
+        return prompt, None
+
+    wf = agent_cfg.workflows[target]
+    effective_prompt = wf.entry_prompt or prompt
+    system_prompt_override = wf.prompt_template or None
+    return effective_prompt, system_prompt_override
+
+
 # ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
@@ -235,6 +268,22 @@ async def _do_command(args: argparse.Namespace, config, config_path: Path | None
                 if not prompt:
                     return 0
 
+            if not prompt:
+                return 0
+
+            prompt, system_prompt_override = _resolve_workflow(
+                args.agent,
+                args.workflow,
+                prompt,
+                config,
+            )
+
+            if system_prompt_override:
+                from fin_assist.agents.registry import SYSTEM_PROMPTS
+
+                override_text = SYSTEM_PROMPTS.get(system_prompt_override, system_prompt_override)
+                prompt = f"[Workflow context]\n{override_text}\n\n[Request]\n{prompt}"
+
             prompt = resolve_at_references(prompt, context_settings=config.context)
             result, deferred_calls = await render_stream(
                 client.stream_agent(args.agent, prompt),
@@ -303,6 +352,22 @@ async def _talk_command(args: argparse.Namespace, config, config_path: Path | No
                 context_settings=config.context,
             )
             message = args.message
+
+            if message:
+                message, system_prompt_override = _resolve_workflow(
+                    args.agent,
+                    args.workflow,
+                    message,
+                    config,
+                )
+                if system_prompt_override:
+                    from fin_assist.agents.registry import SYSTEM_PROMPTS
+
+                    override_text = SYSTEM_PROMPTS.get(
+                        system_prompt_override, system_prompt_override
+                    )
+                    message = f"[Workflow context]\n{override_text}\n\n[Request]\n{message}"
+
             final_context_id = await run_chat_loop(
                 client.stream_agent,
                 args.agent,
@@ -416,6 +481,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Show agent thinking/reasoning in the output.",
     )
+    do_parser.add_argument(
+        "--workflow",
+        default=None,
+        help="Name of a workflow defined in the agent's config (e.g. commit, pr, summarize).",
+    )
 
     talk_parser = subparsers.add_parser(
         "talk",
@@ -452,6 +522,11 @@ def main(argv: list[str] | None = None) -> int:
         "--show-thinking",
         action="store_true",
         help="Show agent thinking/reasoning in the chat output.",
+    )
+    talk_parser.add_argument(
+        "--workflow",
+        default=None,
+        help="Name of a workflow defined in the agent's config.",
     )
 
     list_parser = subparsers.add_parser(
@@ -503,7 +578,7 @@ def main(argv: list[str] | None = None) -> int:
                     "Example:\n\n"
                     "  [agents.default]\n"
                     '  system_prompt = "chain-of-thought"\n'
-                    '  tools = ["read_file", "git_diff", "run_shell"]'
+                    '  tools = ["read_file", "git", "run_shell"]'
                 )
             else:
                 names = ", ".join(config.agents)

--- a/src/fin_assist/config/schema.py
+++ b/src/fin_assist/config/schema.py
@@ -63,6 +63,25 @@ class ServerSettings(BaseModel):
     log_path: str = str(DATA_DIR / "hub.log")
 
 
+class WorkflowConfig(BaseModel):
+    """Per-workflow configuration within an agent.
+
+    Workflows are prompt-steered sub-tasks an agent can perform.  They define
+    a description (for discovery), a prompt template name or inline text, an
+    entry prompt sent as the initial user message, and optional serving-mode
+    overrides.
+
+    This is level 2 of the workflow spectrum (prompt steering).  Future
+    extensions (level 3) may add ``tool_scope`` and ``approval_override``
+    fields — see the Skills API vision in architecture.md.
+    """
+
+    description: str = ""
+    prompt_template: str = ""
+    entry_prompt: str = ""
+    serving_modes: list[ServingMode] | None = None
+
+
 class AgentConfig(BaseModel):
     """Per-agent configuration.
 
@@ -78,6 +97,7 @@ class AgentConfig(BaseModel):
     serving_modes: list[ServingMode] = Field(default_factory=lambda: ["do", "talk"])
     tags: list[str] = Field(default_factory=list)
     tools: list[str] = Field(default_factory=list)
+    workflows: dict[str, WorkflowConfig] = Field(default_factory=dict)
 
 
 _DEFAULT_AGENTS: dict[str, AgentConfig] = {}

--- a/src/fin_assist/llm/prompts.py
+++ b/src/fin_assist/llm/prompts.py
@@ -60,8 +60,9 @@ message, and commit. Steps:
 1. Run `git status --porcelain` to see changed files.
 2. Run `git diff` and `git diff --cached` to see unstaged and staged changes.
 3. Run `git log --oneline -10` to understand recent commit style.
-4. Stage appropriate files with `git add` (prefer `git add -A` unless the \
-user specified particular files).
+4. Stage ONLY the files relevant to this commit. Use `git add <files>` for \
+specific files. Only use `git add -A` if the user explicitly asks to stage \
+everything.
 5. Compose a conventional commit message (type(scope): description). Use the \
 diff content to determine type (feat, fix, refactor, docs, chore, etc.) and \
 write a concise imperative description.
@@ -74,7 +75,8 @@ Create a pull request from the current branch. Steps:
 3. Run `git diff main...HEAD` (or the appropriate base branch) to see the \
 full diff for the PR.
 4. Compose a PR title and body based on the changes.
-5. Run `gh pr create --title "title" --body "body"`.
+5. Create the PR using a heredoc for the body to preserve formatting:
+   `gh pr create --title "title" --body-file - <<'EOF'\nbody text\nEOF`
 
 ### summarize
 Summarize the current state of the repository without executing any mutating \
@@ -89,7 +91,9 @@ commands. Steps:
 and adapt the closest workflow.
 - Always inspect the repository state before making changes.
 - For commit messages, follow conventional commits format.
-- For PRs, include a clear description of what changed and why.
+- For PRs, use `--body-file -` with a heredoc instead of `--body "..."` to \
+avoid shell escaping issues with multiline content, backticks, and quotes.
+- Stage files selectively — never `git add -A` unless the user asks.
 - Never force push or run destructive commands unless explicitly asked.
 - Keep responses concise — show the action, not the reasoning.\
 """
@@ -117,10 +121,12 @@ Steps:
 1. Inspect the current branch changes using git tools.
 2. Determine the base branch (default: main).
 3. Compose a PR title and body.
-4. Create the PR using gh.
+4. Create the PR using a heredoc for the body: \
+`gh pr create --title "title" --body-file - <<'EOF'\nbody\nEOF`
 
 The PR title should follow conventional commit style. The body should explain \
-what changed and why, in clear prose.\
+what changed and why, in clear prose. Always use `--body-file -` with a \
+heredoc instead of `--body "..."` to avoid shell escaping issues.\
 """
 
 GIT_SUMMARIZE_INSTRUCTIONS = """\

--- a/src/fin_assist/llm/prompts.py
+++ b/src/fin_assist/llm/prompts.py
@@ -48,6 +48,93 @@ developers inspect and understand their codebase.
 Keep responses concise. When running shell commands, use fish shell syntax.\
 """
 
+GIT_INSTRUCTIONS = """\
+You are a git workflow assistant. You help developers with common git \
+operations: committing changes, creating pull requests, and summarizing diffs.
+
+## Available workflows
+
+### commit
+Analyze the current staged and unstaged changes, compose a conventional commit \
+message, and commit. Steps:
+1. Run `git status --porcelain` to see changed files.
+2. Run `git diff` and `git diff --cached` to see unstaged and staged changes.
+3. Run `git log --oneline -10` to understand recent commit style.
+4. Stage appropriate files with `git add` (prefer `git add -A` unless the \
+user specified particular files).
+5. Compose a conventional commit message (type(scope): description). Use the \
+diff content to determine type (feat, fix, refactor, docs, chore, etc.) and \
+write a concise imperative description.
+6. Run `git commit -m "message"`.
+
+### pr
+Create a pull request from the current branch. Steps:
+1. Run `git status --porcelain` and `git diff` to understand current changes.
+2. Run `git log --oneline -10` to understand recent commits.
+3. Run `git diff main...HEAD` (or the appropriate base branch) to see the \
+full diff for the PR.
+4. Compose a PR title and body based on the changes.
+5. Run `gh pr create --title "title" --body "body"`.
+
+### summarize
+Summarize the current state of the repository without executing any mutating \
+commands. Steps:
+1. Run `git status --porcelain` to see changed files.
+2. Run `git diff` and `git diff --cached` to see all changes.
+3. Run `git log --oneline -10` to see recent history.
+4. Write a clear summary of what changed, why, and any observations.
+
+## General rules
+- When the user's request doesn't match a specific workflow, infer the intent \
+and adapt the closest workflow.
+- Always inspect the repository state before making changes.
+- For commit messages, follow conventional commits format.
+- For PRs, include a clear description of what changed and why.
+- Never force push or run destructive commands unless explicitly asked.
+- Keep responses concise — show the action, not the reasoning.\
+"""
+
+GIT_COMMIT_INSTRUCTIONS = """\
+You are generating a git commit message. Analyze the staged and unstaged \
+changes and compose a conventional commit message.
+
+Steps:
+1. Inspect the current changes using git tools.
+2. Compose a conventional commit message (type(scope): description).
+3. Stage changes and commit.
+
+Follow conventional commits: type(scope)!: description where type is one of \
+feat, fix, refactor, docs, test, chore, perf, ci, build, revert. Include \
+! after scope for breaking changes. Add a blank line and body paragraph if \
+the change needs explanation beyond the title.\
+"""
+
+GIT_PR_INSTRUCTIONS = """\
+You are creating a pull request. Analyze the branch changes and compose a PR \
+title and body.
+
+Steps:
+1. Inspect the current branch changes using git tools.
+2. Determine the base branch (default: main).
+3. Compose a PR title and body.
+4. Create the PR using gh.
+
+The PR title should follow conventional commit style. The body should explain \
+what changed and why, in clear prose.\
+"""
+
+GIT_SUMMARIZE_INSTRUCTIONS = """\
+You are summarizing repository changes. Analyze the current state and write a \
+clear, concise summary.
+
+Steps:
+1. Inspect the current changes using git tools.
+2. Write a summary covering: what files changed, the nature of the changes, \
+and any observations about the current state.
+
+Do NOT execute any mutating commands. This workflow is read-only.\
+"""
+
 
 def format_context(context: Sequence[ContextItem] | None) -> str:
     if not context:

--- a/tests/test_agents/test_spec.py
+++ b/tests/test_agents/test_spec.py
@@ -192,14 +192,14 @@ class TestAgentSpecCardMetadata:
     def test_supported_context_types_from_tools(self, mock_config, mock_credentials) -> None:
         agent = AgentSpec(
             name="test",
-            agent_config=AgentConfig(tools=["read_file", "git_diff", "git_log"]),
+            agent_config=AgentConfig(tools=["read_file", "git", "gh"]),
             config=mock_config,
             credentials=mock_credentials,
         )
         meta = agent.agent_card_metadata
         assert _MAP["read_file"] in meta.supported_context_types
-        assert _MAP["git_diff"] in meta.supported_context_types
-        assert _MAP["git_log"] in meta.supported_context_types
+        assert _MAP["git"] in meta.supported_context_types
+        assert _MAP["gh"] in meta.supported_context_types
         assert "env" not in meta.supported_context_types
 
     def test_no_context_types_when_no_tools(self, mock_config, mock_credentials) -> None:
@@ -231,13 +231,13 @@ class TestAgentSpecSupportsContext:
     def test_supports_context_types_from_tools(self, mock_config, mock_credentials) -> None:
         agent = AgentSpec(
             name="test",
-            agent_config=AgentConfig(tools=["read_file", "git_diff"]),
+            agent_config=AgentConfig(tools=["read_file", "git"]),
             config=mock_config,
             credentials=mock_credentials,
         )
         assert agent.supports_context(_MAP["read_file"]) is True
-        assert agent.supports_context(_MAP["git_diff"]) is True
-        assert agent.supports_context(_MAP["git_log"]) is False
+        assert agent.supports_context(_MAP["git"]) is True
+        assert agent.supports_context(_MAP["gh"]) is False
         assert agent.supports_context("env") is False
 
     def test_supports_no_context_when_no_tools(self, mock_config, mock_credentials) -> None:
@@ -248,7 +248,7 @@ class TestAgentSpecSupportsContext:
             credentials=mock_credentials,
         )
         assert agent.supports_context("file") is False
-        assert agent.supports_context("git_diff") is False
+        assert agent.supports_context("git") is False
 
     def test_rejects_unknown_context_type(self, mock_config, mock_credentials) -> None:
         agent = _make_default_agent(mock_config, mock_credentials)
@@ -405,11 +405,11 @@ class TestAgentSpecConfigProperties:
     def test_tools_from_config(self, mock_config, mock_credentials) -> None:
         agent = AgentSpec(
             name="test",
-            agent_config=AgentConfig(tools=["read_file", "git_diff"]),
+            agent_config=AgentConfig(tools=["read_file", "git"]),
             config=mock_config,
             credentials=mock_credentials,
         )
-        assert agent.tools == ["read_file", "git_diff"]
+        assert agent.tools == ["read_file", "git"]
 
     def test_tools_default_empty(self, mock_config, mock_credentials) -> None:
         agent = AgentSpec(

--- a/tests/test_agents/test_tools.py
+++ b/tests/test_agents/test_tools.py
@@ -129,9 +129,14 @@ class TestCreateDefaultRegistry:
         tools = registry.list_tools()
         names = {t.name for t in tools}
         assert "read_file" in names
-        assert "git_diff" in names
-        assert "git_log" in names
+        assert "git" in names
+        assert "gh" in names
         assert "shell_history" in names
+
+    def test_git_diff_and_git_log_removed(self) -> None:
+        registry = create_default_registry()
+        assert registry.get("git_diff") is None
+        assert registry.get("git_log") is None
 
     def test_builtin_tools_have_descriptions(self) -> None:
         registry = create_default_registry()
@@ -144,23 +149,24 @@ class TestCreateDefaultRegistry:
             assert tool.parameters_schema, f"Tool {tool.name} has no parameters_schema"
             assert tool.parameters_schema.get("type") == "object"
 
-    def test_context_tools_have_no_approval_policy(self) -> None:
+    def test_read_only_tools_have_no_approval_policy(self) -> None:
         registry = create_default_registry()
-        context_tools = ["read_file", "git_diff", "git_log", "shell_history"]
-        for name in context_tools:
+        read_only_tools = ["read_file", "shell_history"]
+        for name in read_only_tools:
             tool = registry.get(name)
             assert tool is not None
             assert tool.approval_policy is None, (
                 f"Tool {tool.name} unexpectedly has approval_policy"
             )
 
-    def test_run_shell_has_always_approval_policy(self) -> None:
+    def test_scoped_cli_tools_have_always_approval_policy(self) -> None:
         registry = create_default_registry()
-        tool = registry.get("run_shell")
-        assert tool is not None
-        assert tool.approval_policy is not None
-        assert tool.approval_policy.mode == "always"
-        assert tool.approval_policy.reason is not None
+        for name in ("git", "gh", "run_shell"):
+            tool = registry.get(name)
+            assert tool is not None
+            assert tool.approval_policy is not None
+            assert tool.approval_policy.mode == "always"
+            assert tool.approval_policy.reason is not None
 
     def test_read_file_has_path_parameter(self) -> None:
         registry = create_default_registry()
@@ -170,11 +176,23 @@ class TestCreateDefaultRegistry:
         assert "path" in props
         assert props["path"]["type"] == "string"
 
-    def test_git_diff_has_no_required_parameters(self) -> None:
+    def test_git_has_args_parameter(self) -> None:
         registry = create_default_registry()
-        tool = registry.get("git_diff")
+        tool = registry.get("git")
         assert tool is not None
-        assert tool.parameters_schema.get("required", []) == []
+        props = tool.parameters_schema["properties"]
+        assert "args" in props
+        assert "required" in tool.parameters_schema
+        assert "args" in tool.parameters_schema["required"]
+
+    def test_gh_has_args_parameter(self) -> None:
+        registry = create_default_registry()
+        tool = registry.get("gh")
+        assert tool is not None
+        props = tool.parameters_schema["properties"]
+        assert "args" in props
+        assert "required" in tool.parameters_schema
+        assert "args" in tool.parameters_schema["required"]
 
     def test_shell_history_has_optional_query(self) -> None:
         registry = create_default_registry()
@@ -292,74 +310,54 @@ class TestReadFileCallable:
         assert "File not found" in result
 
 
-class TestGitDiffCallable:
+class TestGitCallable:
     @pytest.mark.asyncio
-    async def test_returns_diff_when_available(self) -> None:
-        from fin_assist.context.base import ContextItem
-
-        mock_item = ContextItem(
-            id="git_diff:diff", type="git_diff", content="diff content", status="available"
-        )
-        with patch("fin_assist.context.git.GitContext") as MockCtx:
-            MockCtx.return_value.get_item.return_value = mock_item
+    async def test_runs_git_with_args(self) -> None:
+        proc = _FakeProc(stdout=b"M file.py\n")
+        with patch("asyncio.create_subprocess_shell", return_value=proc) as mock_spawn:
             registry = create_default_registry()
-            tool = registry.get("git_diff")
+            tool = registry.get("git")
             assert tool is not None
-            result = await _invoke(tool)
-        assert result == "diff content"
-
-    @pytest.mark.asyncio
-    async def test_returns_error_when_not_available(self) -> None:
-        from fin_assist.context.base import ContextItem
-
-        mock_item = ContextItem(
-            id="git_diff:diff",
-            type="git_diff",
-            status="error",
-            error_reason="Not a git repo",
-        )
-        with patch("fin_assist.context.git.GitContext") as MockCtx:
-            MockCtx.return_value.get_item.return_value = mock_item
-            registry = create_default_registry()
-            tool = registry.get("git_diff")
-            assert tool is not None
-            result = await _invoke(tool)
-        assert "Error getting git diff" in result
-
-
-class TestGitLogCallable:
-    @pytest.mark.asyncio
-    async def test_returns_log_when_available(self) -> None:
-        from fin_assist.context.base import ContextItem
-
-        mock_item = ContextItem(
-            id="git_log:log", type="git_log", content="abc123 commit", status="available"
-        )
-        with patch("fin_assist.context.git.GitContext") as MockCtx:
-            MockCtx.return_value.get_item.return_value = mock_item
-            registry = create_default_registry()
-            tool = registry.get("git_log")
-            assert tool is not None
-            result = await _invoke(tool)
-        assert result == "abc123 commit"
+            result = await _invoke(tool, args="status --porcelain")
+        assert "M file.py" in result
+        mock_spawn.assert_called_once()
+        called_cmd = mock_spawn.call_args[0][0]
+        assert called_cmd.startswith("git ")
+        assert "status --porcelain" in called_cmd
 
     @pytest.mark.asyncio
-    async def test_returns_error_when_not_available(self) -> None:
-        from fin_assist.context.base import ContextItem
-
-        mock_item = ContextItem(
-            id="git_log:log",
-            type="git_log",
-            status="error",
-            error_reason="git not available",
-        )
-        with patch("fin_assist.context.git.GitContext") as MockCtx:
-            MockCtx.return_value.get_item.return_value = mock_item
+    async def test_spawn_failure_returns_error(self) -> None:
+        with patch("asyncio.create_subprocess_shell", side_effect=OSError("no git")):
             registry = create_default_registry()
-            tool = registry.get("git_log")
+            tool = registry.get("git")
             assert tool is not None
-            result = await _invoke(tool)
-        assert "Error getting git log" in result
+            result = await _invoke(tool, args="log")
+        assert "Error executing git" in result
+
+
+class TestGhCallable:
+    @pytest.mark.asyncio
+    async def test_runs_gh_with_args(self) -> None:
+        proc = _FakeProc(stdout=b"42\tOpen\tFix bug\tmain")
+        with patch("asyncio.create_subprocess_shell", return_value=proc) as mock_spawn:
+            registry = create_default_registry()
+            tool = registry.get("gh")
+            assert tool is not None
+            result = await _invoke(tool, args="pr list")
+        assert "Fix bug" in result
+        mock_spawn.assert_called_once()
+        called_cmd = mock_spawn.call_args[0][0]
+        assert called_cmd.startswith("gh ")
+        assert "pr list" in called_cmd
+
+    @pytest.mark.asyncio
+    async def test_spawn_failure_returns_error(self) -> None:
+        with patch("asyncio.create_subprocess_shell", side_effect=OSError("no gh")):
+            registry = create_default_registry()
+            tool = registry.get("gh")
+            assert tool is not None
+            result = await _invoke(tool, args="pr list")
+        assert "Error executing gh" in result
 
 
 class TestShellHistoryCallable:

--- a/tests/test_cli/interaction/test_streaming.py
+++ b/tests/test_cli/interaction/test_streaming.py
@@ -207,16 +207,16 @@ class TestFormatToolCall:
         assert "custom_tool" in plain
         assert "🔧" in plain
 
-    def test_git_diff_no_key_arg(self):
+    def test_git_tool_shows_args(self):
         event = StreamEvent(
             kind="tool_call",
-            tool_name="git_diff",
-            tool_args={},
+            tool_name="git",
+            tool_args={"args": "diff"},
         )
         rendered = _format_tool_call(event)
         plain = rendered.plain
-        assert "git_diff" in plain
-        assert ":" not in plain.split("git_diff", 1)[1]
+        assert "git" in plain
+        assert "diff" in plain
 
 
 class TestFormatToolResult:
@@ -224,7 +224,7 @@ class TestFormatToolResult:
         event = StreamEvent(
             kind="tool_result",
             text="No uncommitted changes",
-            tool_name="git_diff",
+            tool_name="git",
         )
         rendered = _format_tool_result(event)
         plain = rendered.plain

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -1022,3 +1022,104 @@ class TestListCommand:
             result = _run_main("list", "tools")
         mock_ensure.assert_not_called()
         assert result == 0
+
+
+class TestResolveWorkflow:
+    def test_no_workflows_returns_prompt_unchanged(self):
+        from fin_assist.cli.main import _resolve_workflow
+        from fin_assist.config.schema import AgentConfig, Config
+
+        config = Config()
+        prompt, override = _resolve_workflow("test", None, "hello", config)
+        assert prompt == "hello"
+        assert override is None
+
+    def test_explicit_workflow_name_resolves(self):
+        from fin_assist.cli.main import _resolve_workflow
+        from fin_assist.config.schema import AgentConfig, Config, WorkflowConfig
+
+        config = Config(
+            agents={
+                "git": AgentConfig(
+                    system_prompt="git",
+                    workflows={
+                        "commit": WorkflowConfig(
+                            description="Commit workflow",
+                            prompt_template="git-commit",
+                            entry_prompt="Analyze current changes and commit.",
+                        ),
+                    },
+                ),
+            }
+        )
+        prompt, override = _resolve_workflow("git", "commit", "commit", config)
+        assert prompt == "Analyze current changes and commit."
+        assert override == "git-commit"
+
+    def test_prompt_matches_workflow_name(self):
+        from fin_assist.cli.main import _resolve_workflow
+        from fin_assist.config.schema import AgentConfig, Config, WorkflowConfig
+
+        config = Config(
+            agents={
+                "git": AgentConfig(
+                    system_prompt="git",
+                    workflows={
+                        "commit": WorkflowConfig(
+                            entry_prompt="Analyze current changes and commit.",
+                        ),
+                    },
+                ),
+            }
+        )
+        prompt, override = _resolve_workflow("git", None, "commit", config)
+        assert prompt == "Analyze current changes and commit."
+
+    def test_prompt_does_not_match_workflow(self):
+        from fin_assist.cli.main import _resolve_workflow
+        from fin_assist.config.schema import AgentConfig, Config, WorkflowConfig
+
+        config = Config(
+            agents={
+                "git": AgentConfig(
+                    system_prompt="git",
+                    workflows={
+                        "commit": WorkflowConfig(
+                            entry_prompt="Analyze current changes.",
+                        ),
+                    },
+                ),
+            }
+        )
+        prompt, override = _resolve_workflow("git", None, "status check", config)
+        assert prompt == "status check"
+        assert override is None
+
+    def test_workflow_without_entry_prompt_uses_original(self):
+        from fin_assist.cli.main import _resolve_workflow
+        from fin_assist.config.schema import AgentConfig, Config, WorkflowConfig
+
+        config = Config(
+            agents={
+                "git": AgentConfig(
+                    system_prompt="git",
+                    workflows={
+                        "commit": WorkflowConfig(
+                            prompt_template="git-commit",
+                        ),
+                    },
+                ),
+            }
+        )
+        prompt, override = _resolve_workflow("git", "commit", "commit", config)
+        assert prompt == "commit"
+        assert override == "git-commit"
+
+    def test_unknown_agent_returns_prompt_unchanged(self):
+        from fin_assist.cli.main import _resolve_workflow
+        from fin_assist.config.schema import Config
+
+        config = Config()
+        prompt, override = _resolve_workflow("nonexistent", None, "hello", config)
+        assert prompt == "hello"
+        assert override is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ from fin_assist.config.schema import (
     GeneralSettings,
     ProviderConfig,
     ServerSettings,
+    WorkflowConfig,
 )
 from fin_assist.paths import DATA_DIR
 
@@ -438,6 +439,7 @@ class TestAgentConfig:
         assert ac.thinking == "medium"
         assert ac.serving_modes == ["do", "talk"]
         assert ac.tags == []
+        assert ac.workflows == {}
 
     def test_shell_config(self) -> None:
         ac = AgentConfig(
@@ -473,6 +475,50 @@ class TestAgentConfig:
         )
         config, _ = load_config(config_file)
         assert config.agents["shell"].serving_modes == ["do"]
+
+    def test_config_workflows_from_toml(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[agents.git]\n"
+            'system_prompt = "git"\n'
+            'serving_modes = ["do"]\n'
+            "\n"
+            "[agents.git.workflows.commit]\n"
+            'description = "Generate a commit message."\n'
+            'prompt_template = "git-commit"\n'
+            'entry_prompt = "Analyze the current changes."\n'
+            "\n"
+            "[agents.git.workflows.summarize]\n"
+            'description = "Summarize changes."\n'
+            'entry_prompt = "Summarize current diffs."\n'
+            'serving_modes = ["do", "talk"]\n'
+        )
+        config, _ = load_config(config_file)
+        git = config.agents["git"]
+        assert "commit" in git.workflows
+        assert git.workflows["commit"].prompt_template == "git-commit"
+        assert git.workflows["commit"].entry_prompt == "Analyze the current changes."
+        assert git.workflows["commit"].serving_modes is None
+        assert git.workflows["summarize"].serving_modes == ["do", "talk"]
+
+
+class TestWorkflowConfig:
+    def test_defaults(self) -> None:
+        wf = WorkflowConfig()
+        assert wf.description == ""
+        assert wf.prompt_template == ""
+        assert wf.entry_prompt == ""
+        assert wf.serving_modes is None
+
+    def test_custom_values(self) -> None:
+        wf = WorkflowConfig(
+            description="Commit workflow",
+            prompt_template="git-commit",
+            entry_prompt="Generate a commit message.",
+            serving_modes=["do"],
+        )
+        assert wf.description == "Commit workflow"
+        assert wf.serving_modes == ["do"]
 
 
 class TestServerSettingsDataDir:


### PR DESCRIPTION
## Summary

- **Git agent** (`fin do --agent git commit|pr|summarize`) — first real end-user agent with three workflows
- **Scoped CLI tools** (`git`, `gh`) — replace per-subcommand wrappers (`git_diff`, `git_log`) with one tool per CLI prefix; LLM picks subcommand/args, saving prompt tokens
- **WorkflowConfig** — agent-scoped config primitive for prompt-steered sub-tasks with entry prompts, system prompt overrides, and serving mode overrides
- **Approval loop fix** — `if deferred_calls` → `while deferred_calls` so sequential tool calls requiring approval are handled correctly in both `do` and `talk` modes
- **Skills API foundation** — scoped CLI tools + WorkflowConfig are the proto-skill pattern documented in #98

Closes #79

## Changes

| Area | Change |
|------|--------|
| `config/schema.py` | `WorkflowConfig` model + `workflows` field on `AgentConfig` |
| `agents/tools.py` | `_make_scoped_cli()` factory, `git`/`gh` tools, remove `git_diff`/`git_log` wrappers |
| `agents/spec.py` | `_CONTEXT_TYPE_MAP` updated for `git`/`gh` |
| `llm/prompts.py` | `GIT_INSTRUCTIONS`, `GIT_COMMIT_INSTRUCTIONS`, `GIT_PR_INSTRUCTIONS`, `GIT_SUMMARIZE_INSTRUCTIONS` |
| `agents/registry.py` | Register `git`, `git-commit`, `git-pr`, `git-summarize` prompts |
| `cli/main.py` | `_resolve_workflow()` helper, `--workflow` flag for do/talk, approval loop fix |
| `cli/interaction/chat.py` | Approval loop fix |
| `cli/interaction/streaming.py` | Emoji map + key arg for `git`/`gh` tools |
| `config.toml` | Git agent config with commit/pr/summarize workflows |
| `docs/architecture.md` | Scoped CLI tools section, workflow docs, Phase 15/16 updates |
| `handoff.md` | Status update, git agent history, next session = tracing |

## Test plan

- [x] 729 tests passing, `just ci` green
- [x] `fin list tools` — shows `git`/`gh` with approval required, no `git_diff`/`git_log`
- [x] `fin list prompts` — shows `git`, `git-commit`, `git-pr`, `git-summarize`
- [x] `fin agents` — shows git agent with `do` mode
- [x] `fin do --agent git pr` — live tested: agent analyzes diff, composes PR, approval loop handles sequential deferred calls
- [x] `fin do --agent git summarize` — read-only workflow tested