### PR TITLE
docs: restructure documentation around context strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,36 +11,60 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Each job invokes a `just` recipe so the justfile remains the single source of
+# truth for what runs in CI. Adding a step to `just ci` automatically extends
+# CI — no YAML changes required. See AGENTS.md § Commands.
+
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
       - uses: DeterminateSystems/magic-nix-cache-action@v13
-      - run: nix shell nixpkgs#treefmt nixpkgs#nixfmt-rfc-style nixpkgs#ruff --command treefmt --ci
+        with:
+          use-flakehub: false
+      - run: nix shell nixpkgs#just nixpkgs#treefmt nixpkgs#nixfmt-rfc-style nixpkgs#ruff --command just check
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
       - uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
       - run: |
-          nix shell nixpkgs#uv nixpkgs#ruff --command bash -c "
+          nix shell nixpkgs#just nixpkgs#uv nixpkgs#ruff --command bash -c "
             uv sync --all-extras
-            ruff check src/
-            uv run ty check src/
+            just lint
+            just lint-imports
+          "
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
+      - run: |
+          nix shell nixpkgs#just nixpkgs#uv --command bash -c "
+            uv sync --all-extras
+            just typecheck
           "
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
       - uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
       - run: |
-          nix shell nixpkgs#uv --command bash -c "
+          nix shell nixpkgs#just nixpkgs#uv --command bash -c "
             uv sync --all-extras
-            uv run pytest tests/ -x --tb=short
+            just test -x --tb=short
           "

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,35 @@
 
 Expandable personal AI agent platform for terminal workflows. See `docs/architecture.md` for full architecture.
 
+## Context Strategy
+
+Each context surface has **one job** and **one update cadence**. If you find yourself updating two surfaces with the same information, one of them is wrong.
+
+| Surface | Job | Cadence | Lifetime |
+|---------|-----|---------|----------|
+| `README.md` | Project soul — vision, getting started, architecture overview | Major shifts only | Forever |
+| `docs/*.md` | Architecture deep dives, design decision rationale | Per architectural change | Forever |
+| `AGENTS.md` (this file) | Development workflow, conventions, skill authoring | Per workflow change | Forever |
+| `handoff.md` | In-flight design sketches + last 1–2 sessions of rolling context | Per session | Rolling — old content prunes |
+| GitHub **milestones** | Committed work that we know we want to ship | Per planning cycle | Until shipped |
+| GitHub **issues** | Ideas, bugs, refactor discussions, things-to-discuss | Per discussion | Until closed/promoted to milestone |
+
+### Issues vs milestones
+
+- **Issues** are for things that need conversation: enhancement ideas, out-of-scope bugs found while working on a feature, refactor discussions, "we should consider X" thoughts. State is fluid; they may resolve to "won't do," may merge with other issues, may eventually graduate to a milestone.
+- **Milestones** are for committed work — things we've decided to ship under a specific tag. The "story" for a release.
+
+**The single-source-of-truth rule:** when an issue graduates to committed work, add it to a milestone. When work is committed from the start (e.g., the natural next phase), go straight to a milestone — do not file an issue first.
+
+**Before filing a new GitHub issue, check the active milestones.** If the work belongs to a known milestone, add it there directly. Issues are for things that genuinely need discussion before commitment.
+
+### Doc surfaces — what NOT to do
+
+- Do not maintain a "phases" or "implementation progress" table in `handoff.md` — that's what milestones are for.
+- Do not duplicate milestone descriptions in `handoff.md`. Link to the milestone instead.
+- Do not put architecture decisions in `handoff.md`. Sketch there during design; once shipped, the decision lives in `docs/`.
+- Do not put session-specific context in `docs/` or `README.md`. Those are forever-docs.
+
 ## Development Workflow
 
 This project follows an **SDD → TDD** implementation pattern:
@@ -132,30 +161,25 @@ This split is **project-specific**, not an industry standard — but we apply it
 
 ## Session Handoffs (handoff.md)
 
-`handoff.md` is the rolling context document for multi-session development. It enables seamless handoffs between coding sessions (including AI agent sessions).
+`handoff.md` holds two things and two things only:
 
-### Purpose
+1. **In-flight Design Sketches** — SDD work for features not yet shipped. Once a sketch ships, the durable parts move to `docs/` and the sketch is deleted.
+2. **Rolling session log** — last 1–2 sessions of context for the next session pickup. Older content prunes; git log is the long-term record.
 
-- Capture what was accomplished in each session
-- Document design sketches before implementation
-- Track implementation progress across phases
-- Provide quick-start context for fresh sessions
+It is **not** for: phase tables, implementation progress, milestone descriptions, historical reference, or "what we shipped in v0.x." Those live in milestones, git log, or `docs/` respectively.
 
-### When to Update
+### When to update
 
-- **Start of session**: Read handoff.md first for context
-- **After design work**: Add sketches to "Design Sketches" section
-- **At checkpoints**: Update "What Was Accomplished"
-- **End of session**: Update "Next Session" with next steps
-- **Phase completion**: Update "Implementation Progress" table
+- **Start of session**: read for context (current state header + next session pointer)
+- **During design**: add/update sketches under "Design Sketches"
+- **End of session**: update "Recent work" and "Next Session"; prune anything older than ~2 sessions back
 
-### Fresh Session Quick-Start
+### Fresh session quick-start
 
-1. Read `handoff.md` - current state and next steps
-2. Read `docs/architecture.md` - full architecture
-3. Read `AGENTS.md` - dev patterns (this file)
-4. Check "Implementation Progress" table
-5. Continue from "Next Session" section
+1. Read `handoff.md` — current state and next steps
+2. Skim active milestones at https://github.com/ColeB1722/fin-assist/milestones for the "story" of in-flight work
+3. Read `docs/architecture.md` for architectural context (or specific deep-dive docs)
+4. Read this file (`AGENTS.md`) for workflow and conventions
 
 ## Skill Authoring
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ After design is sketched, write tests BEFORE writing implementation code:
 | `just fmt` | Format all code |
 | `just lint` | Run linter |
 | `just lint-fix` | Auto-fix lint issues |
+| `just lint-imports` | Enforce hub/cli architecture firewall (import-linter) |
 | `just typecheck` | Run type checker |
 | `just test` | Run tests |
 | `just test-cov` | Run tests with coverage |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,7 @@ Use conventional commits format...
 - Tools are **gated** — only `base_tools` + loaded skills' tools are registered; unloaded skills' tools are not available
 - Tools are **shared** across skills — name collisions are a config validation error
 - **Agent-level** `tool_policies` define approval per tool, not per skill (eliminates merge conflicts)
-- `AgentSpec.base_tools` lists always-available safe/read-only tools (default: `["read_file"]`)
+- `AgentSpec.base_tools` lists always-available tools (default: `[]`; opt in via config or skills)
 - `--skill` CLI flag pre-loads a skill: `fin do git --skill commit`
 - Positional skill matching: `fin do git commit` → agent=git, skill=commit
 - `/skill:<name>` REPL command loads a skill mid-session

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # fin-assist
 
-Expandable personal AI agent platform for terminal workflows. See `docs/architecture.md` for full architecture.
+Expandable personal AI agent platform for terminal workflows. See [`README.md`](README.md) for the user-facing pitch and [`docs/architecture.md`](docs/architecture.md) for internals.
 
 ## Context Strategy
 
@@ -38,7 +38,7 @@ This project follows an **SDD → TDD** implementation pattern:
 ### 1. Sketch-Driven Design (SDD)
 
 Before implementing any feature:
-1. Review `docs/architecture.md` for alignment
+1. Review [`docs/architecture.md`](docs/architecture.md) for alignment (and the relevant deep-dive doc if applicable: [`skills.md`](docs/skills.md), [`tracing.md`](docs/tracing.md), [`configuration.md`](docs/configuration.md))
 2. Sketch the design in `handoff.md` under "Design Sketches"
 3. Define interfaces and data flow
 4. Identify edge cases and error handling
@@ -178,7 +178,7 @@ It is **not** for: phase tables, implementation progress, milestone descriptions
 
 1. Read `handoff.md` — current state and next steps
 2. Skim active milestones at https://github.com/ColeB1722/fin-assist/milestones for the "story" of in-flight work
-3. Read `docs/architecture.md` for architectural context (or specific deep-dive docs)
+3. Read [`docs/architecture.md`](docs/architecture.md) for architectural context, or jump straight to a deep-dive: [`skills.md`](docs/skills.md), [`tracing.md`](docs/tracing.md), [`configuration.md`](docs/configuration.md), [`decisions.md`](docs/decisions.md)
 4. Read this file (`AGENTS.md`) for workflow and conventions
 
 ## Skill Authoring
@@ -252,10 +252,10 @@ Use conventional commits format...
 2. If the skill needs a new tool, add it to `create_default_registry()` in `agents/tools.py`
 3. Write tests in `tests/test_agents/test_skills.py` (loader, catalog, manager)
 4. Run `just ci` to verify
-5. Update `docs/architecture.md` if the skill introduces new patterns
+5. Update [`docs/skills.md`](docs/skills.md) if the skill introduces new patterns
 
 ## Before Committing
 
 1. Run `just ci` to ensure all checks pass
 2. Update `handoff.md` if work spans multiple sessions
-3. Reference `docs/architecture.md` for design decisions
+3. Reference [`docs/decisions.md`](docs/decisions.md) for design decisions and [`docs/architecture.md`](docs/architecture.md) for component contracts

--- a/README.md
+++ b/README.md
@@ -1,128 +1,24 @@
 # fin-assist
 
-**Your terminal, with AI agents that have hands.** fin-assist is a personal AI agent platform that lives in your shell. You bring agents to your work — git, shell, your codebase — instead of context-switching to a chat tab. Each agent is purpose-built for a workflow, runs locally, and uses real tools (with approval gates for the dangerous ones).
+Personal AI agent platform for terminal workflows. Agents, skills, and tools are defined in TOML; a local hub serves them via the [A2A protocol](https://google.github.io/A2A/); a CLI client streams responses inline. Tool calls run on the host machine and pass through configurable approval gates.
 
-> ⚠️ Pre-release. Currently a personal-use platform; the API and config schema are still moving.
+> Pre-release. The API and config schema are still moving.
 
-```text
-$ fin do git commit
-✓ git diff (auto-approved)
-✓ git diff --staged (auto-approved)
+## Concepts
 
-  feat(skills): add per-tool approval policies
+- **Agent.** A configured combination of system prompt, output type, and capabilities. Agents are TOML entries under `[agents.<name>]`, not Python subclasses. `serving_modes` declares whether the agent supports one-shot (`do`) or multi-turn (`talk`) invocations.
+- **Skill.** A scoped capability bundle within an agent: a tool list, a prompt template, and an entry prompt. Skills gate which tools the LLM can call — unloaded skills' tools are not visible to the agent. Defined under `[agents.<name>.skills.<skill>]`.
+- **Tool.** A callable side-effect surface (`git`, `gh`, `read_file`, `run_shell`, MCP servers). Tools are registered into a shared registry and attached to agents via skills.
+- **Tool policy.** Per-tool approval rules (`always`, `never`, fnmatch pattern rules). Defined at the agent level under `[agents.<name>.tool_policies.<tool>]` so each tool has exactly one policy regardless of how many skills reference it.
+- **Hub.** Local FastAPI server (`127.0.0.1:4096` by default) that mounts each enabled agent as an A2A sub-app. The CLI is one client; any A2A-compatible client can connect.
 
-  Move approval rules from per-skill config to agent-level tool_policies,
-  eliminating merge conflicts when multiple skills share a tool.
+## Example
 
-? Run 'git commit -m ...'? [y/N] y
-✓ Committed.
-```
-
-## What it actually is
-
-You run **agents** — small specialized AI workers — from your terminal. An agent is shaped by:
-
-- **A system prompt** that defines what it's good at (git workflows, shell commands, design brainstorming)
-- **Skills** it can load (a "commit" skill, a "PR" skill) that scope down what tools it has and steer how it works
-- **Tools** the agent can actually call (`git`, `gh`, `read_file`, `run_shell`) — gated by approval policies you configure
-
-```mermaid
-flowchart LR
-    USER(("you<br/>(in your terminal)"))
-
-    subgraph FIN["fin-assist"]
-        direction TB
-        CLI["CLI<br/><i>fin do · fin talk</i>"]
-        HUB["Agent Hub<br/><i>local server, 127.0.0.1</i>"]
-
-        subgraph AGENTS["Agents (config-driven)"]
-            direction TB
-            GIT["git agent<br/><i>commit · pr · summarize</i>"]
-            SHELL["shell agent<br/><i>generate commands</i>"]
-            CUSTOM["your agent<br/><i>(add via TOML)</i>"]
-        end
-
-        subgraph CAPS["Skills · Tools · Approval"]
-            direction TB
-            SKILLS["Skills<br/><i>scope tools, steer prompts</i>"]
-            TOOLS["Tools<br/><i>git · gh · shell · read_file · MCP</i>"]
-            APPROVAL["Approval gates<br/><i>per-tool policies</i>"]
-        end
-    end
-
-    LLM["LLM provider<br/><i>your API key</i>"]
-
-    USER -->|"prompt"| CLI
-    CLI <-->|"local"| HUB
-    HUB --> AGENTS
-    AGENTS --> CAPS
-    CAPS -->|"reasoning"| LLM
-    CAPS -.->|"tool calls"| USER
-
-    classDef external fill:#f5f5f5,stroke:#999,stroke-dasharray: 3 3
-    class LLM external
-    classDef user fill:#fef9e7,stroke:#b58900
-    class USER user
-```
-
-A few things make this different from "yet another AI CLI":
-
-- **Agents are TOML, not Python.** Add a new agent by editing `config.toml` — pick a system prompt, list skills, set tool approval policies. No subclassing.
-- **Skills gate tools.** When you run `fin do git commit`, the agent only has the tools the `commit` skill grants. Other tools don't exist from its perspective.
-- **Real approval gates.** Per-tool fnmatch rules: `git diff*` auto-approves, `git push*` always asks. You stay in control of side effects.
-- **Protocol-native.** The hub speaks [A2A](https://google.github.io/A2A/) — any A2A client can connect, future agents can be in any language.
-- **Local-first.** The hub binds to `127.0.0.1`. Your prompts and history stay on your machine.
-
-## Getting started
-
-**Requirements:** [`devenv`](https://devenv.sh/) (or Python 3.12+ with `uv`).
-
-```bash
-# Enter the dev shell (Nix-managed)
-just dev
-
-# Install fin-assist
-uv sync
-
-# Configure a provider (Anthropic, OpenAI, OpenRouter, Google)
-export ANTHROPIC_API_KEY=sk-...
-# (interactive setup planned — see issue #124)
-
-# Try it
-fin-assist do "list the largest files in this repo"
-fin-assist do --agent git commit       # uses the git agent's `commit` skill
-fin-assist talk --agent git            # multi-turn session
-```
-
-Set `FIN_DATA_DIR=./.fin` (already set in `devenv.nix` for repo dev) to keep state colocated with your project instead of `~/.local/share/fin/`.
-
-### CLI cheat sheet
-
-```text
-fin-assist serve                            Start the agent hub (foreground)
-fin-assist start | stop | status            Background hub lifecycle
-fin-assist agents                           List available agents
-fin-assist do "prompt"                      One-shot to default agent
-fin-assist do --agent test "prompt"         One-shot to a named agent
-fin-assist do --agent git --skill commit    One-shot with a skill pre-loaded
-fin-assist do --agent git commit            Prompt-as-skill shortcut: prompt is
-                                            auto-promoted to skill when it matches
-fin-assist do                               Open input panel
-fin-assist do --edit "prompt"               Open input panel, pre-filled
-fin-assist talk [--agent <n>] [--skill <n>] Multi-turn session
-fin-assist list tools|skills|prompts        List registry entries
-```
-
-Inside `fin do` / `fin talk`, use `@`-completion to inject context: `@file:src/foo.py`, `@git:diff`, `@git:log`, `@history:query`.
-
-## Configuration in 30 seconds
+A `git` agent with a `commit` skill — TOML config, then invocation:
 
 ```toml
-[general]
-default_agent = "git"
-
+# config.toml
 [agents.git]
-description = "Git workflows."
 system_prompt = "git"
 serving_modes = ["do"]
 
@@ -133,29 +29,113 @@ prompt_template = "git-commit"
 entry_prompt = "Analyze the current changes and generate a conventional commit message."
 
 [agents.git.tool_policies.git]
-default = "always"
+default = "always"                                      # require approval by default
 rules = [
-  { pattern = "git diff*",   mode = "never" },
+  { pattern = "git diff*",   mode = "never" },          # auto-approve read-only ops
   { pattern = "git status*", mode = "never" },
   { pattern = "git log*",    mode = "never" },
 ]
 ```
 
-That's it — `fin do git commit` will now use this agent. See [`docs/configuration.md`](docs/configuration.md) for the full schema and [`docs/skills.md`](docs/skills.md) for the skills authoring guide.
+```text
+$ fin-assist do --agent git commit
+✓ git diff             (auto-approved by tool_policies)
+✓ git diff --staged    (auto-approved by tool_policies)
+
+  feat(skills): add per-tool approval policies
+
+  Move approval rules from per-skill config to agent-level tool_policies,
+  eliminating merge conflicts when multiple skills share a tool.
+
+? Run 'git commit -m ...'? [y/N] y    # default policy: requires approval
+✓ Committed.
+```
+
+`fin-assist do --agent git commit` — `commit` is the prompt; because `commit` matches a skill on the `git` agent, it's auto-promoted to `--skill commit` (entry prompt sent, skill's tools loaded, `prompt_template` injected as system prompt).
+
+## Architecture
+
+```mermaid
+flowchart LR
+    CLI["CLI client<br/>fin-assist do/talk"]
+
+    subgraph HUB["Hub (FastAPI · 127.0.0.1:4096)"]
+        direction TB
+        ROUTER["Hub router<br/>mount table per agent"]
+
+        subgraph SUB["Per-agent A2A sub-app"]
+            direction TB
+            EXEC["Executor<br/>(streams · approval · context)"]
+            BACKEND["AgentBackend<br/>(pydantic-ai)"]
+        end
+
+        STORE["ContextStore<br/>SQLite"]
+    end
+
+    LLM[("LLM provider<br/>via API key")]
+
+    CLI <-->|"A2A JSON-RPC + SSE"| ROUTER
+    ROUTER --> EXEC
+    EXEC --> BACKEND
+    EXEC <--> STORE
+    BACKEND --> LLM
+
+    classDef external fill:#f5f5f5,stroke:#999,stroke-dasharray: 3 3
+    class LLM external
+```
+
+One hub process serves N agents, each as its own A2A sub-app at `/agents/<name>/`. The CLI auto-starts the hub if it isn't running. See [`docs/architecture.md`](docs/architecture.md) for the full picture.
+
+## Install
+
+Requirements: [`devenv`](https://devenv.sh/), or Python 3.12+ with [`uv`](https://docs.astral.sh/uv/).
+
+```bash
+just dev                              # enter dev shell (Nix-managed)
+uv sync                               # install dependencies
+
+export ANTHROPIC_API_KEY=sk-...       # or OPENAI_API_KEY, OPENROUTER_API_KEY, GOOGLE_API_KEY
+                                      # (interactive setup: planned, see issue #124)
+
+fin-assist agents                     # verify install — lists configured agents
+```
+
+State (logs, hub DB, sessions, history, credentials, traces) lives under `$FIN_DATA_DIR`, default `~/.local/share/fin/`. The repo's `devenv.nix` sets `FIN_DATA_DIR=./.fin` so state is colocated with the checkout during development.
+
+## CLI reference
+
+```text
+fin-assist serve                            Start the hub (foreground)
+fin-assist start | stop | status            Background hub lifecycle
+fin-assist agents                           List configured agents
+fin-assist do "<prompt>"                    One-shot to default agent
+fin-assist do --agent <name> "<prompt>"     One-shot to a named agent
+fin-assist do --agent <name> --skill <s>    One-shot with skill pre-loaded
+fin-assist do --agent <name> <skill>        Prompt-as-skill: prompt auto-promoted
+                                            to skill when it matches a skill name
+fin-assist do                               No prompt → opens input panel
+fin-assist do --edit "<prompt>"             Opens panel pre-filled
+fin-assist talk [--agent <n>] [--skill <n>] Multi-turn session
+fin-assist talk --resume <id>               Resume a saved session
+fin-assist talk --list                      List saved sessions
+fin-assist list tools|skills|prompts|output-types
+```
+
+Inside `do` / `talk`, `@`-completion injects context inline: `@file:<path>`, `@git:diff`, `@git:log`, `@history:<query>`.
+
+REPL commands during `talk`: `/skills` (list), `/skill:<name>` (load), `/help`, `/exit`.
 
 ## Documentation
 
-For the user perspective, this README is the front door. For internals:
-
-- [`docs/architecture.md`](docs/architecture.md) — how the hub, agents, and backends fit together
+- [`docs/architecture.md`](docs/architecture.md) — hub, agents, backends, A2A integration
 - [`docs/configuration.md`](docs/configuration.md) — TOML schema, env vars, credentials
 - [`docs/skills.md`](docs/skills.md) — skills, tool gating, approval policies, SKILL.md format
-- [`docs/tracing.md`](docs/tracing.md) — OTel instrumentation and HITL trace continuity
-- [`docs/decisions.md`](docs/decisions.md) — design decisions and open questions
-- [`AGENTS.md`](AGENTS.md) — development workflow and conventions (for contributors)
+- [`docs/tracing.md`](docs/tracing.md) — OTel instrumentation, HITL trace continuity
+- [`docs/decisions.md`](docs/decisions.md) — design decisions, open questions
+- [`AGENTS.md`](AGENTS.md) — development workflow and conventions
 
-Active work lives in [GitHub milestones](https://github.com/ColeB1722/fin-assist/milestones); ideas and discussions live in [issues](https://github.com/ColeB1722/fin-assist/issues).
+Committed work: [GitHub milestones](https://github.com/ColeB1722/fin-assist/milestones). Discussions and ideas: [GitHub issues](https://github.com/ColeB1722/fin-assist/issues).
 
 ## Status
 
-Pre-release, single-developer project. Currently shipping v0.1 (Skills API). The protocol layer (A2A), hub, CLI, streaming, tool calling, HITL approval, tracing, and skills are all working. Next up: MCP integration, additional agents (SDD, TDD), and a TUI client.
+v0.1 (Skills API) shipped. Working: A2A protocol, hub, CLI, streaming, tool calling, HITL approval, tracing, skills. v0.1.1 in progress: MCP, per-subcommand approval, interactive credential setup.

--- a/README.md
+++ b/README.md
@@ -1,256 +1,158 @@
 # fin-assist
 
-Expandable personal AI agent platform for terminal workflows. An **Agent Hub** hosts N specialized agents over the [A2A protocol](https://google.github.io/A2A/) — clients dynamically adapt their UI based on each agent's declared capabilities. Shared agentic capabilities (tools, approval, context, tracing) are framework-agnostic platform abstractions; LLM frameworks plug in via backend implementations.
+**Your terminal, with AI agents that have hands.** fin-assist is a personal AI agent platform that lives in your shell. You bring agents to your work — git, shell, your codebase — instead of context-switching to a chat tab. Each agent is purpose-built for a workflow, runs locally, and uses real tools (with approval gates for the dangerous ones).
 
-## Architecture
+> ⚠️ Pre-release. Currently a personal-use platform; the API and config schema are still moving.
 
-Diagrams progress from external view → hub internals → backend wiring → per-request sequence. The Mermaid blocks below are canonical; `just diagrams` renders them to `docs/diagrams/*.svg` (+ `*.png`) for offline viewing.
+```text
+$ fin do git commit
+✓ git diff (auto-approved)
+✓ git diff --staged (auto-approved)
 
-### 1. System Context
+  feat(skills): add per-tool approval policies
 
-Who talks to what.
+  Move approval rules from per-skill config to agent-level tool_policies,
+  eliminating merge conflicts when multiple skills share a tool.
 
-<!-- diagram:01-system-context -->
-```mermaid
-graph LR
-    User(("User"))
-
-    subgraph Clients
-        CLI["CLI Client<br/>Rich · a2a-sdk ClientFactory"]
-        TUI["TUI Client<br/>(planned)"]
-    end
-
-        HUB["Agent Hub<br/>FastAPI · 127.0.0.1:4096<br/>A2A protocol"]
-
-    LLM["LLM Providers<br/>Anthropic · OpenAI<br/>OpenRouter · Google"]
-
-    User --> CLI
-    User --> TUI
-    CLI -->|"JSON-RPC + SSE"| HUB
-    TUI -->|"JSON-RPC + SSE"| HUB
-    HUB -->|"HTTPS"| LLM
-
-    classDef planned stroke-dasharray: 5 5
-    class TUI planned
+? Run 'git commit -m ...'? [y/N] y
+✓ Committed.
 ```
 
-### 2. Hub Internals
+## What it actually is
 
-Routing, per-agent sub-apps, and the Executor/stores inside the hub process.
+You run **agents** — small specialized AI workers — from your terminal. An agent is shaped by:
 
-<!-- diagram:02-hub-internals -->
+- **A system prompt** that defines what it's good at (git workflows, shell commands, design brainstorming)
+- **Skills** it can load (a "commit" skill, a "PR" skill) that scope down what tools it has and steer how it works
+- **Tools** the agent can actually call (`git`, `gh`, `read_file`, `run_shell`) — gated by approval policies you configure
+
 ```mermaid
-graph TD
-    IN["A2A request<br/>(from client)"]
-    DISC["GET /agents · GET /health<br/>(hub-level discovery)"]
+flowchart LR
+    USER(("you<br/>(in your terminal)"))
 
-    subgraph HUB_PROC["Agent Hub (FastAPI, 127.0.0.1:4096)"]
-        HUB["Hub Router<br/>mount table:<br/>· /agents/test/<br/>· /agents/{name}/ (from config)"]
+    subgraph FIN["fin-assist"]
+        direction TB
+        CLI["CLI<br/><i>fin do · fin talk</i>"]
+        HUB["Agent Hub<br/><i>local server, 127.0.0.1</i>"]
 
-        subgraph SUBAPP["Per-Agent A2A Sub-App · one instance per enabled agent"]
+        subgraph AGENTS["Agents (config-driven)"]
             direction TB
-            DRH["DefaultRequestHandler<br/>(a2a-sdk)<br/>JSON-RPC dispatch for this agent"]
-            EXEC["Executor<br/>AgentExecutor + TaskUpdater<br/>wraps this agent's PydanticAIBackend"]
-            TS["InMemoryTaskStore<br/>ephemeral · this sub-app only"]
+            GIT["git agent<br/><i>commit · pr · summarize</i>"]
+            SHELL["shell agent<br/><i>generate commands</i>"]
+            CUSTOM["your agent<br/><i>(add via TOML)</i>"]
         end
 
-        CS["ContextStore<br/>SQLite · opaque bytes<br/>single instance, shared across sub-apps"]
-
-        FACTORY["AgentFactory<br/>AgentSpec → sub-app<br/>+ AgentCard (w/ fin_assist:meta ext)"]
+        subgraph CAPS["Skills · Tools · Approval"]
+            direction TB
+            SKILLS["Skills<br/><i>scope tools, steer prompts</i>"]
+            TOOLS["Tools<br/><i>git · gh · shell · read_file · MCP</i>"]
+            APPROVAL["Approval gates<br/><i>per-tool policies</i>"]
+        end
     end
 
-    BACKEND["Backend Layer<br/>(see §3)"]
+    LLM["LLM provider<br/><i>your API key</i>"]
 
-    IN --> HUB
-    HUB -->|"dispatches to matching sub-app"| DRH
-    DRH --> EXEC
-    DRH <--> TS
-    EXEC -->|"shared store · keyed by context_id"| CS
-    EXEC -->|"delegates LLM work"| BACKEND
-
-    FACTORY -.->|"builds at startup<br/>(N instances)"| SUBAPP
-    FACTORY -.->|"publishes cards"| DISC
+    USER -->|"prompt"| CLI
+    CLI <-->|"local"| HUB
+    HUB --> AGENTS
+    AGENTS --> CAPS
+    CAPS -->|"reasoning"| LLM
+    CAPS -.->|"tool calls"| USER
 
     classDef external fill:#f5f5f5,stroke:#999,stroke-dasharray: 3 3
-    class IN,BACKEND,DISC external
-    classDef startup fill:#fafafa,stroke:#bbb,stroke-dasharray: 4 3
-    class FACTORY startup
-    classDef shared fill:#f0f7ff,stroke:#4a7fb0,stroke-width:2px
-    class CS shared
+    class LLM external
+    classDef user fill:#fef9e7,stroke:#b58900
+    class USER user
 ```
 
-### 3. Backend Layer & Shared Services
+A few things make this different from "yet another AI CLI":
 
-How the Executor reaches the LLM and what cross-cutting services it leans on.
+- **Agents are TOML, not Python.** Add a new agent by editing `config.toml` — pick a system prompt, list skills, set tool approval policies. No subclassing.
+- **Skills gate tools.** When you run `fin do git commit`, the agent only has the tools the `commit` skill grants. Other tools don't exist from its perspective.
+- **Real approval gates.** Per-tool fnmatch rules: `git diff*` auto-approves, `git push*` always asks. You stay in control of side effects.
+- **Protocol-native.** The hub speaks [A2A](https://google.github.io/A2A/) — any A2A client can connect, future agents can be in any language.
+- **Local-first.** The hub binds to `127.0.0.1`. Your prompts and history stay on your machine.
 
-<!-- diagram:03-backend-services -->
-```mermaid
-graph TD
-    EXEC["Executor<br/>(from hub)"]
+## Getting started
 
-    subgraph BACKEND_GRP["Backend Layer"]
-        BEH["«protocol» AgentBackend"]
-        PAI["PydanticAIBackend<br/>pydantic-ai Agent · FallbackModel"]
-        SH["StreamHandle<br/>async iter (deltas) + result()"]
-        MCE["MissingCredentialsError<br/>raised when API key absent"]
-    end
+**Requirements:** [`devenv`](https://devenv.sh/) (or Python 3.12+ with `uv`).
 
-    subgraph SPEC_GRP["Agent Specification"]
-        SPEC["AgentSpec<br/>pure config · zero framework deps"]
-    end
+```bash
+# Enter the dev shell (Nix-managed)
+just dev
 
-    subgraph SHARED["Shared Services"]
-        CREDS["CredentialStore<br/>env → file → keyring"]
-        CONFIG["ConfigLoader<br/>TOML + env (FIN_*)<br/>pydantic-settings"]
-        REG["ProviderRegistry<br/>LLM providers · api_key injected"]
-    end
+# Install fin-assist
+uv sync
 
-    LLM["LLM Providers<br/>Anthropic · OpenAI · OpenRouter · Google"]
+# Configure a provider (Anthropic, OpenAI, OpenRouter, Google)
+fin-assist /connect
 
-    EXEC --> BEH
-    BEH -.->|"implemented by"| PAI
-    PAI --> SH
-    PAI -->|"create_model(provider, api_key)"| REG
-    REG --> LLM
-    PAI --> SPEC
-    PAI -.->|"raises on missing key"| MCE
-    SPEC -->|"get_api_key(provider)"| CREDS
-    SPEC --> CONFIG
-
-    classDef external fill:#f5f5f5,stroke:#999,stroke-dasharray: 3 3
-    class EXEC,LLM external
-    classDef error fill:#fff3f3,stroke:#c66
-    class MCE error
+# Try it
+fin-assist do "list the largest files in this repo"
+fin-assist do git commit            # uses the git agent's commit skill
+fin-assist talk --agent git         # multi-turn session
 ```
 
-### 4. Request Flow
+Set `FIN_DATA_DIR=./.fin` (already set in `devenv.nix` for repo dev) to keep state colocated with your project instead of `~/.local/share/fin/`.
 
-End-to-end sequence of a single `SendStreamingMessage` call.
+### CLI cheat sheet
 
-<!-- diagram:04-request-flow -->
-```mermaid
-sequenceDiagram
-    participant C as CLI Client
-    participant H as Agent Hub<br/>(sub-app + DefaultRequestHandler)
-    participant E as Executor
-    participant B as AgentBackend<br/>(PydanticAIBackend)
-    participant SH as StreamHandle
-    participant CS as ContextStore
-    participant LLM as LLM Provider
-
-    C->>H: SendStreamingMessage (JSON-RPC + SSE)
-    H->>E: execute(context, event_queue)
-    E->>E: Task enqueued (SUBMITTED)
-    E->>E: updater.start_work() → WORKING
-
-    E->>B: check_credentials()
-    B-->>E: [] or [missing providers]
-
-    alt Credentials missing
-        Note over E,B: raises MissingCredentialsError
-        E->>E: updater.requires_auth() → AUTH_REQUIRED
-        H-->>C: SSE: TaskStatusUpdateEvent (auth_required)
-    else Credentials present
-        E->>CS: load(context_id)
-        CS-->>E: bytes or None
-        E->>B: deserialize_history(bytes)
-        B-->>E: message_history (prior turns)
-
-        E->>B: convert_history([current_message])
-        B-->>E: framework messages (this turn)
-
-        E->>B: run_stream(messages=history)
-        B-->>E: StreamHandle
-        Note over B,LLM: backend holds LLM connection
-
-        loop Token-by-token
-            SH-->>E: text delta (async iter)
-            E->>H: updater.add_artifact(append=true, last_chunk=false)
-            H-->>C: SSE: TaskArtifactUpdateEvent
-        end
-
-        E->>H: updater.add_artifact("", last_chunk=true)
-        H-->>C: SSE: TaskArtifactUpdateEvent (last_chunk=true)
-
-        alt Exception during stream
-            E->>E: updater.failed() → FAILED
-            H-->>C: SSE: TaskStatusUpdateEvent (failed)
-        end
-
-        E->>SH: await result()
-        SH-->>E: RunResult (output, serialized_history, new_message_parts)
-
-        E->>CS: save(context_id, serialized_history)
-
-        loop new_message_parts (thinking blocks, etc.)
-            E->>H: updater.update_status(WORKING, message=part)
-            H-->>C: SSE: TaskStatusUpdateEvent (WORKING + message)
-        end
-
-        alt Structured output (non-str)
-            E->>B: convert_result_to_part(output)
-            B-->>E: Part (data + json_schema metadata)
-            E->>H: updater.add_artifact(structured, new artifact_id)
-            H-->>C: SSE: TaskArtifactUpdateEvent (structured)
-        end
-
-        E->>E: updater.complete() → COMPLETED
-        H-->>C: SSE: TaskStatusUpdateEvent (completed)
-    end
-```
-
-## Key Concepts
-
-| Concept | Implementation |
-|---------|---------------|
-| **Config-driven agents** | Agent behavior (prompt, output type, thinking, approval, skills) defined in TOML — new agents are config entries, not new classes |
-| **Platform owns abstractions** | Tools, approval, context, step events, and tracing are framework-agnostic platform types; backends adapt them to their LLM framework |
-| **Protocol-native** | A2A via a2a-sdk v1.0; any A2A client can connect; enables future agent-to-agent workflows |
-| **Multi-path routing** | N agents → N A2A sub-apps at `/agents/{name}/`, each with its own agent card |
-| **Token-by-token streaming** | `SendStreamingMessage` SSE → `TaskUpdater.add_artifact(append=True)` → Rich `Live` rendering |
-| **Skills API** | Agents organize tools via skills — each skill bundles tools, approval rules, context injection, and prompt steering; agent-driven `load_skill` discovery; SKILL.md file format |
-| **Local-first** | Binds `127.0.0.1` only; no network exposure by default |
-
-## CLI Usage
-
-```
-fin-assist serve                        Start agent hub
+```text
+fin-assist serve                        Start the agent hub
 fin-assist agents                       List available agents
-fin-assist do "prompt"                  One-shot query (default agent)
-fin-assist do --agent test "prompt"     One-shot query (named agent)
-fin-assist do --skill commit "prompt"   One-shot query with skill pre-loaded
-fin-assist do                           Open input panel (default agent)
-fin-assist do --edit "prompt"           Open input panel pre-filled with prompt
-fin-assist talk                         Multi-turn session (default agent)
-fin-assist talk --agent test            Multi-turn session (named agent)
-fin-assist talk --skill commit          Multi-turn session with skill pre-loaded
-fin-assist list tools                   List registered tools
-fin-assist list skills                  List skills grouped by agent
-fin-assist list prompts                 List registered system prompts
-fin-assist list output-types            List registered output types
+fin-assist do "prompt"                  One-shot to default agent
+fin-assist do --agent test "prompt"     One-shot to a named agent
+fin-assist do --skill commit "prompt"   One-shot with a skill pre-loaded
+fin-assist do <agent> <skill>           Positional skill (e.g. fin do git commit)
+fin-assist do                           Open input panel
+fin-assist do --edit "prompt"           Open input panel, pre-filled
+fin-assist talk                         Multi-turn session
+fin-assist list tools|skills|prompts    List registry entries
 ```
 
-Context injection via `@`-completion in the input panel: `@file:path.py`, `@git:diff`, `@git:log`, `@history:query`.
+Inside `fin do` / `fin talk`, use `@`-completion to inject context: `@file:src/foo.py`, `@git:diff`, `@git:log`, `@history:query`.
+
+## Configuration in 30 seconds
+
+```toml
+[general]
+default_agent = "git"
+
+[agents.git]
+description = "Git workflows."
+system_prompt = "git"
+serving_modes = ["do"]
+
+[agents.git.skills.commit]
+description = "Generate a conventional commit message from current changes."
+tools = ["git"]
+prompt_template = "git-commit"
+entry_prompt = "Analyze the current changes and generate a conventional commit message."
+
+[agents.git.tool_policies.git]
+default = "always"
+rules = [
+  { pattern = "git diff*",   mode = "never" },
+  { pattern = "git status*", mode = "never" },
+  { pattern = "git log*",    mode = "never" },
+]
+```
+
+That's it — `fin do git commit` will now use this agent. See [`docs/configuration.md`](docs/configuration.md) for the full schema and [`docs/skills.md`](docs/skills.md) for the skills authoring guide.
+
+## Documentation
+
+For the user perspective, this README is the front door. For internals:
+
+- [`docs/architecture.md`](docs/architecture.md) — how the hub, agents, and backends fit together
+- [`docs/configuration.md`](docs/configuration.md) — TOML schema, env vars, credentials
+- [`docs/skills.md`](docs/skills.md) — skills, tool gating, approval policies, SKILL.md format
+- [`docs/tracing.md`](docs/tracing.md) — OTel instrumentation and HITL trace continuity
+- [`docs/decisions.md`](docs/decisions.md) — design decisions and open questions
+- [`AGENTS.md`](AGENTS.md) — development workflow and conventions (for contributors)
+
+Active work lives in [GitHub milestones](https://github.com/ColeB1722/fin-assist/milestones); ideas and discussions live in [issues](https://github.com/ColeB1722/fin-assist/issues).
 
 ## Status
 
-| Phase | Description | Status |
-|-------|-------------|--------|
-| 1–8b | Repo setup → CLI REPL | Done |
-| 9 | Streaming + integration tests | Done |
-| Config redesign | Config-driven agents, `AgentSpec` pure config | Done |
-| a2a-sdk migration | fasta2a → a2a-sdk v1.0, FastAPI, streaming | Done |
-| Executor + Tools + HITL | Multi-step executor, tool calling, approval (PR #87) | Done |
-| Remove built-in agents | Pure infrastructure; all agents from config.toml | Done |
-| Input panel + `--edit` | Interactive `fin do`, `--edit` flag, `--agent` flag | Done |
-| `@`-completion | Inline context injection (`@file:`, `@git:`, `@history:`) | Done |
-| `fin list` | CLI capabilities listing (tools, skills, prompts, output-types) | Done |
-| Observability | OTel tracing (hub + CLI), OpenInference/Phoenix bridge, JSONL span sink, HITL trace continuity | Done |
-| 15 | Skills API v0.1 | Done |
-| 11 | Multiplexer (tmux/zellij) | Planned |
-| 13 | TUI client (Textual) | Planned |
-| 15b | MCP integration (v0.1.1) | Planned |
-| 16 | Additional agents (SDD, TDD) | Planned |
-| 17 | Multi-agent workflows | Planned |
-
-See [docs/architecture.md](docs/architecture.md) for full architecture, design decisions, and implementation details.
+Pre-release, single-developer project. Currently shipping v0.1 (Skills API). The protocol layer (A2A), hub, CLI, streaming, tool calling, HITL approval, tracing, and skills are all working. Next up: MCP integration, additional agents (SDD, TDD), and a TUI client.

--- a/README.md
+++ b/README.md
@@ -85,12 +85,13 @@ just dev
 uv sync
 
 # Configure a provider (Anthropic, OpenAI, OpenRouter, Google)
-fin-assist /connect
+export ANTHROPIC_API_KEY=sk-...
+# (interactive setup planned — see issue #124)
 
 # Try it
 fin-assist do "list the largest files in this repo"
-fin-assist do git commit            # uses the git agent's commit skill
-fin-assist talk --agent git         # multi-turn session
+fin-assist do --agent git commit       # uses the git agent's `commit` skill
+fin-assist talk --agent git            # multi-turn session
 ```
 
 Set `FIN_DATA_DIR=./.fin` (already set in `devenv.nix` for repo dev) to keep state colocated with your project instead of `~/.local/share/fin/`.
@@ -98,16 +99,18 @@ Set `FIN_DATA_DIR=./.fin` (already set in `devenv.nix` for repo dev) to keep sta
 ### CLI cheat sheet
 
 ```text
-fin-assist serve                        Start the agent hub
-fin-assist agents                       List available agents
-fin-assist do "prompt"                  One-shot to default agent
-fin-assist do --agent test "prompt"     One-shot to a named agent
-fin-assist do --skill commit "prompt"   One-shot with a skill pre-loaded
-fin-assist do <agent> <skill>           Positional skill (e.g. fin do git commit)
-fin-assist do                           Open input panel
-fin-assist do --edit "prompt"           Open input panel, pre-filled
-fin-assist talk                         Multi-turn session
-fin-assist list tools|skills|prompts    List registry entries
+fin-assist serve                            Start the agent hub (foreground)
+fin-assist start | stop | status            Background hub lifecycle
+fin-assist agents                           List available agents
+fin-assist do "prompt"                      One-shot to default agent
+fin-assist do --agent test "prompt"         One-shot to a named agent
+fin-assist do --agent git --skill commit    One-shot with a skill pre-loaded
+fin-assist do --agent git commit            Prompt-as-skill shortcut: prompt is
+                                            auto-promoted to skill when it matches
+fin-assist do                               Open input panel
+fin-assist do --edit "prompt"               Open input panel, pre-filled
+fin-assist talk [--agent <n>] [--skill <n>] Multi-turn session
+fin-assist list tools|skills|prompts        List registry entries
 ```
 
 Inside `fin do` / `fin talk`, use `@`-completion to inject context: `@file:src/foo.py`, `@git:diff`, `@git:log`, `@history:query`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,371 +1,154 @@
-# fin-assist Architecture
+# Architecture
 
-## Overview
+Developer reference for fin-assist's internals. For the user-facing pitch, see [`README.md`](../README.md). For deep dives, see the focused docs:
 
-fin-assist is an **expandable personal AI agent platform** for terminal workflows. It provides an **Agent Hub** — a server that hosts N specialized agents over the A2A protocol — and multiple client interfaces (CLI, TUI, future web) that dynamically adapt their UI based on each agent's declared capabilities.
+- [`configuration.md`](configuration.md) — TOML schema, file precedence, credentials
+- [`skills.md`](skills.md) — skills lifecycle, tool gating, approval policies
+- [`tracing.md`](tracing.md) — OTel instrumentation, HITL trace continuity, full instrumented request flow
+- [`decisions.md`](decisions.md) — design decisions and open questions
 
-### Core Vision
+## Vision
 
-**Pluggable Agentic Experimentation Platform** — fin-assist exposes shared agentic capabilities (tools, approval gates, context providers, observability) as framework-agnostic platform abstractions. Different LLM frameworks or providers plug in via backend implementations. The platform owns the abstractions; backends adapt them. This mirrors how the project uses open protocols (A2A for transport, OTel for observability) — the platform defines the shape, backends fill in the framework-specific details.
+**Pluggable agentic experimentation platform.** fin-assist exposes shared agentic capabilities (tools, approval gates, context providers, observability) as framework-agnostic platform abstractions. Different LLM frameworks plug in via backend implementations. The platform owns the abstractions; backends adapt them. This mirrors the project's use of open protocols (A2A for transport, OTel for observability) — the platform defines the shape, backends fill in framework-specific details.
 
-**Agent Hub** — A "turnstile" of specialized agents exposed via A2A protocol (a2a-sdk v1.0). Each agent is independently discoverable, has its own agent card, and can be swapped in/out of the server. The hub handles routing, conversation persistence, and agent lifecycle.
+**Agent Hub.** A "turnstile" of specialized agents exposed via the [A2A protocol](https://google.github.io/A2A/) (via [a2a-sdk v1.0](https://github.com/a2aproject/a2a-python)). Each agent is independently discoverable, has its own agent card, and can be swapped in/out of the server. The hub handles routing, conversation persistence, and agent lifecycle.
 
-**Dynamic UI via Agent Metadata** — Clients adapt their interface based on agent capabilities. Static metadata (multi-turn, thinking support, model selection) is declared in the A2A agent card via `AgentExtension`. Dynamic metadata (accept actions, rendering hints) is returned per-response in task artifacts. Clients don't need to know about specific agents — they read metadata and adapt.
+**Dynamic UI via agent metadata.** Clients adapt their interface based on agent capabilities. Static metadata (multi-turn, thinking support, model selection) is declared in the A2A agent card via `AgentExtension`. Dynamic metadata (accept actions, rendering hints) is returned per-response in task artifacts. Clients don't need to know about specific agents — they read metadata and adapt.
 
-**Protocol-Native** — Built on A2A (Agent-to-Agent) protocol via a2a-sdk v1.0 (Google's official Python SDK). Any A2A-compatible client can communicate with the hub. This enables future agent-to-agent workflows (e.g., SDD agent handing off to TDD agent).
+**Protocol-native.** Built on A2A. Any A2A-compatible client can communicate with the hub. This enables future agent-to-agent workflows (e.g., SDD agent handing off to TDD agent).
 
-**CLI-First, TUI-Later** — Start with a simple CLI client for fast iteration and testing, then layer on a TUI and other clients. The server is the stable core; clients are interchangeable.
+**CLI-first, TUI-later.** Start with a simple CLI client for fast iteration and testing, then layer on TUI and other clients. The server is the stable core; clients are interchangeable.
 
-## Design Principles
+## Design principles
 
-1. **Config-driven agents** — Agent behavior (system prompt, output type, thinking, serving modes, approval, skills) is defined in TOML config, not Python subclasses. New agents are config entries, not new classes.
-2. **Protocol-native** — Built on A2A via a2a-sdk v1.0 for standardized agent communication. Multi-path routing: N agents, N agent cards, one server.
-3. **Platform owns abstractions, backends adapt them** — Shared agentic capabilities (tools, approval, context, step events, tracing) are framework-agnostic platform types in `agents/`. LLM frameworks plug in via backend implementations that adapt platform concepts to their APIs. The platform never imports from backends.
+1. **Config-driven agents** — Behavior (system prompt, output type, thinking, serving modes, approval, skills) lives in TOML, not Python subclasses. New agents are config entries, not new classes.
+2. **Protocol-native** — A2A via a2a-sdk v1.0 for standardized agent communication. Multi-path routing: N agents, N agent cards, one server.
+3. **Platform owns abstractions, backends adapt them** — Tools, approval, context, step events, tracing are framework-agnostic platform types in `agents/`. LLM frameworks plug in via backends that adapt platform concepts to their APIs. The platform never imports from backends.
 4. **Local-first** — Server binds to `127.0.0.1` only; no network exposure by default.
 5. **Hub-first development** — Build the agent hub (server) as the stable core, then iterate on clients.
 6. **Metadata-driven clients** — Clients read agent capabilities from agent cards and adapt dynamically. No client-side agent-specific code.
 
-## Non-Goals
+## Non-goals
 
 - Network-accessible deployment (personal use only, local-first)
 - Real-time command suggestions (on-demand only)
 - IDE/editor integration (beyond future MCP)
-- TOML-based agent *creation* (agents defined via TOML config, but the `AgentSpec` class is the only spec implementation — no `fin ingest` to create new agent classes from TOML)
+- TOML-based agent *creation* — agents are defined via TOML config, but `AgentSpec` is the only spec implementation. There is no `fin ingest` to create new agent classes from TOML.
 
----
+## Maintenance contract
 
-## Documentation Layout
+When a structural change to the system lands, update the relevant doc(s) in the same commit. Any claim in this document that a subsystem is "integrated" or a design decision is "Resolved" must cite a real call site (`file:line`) somewhere in `src/` — not just a test or a TOML field.
 
-- **[README.md](../README.md)** — canonical architecture **diagrams** (4 inline Mermaid blocks: System Context, Hub Internals, Backend + Shared Services, Request Flow). Regenerate rendered images with `just diagrams`. GitHub renders the Mermaid natively.
-- **`docs/architecture.md`** (this file) — architecture **prose**: design principles, component contracts, per-subsystem deep dives, phase history, design-decision rationale. The ASCII overview diagrams below are redundant with the Mermaid diagrams in README and are retained as prose references only — treat the README Mermaid as authoritative if they disagree.
-- **`handoff.md`** — rolling multi-session development log: current phase status, design sketches in flight, next-session pointers.
-- **`AGENTS.md`** — development patterns (SDD → TDD workflow, test quality standards, commit rules).
+## Hub internals
 
-When a structural change to the system lands, update **both** the README Mermaid blocks **and** the relevant architecture.md prose in the same commit. To prevent reoccurrence of the ContextProviders-style drift the audit uncovered, any claim in this document that a subsystem is "integrated" or a design decision is "Resolved" must have a citation to a real call site (file:line) somewhere in `src/` — not just to a test or a TOML field.
+How requests are routed inside the hub process.
 
----
+```mermaid
+graph TD
+    IN["A2A request<br/>(from client)"]
+    DISC["GET /agents · GET /health<br/>(hub-level discovery)"]
 
-## Architecture
+    subgraph HUB_PROC["Agent Hub (FastAPI, 127.0.0.1:4096)"]
+        HUB["Hub Router<br/>mount table:<br/>· /agents/test/<br/>· /agents/{name}/ (from config)"]
 
-### System Overview
+        subgraph SUBAPP["Per-Agent A2A Sub-App · one instance per enabled agent"]
+            direction TB
+            DRH["DefaultRequestHandler<br/>(a2a-sdk)<br/>JSON-RPC dispatch for this agent"]
+            EXEC["Executor<br/>AgentExecutor + TaskUpdater<br/>wraps this agent's PydanticAIBackend"]
+            TS["InMemoryTaskStore<br/>ephemeral · this sub-app only"]
+        end
 
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                         Client Layer (Frontends)                             │
-│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐             │
-│  │  CLI Client     │  │  TUI Client     │  │  Future Clients │             │
-│  │  (primary)      │  │  (Textual)      │  │  (web, GUI...)  │             │
-│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘             │
-└───────────┼────────────────────┼────────────────────┼───────────────────────┘
-            │                    │                    │
-            │  A2A Protocol (HTTP + JSON-RPC)         │
-            │  Agent discovery via agent cards        │
-            │  Dynamic UI via agent card metadata     │
-            └────────────────────┴────────────────────┘
-                                 │
-                                 ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                    Agent Hub (FastAPI / ASGI)                                │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐    │
-│  │  GET /agents — discovery endpoint (lists all agent card URLs)        │    │
-│  │  GET /health — health check                                          │    │
-│  └──────────────────────────────────────────────────────────────────────┘    │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐    │
-│  │  Multi-Path Agent Routing (each agent = separate A2A sub-app)        │    │
-│  │                                                                       │    │
-│  │  /agents/{name}/  (one per enabled config entry)                     │    │
-│  │  (AgentSpec, [agents.<name>])                                        │    │
-│  │  ├── /.well-known/agent-card.json                                    │    │
-│  │  └── / (JSON-RPC endpoint)                                           │    │
-│  └──────────────────────────────────────────────────────────────────────┘    │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐    │
-│  │  Shared Storage                                                       │    │
-│  │  • Task storage — InMemoryTaskStore (a2a-sdk, ephemeral per process) │    │
-│  │  • Context storage — SQLite ContextStore (conversation history)      │    │
-│  └──────────────────────────────────────────────────────────────────────┘    │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐    │
-│  │  Shared Services                                                      │    │
-│  │  • CredentialStore (API keys: env → file → keyring)                  │    │
-│  │  • ConfigLoader (TOML + env (FIN_*), pydantic-settings)              │    │
-│  │  • ProviderRegistry (LLM providers; api_key injected per call)       │    │
-│  │  • ContextProviders — wired as model-driven tools via                │    │
-│  │    `create_default_registry()`                                       │    │
-│  └──────────────────────────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                 │
-                                 ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                     Shell Integration (Fish) — future                        │
-│  ┌──────────────────────────────────────────────────────────────────────┐    │
-│  │  fin_assist.fish — keybinding launches CLI/TUI, receives output       │    │
-│  │  Command insertion — accept shell agent output into commandline       │    │
-│  └──────────────────────────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────────────────────────┘
+        CS["ContextStore<br/>SQLite · opaque bytes<br/>single instance, shared across sub-apps"]
+
+        FACTORY["AgentFactory<br/>AgentSpec → sub-app<br/>+ AgentCard (w/ fin_assist:meta ext)"]
+    end
+
+    BACKEND["Backend Layer<br/>(see below)"]
+
+    IN --> HUB
+    HUB -->|"dispatches to matching sub-app"| DRH
+    DRH --> EXEC
+    DRH <--> TS
+    EXEC -->|"shared store · keyed by context_id"| CS
+    EXEC -->|"delegates LLM work"| BACKEND
+
+    FACTORY -.->|"builds at startup<br/>(N instances)"| SUBAPP
+    FACTORY -.->|"publishes cards"| DISC
+
+    classDef external fill:#f5f5f5,stroke:#999,stroke-dasharray: 3 3
+    class IN,BACKEND,DISC external
+    classDef startup fill:#fafafa,stroke:#bbb,stroke-dasharray: 4 3
+    class FACTORY startup
+    classDef shared fill:#f0f7ff,stroke:#4a7fb0,stroke-width:2px
+    class CS shared
 ```
 
-### Component Diagram
+**Multi-path routing.** A2A maps 1:1 between a server and an agent card. To host N agents on one server, the parent FastAPI app mounts each agent's A2A sub-app at a unique path. Each sub-app has its own `DefaultRequestHandler`, `Executor`, and `InMemoryTaskStore`. The `ContextStore` is the only piece shared across sub-apps — context IDs are naturally scoped per-agent because tasks are sent to different A2A endpoints.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                    CLI Client (primary, built first)                          │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Commands                                                              │   │
-│  │  • fin-assist serve          — start agent hub server                 │   │
-│  │  • fin-assist agents         — list available agents                  │   │
-│  │  • fin-assist do "prompt"    — one-shot query (default_agent)         │   │
-│  │  • fin-assist do --agent <name> "prompt" — one-shot to named agent   │   │
-│  │  • fin-assist do --edit      — open input panel pre-filled with prompt│   │
-│  │  • fin-assist do             — no prompt → opens input panel         │   │
-│  │  • fin-assist talk           — multi-turn session (default_agent)    │   │
-│  │  • fin-assist talk --agent <name> — multi-turn with named agent     │   │
-│  │  • @-completion in FinPrompt injects context (files, git, etc.)      │   │
-│  ├──────────────────────────────────────────────────────────────────────┤   │
-│  │  REPL Mode (second layer)                                             │   │
-│  │  • fin-assist (no args)      — enter interactive REPL                 │   │
-│  │  • /exit                      — exit REPL                            │   │
-│  │  • /help                      — show available commands               │   │
-│  │  • /sessions                  — list saved sessions                   │   │
-│  │  • Dynamic prompts from agent card metadata                          │   │
-│  ├──────────────────────────────────────────────────────────────────────┤   │
-│  │  A2A Client (httpx + a2a-sdk ClientFactory)                           │   │
-│  │  • Discovers agent cards, sends SendMessage / SendStreamingMessage    │   │
-│  │  • Reads AgentCardMeta to adapt display (one-shot vs multi-turn)     │   │
-│  │  • Token-by-token streaming via SSE with Rich Live rendering          │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────┬───────────────────────────────────────────┘
-                                  │  A2A Protocol (HTTP + JSON-RPC)
-                                  ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                    Agent Hub (FastAPI parent ASGI app)                       │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Hub App (hub/app.py)                                                 │   │
-│  │  • Mounts N agent sub-apps at /agents/{name}/                        │   │
-│  │  • GET /agents — discovery (lists all agent card URLs + metadata)    │   │
-│  │  • GET /health — health check                                        │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Agent Factory (hub/factory.py)                                       │   │
-│  │  • AgentSpec → PydanticAIBackend → Executor + DefaultRequestHandler   │   │
-│  │  • Maps AgentCardMeta → AgentExtension(uri="fin_assist:meta")        │   │
-│  │  • Creates InMemoryTaskStore per agent sub-app                       │   │
-│  │  • Shares ContextStore across all sub-apps                           │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Mounted A2A Sub-Apps (one per agent)                                 │   │
-│  │  ┌──────────────────────────────────────────────────────────────┐   │   │
-│  │  │ /agents/{name}/  (one per enabled config entry)             │   │   │
-│  │  │  • AgentSpec from [agents.<name>] config section            │   │   │
-│  │  │  • Serving modes, tools, approval policy from config        │   │   │
-│  │  └──────────────────────────────────────────────────────────────┘   │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Storage                                                               │   │
-│  │  • Task storage: InMemoryTaskStore (a2a-sdk, per sub-app, ephemeral)  │   │
-│  │  • Context storage: SQLite ContextStore (hub/context_store.py)        │   │
-│  │    — single instance, shared across sub-apps; context_id scoped       │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Agent System                                                         │   │
-│  │  ┌────────────────────────────────────────────────────────────────┐  │   │
-│  │  │  AgentSpec (pure config) + AgentBackend protocol               │  │   │
-│  │  │  • AgentSpec: name, system_prompt (registry), output_type        │  │   │
-│  │  │    (registry), agent_card_metadata, credentials — all from TOML │  │   │
-│  │  │  • PydanticAIBackend (only backend impl): pydantic-ai Agent +    │  │   │
-│  │  │    FallbackModel; framework isolation for testability            │  │   │
-│  │  └────────────────────────────────────────────────────────────────┘  │   │
-│  │  AgentSpec instances created from config.agents (TOML sections)      │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-│                                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────┐   │
-│  │  Shared Services                                                      │   │
-│  │  • CredentialStore — env var → file → keyring fallback              │   │
-│  │  • ConfigLoader — file discovery: explicit > FIN_CONFIG_PATH >      │   │
-│  │    ./config.toml > ~/.config/fin/config.toml;                        │   │
-│  │    source precedence: init args > env (FIN_*) > TOML > defaults     │   │
-│  │  • ProviderRegistry — pydantic-ai provider/model creation,          │   │
-│  │    api_key passed per create_model() call                           │   │
-│  │                                                                       │   │
-│  │  ContextProviders — wired as model-driven tools via                   │   │
-│  │  `create_default_registry()`: files, git, history, environment       │   │
-│  └──────────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────┘
-                               │
-                               ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                  Future Clients                                               │
-│  ┌──────────────┐  ┌──────────────────┐  ┌────────────────────────────┐   │
-│  │ TUI Client   │  │ Multiplexer      │  │ Fish Plugin                │   │
-│  │ (Textual)    │  │ (tmux/zellij)    │  │ (keybinding + insertion)   │   │
-│  └──────────────┘  └──────────────────┘  └────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────┘
+```text
+Parent FastAPI App (127.0.0.1:4096)
+├── GET  /agents                                    → discovery (list all agents)
+├── GET  /health                                    → health check
+└── Mount /agents/{name}/                           → AgentSpec([agents.<name>]) A2A sub-app
+    ├── GET  /.well-known/agent-card.json           → agent card
+    └── POST /                                      → JSON-RPC (SendMessage, GetTask, SendStreamingMessage)
 ```
 
----
+## Backend layer
 
-## Directory Structure
+How the Executor reaches the LLM.
 
-```
-fin-assist/
-├── src/
-│   └── fin_assist/
-│       ├── __init__.py
-│       ├── __main__.py              # CLI entry: `fin-assist [serve|agents|do|talk|list]`
-│       ├── providers.py             # ProviderMeta definitions
-│       │
-│       ├── hub/                     # Agent Hub server
-│       │   ├── __init__.py
-│       │   ├── app.py               # Parent FastAPI app, mounts agent sub-apps
-│       │   ├── factory.py           # AgentSpec → a2a-sdk route factories + DefaultRequestHandler
-│       │   ├── executor.py          # Executor (AgentExecutor) — streaming, auth-required, history
-│       │   ├── context_store.py     # SQLite-backed conversation history persistence
-│       │   ├── pidfile.py           # PID file management with fcntl locking
-│       │   └── logging.py           # Hub logging configuration (RotatingFileHandler)
-│       │
-│       ├── cli/                     # CLI client (primary client)
-│       │   ├── __init__.py
-│       │   ├── main.py              # Command dispatch (serve, agents, do, talk, stop)
-│       │   ├── client.py            # A2A client (a2a-sdk ClientFactory over httpx + streaming)
-│       │   ├── display.py           # Rich-based output formatting
-│       │   ├── server.py            # Auto-start hub, health polling, PID management
-│       │   └── interaction/         # Interactive CLI components
-│       │       ├── __init__.py
-│       │       ├── approve.py       # Approval widget (execute/cancel/add context)
-│       │       ├── chat.py          # Multi-turn chat loop (talk command)
-│       │       ├── prompt.py        # FinPrompt — prompt-toolkit (`@`-completion, slash commands)
-│       │       └── response.py      # Response rendering helpers
-│       │
-│       ├── agents/
-│       │   ├── __init__.py
-│       │   ├── spec.py              # AgentSpec — pure config, zero framework deps
-│       │   ├── backend.py           # AgentBackend protocol + PydanticAIBackend + StreamHandle
-│       │   ├── skills.py            # SkillDefinition, SkillCatalog, SkillLoader, SkillManager
-│       │   ├── results.py           # CommandResult and other result models
-│       │   ├── serialization.py     # wrap_payload / unwrap_payload for ContextStore serialization
-│       │   ├── step.py              # StepEvent, StepHandle — platform-level step event types
-│       │   ├── tools.py             # ToolRegistry, ToolDefinition, ApprovalPolicy, ApprovalRule, DeferredToolCall, create_default_registry
-│       │   ├── registry.py          # OUTPUT_TYPES, SYSTEM_PROMPTS
-│       │   ├── metadata.py          # AgentCardMeta, ServingMode, MissingCredentialsError
-│       │
-│       ├── llm/
-│       │   ├── __init__.py
-│       │   ├── model_registry.py   # Provider registry
-│       │   └── prompts.py          # System prompts (per agent)
-│       │
-│       ├── context/
-│       │   ├── __init__.py
-│       │   ├── base.py             # ContextProvider ABC, ContextItem
-│       │   ├── files.py            # FileFinder
-│       │   ├── git.py              # GitContext
-│       │   ├── history.py          # ShellHistory
-│       │   └── environment.py      # Environment context
-│       │
-│       ├── credentials/
-│       │   ├── __init__.py
-│       │   └── store.py            # Credential storage + keyring
-│       │
-│       ├── config/
-│       │   ├── __init__.py
-│       │   ├── loader.py           # Load config.toml
-│       │   └── schema.py           # Config dataclasses
-│       │
-│       ├── ui/                     # TUI Client (Textual) — future
-│       │   ├── __init__.py
-│       │   ├── app.py              # Textual App
-│       │   ├── prompt_input.py     # Text area for input
-│       │   ├── agent_output.py     # Output display
-│       │   ├── agent_selector.py   # Agent switcher
-│       │   ├── model_selector.py   # Provider/model dropdown
-│       │   ├── thinking_selector.py # Thinking effort selector
-│       │   ├── settings_screen.py  # Settings modal
-│       │   └── connect.py          # /connect dialog
-│       │
-│       ├── multiplexer/            # Future: tmux/zellij integration
-│       │   └── ...
-│       │
-│       └── mcp/                    # Future: MCP client integration
-│           └── ...
-│
-├── tests/
-│   ├── conftest.py
-│   ├── test_package.py
-│   ├── test_config.py
-│   ├── test_agents/
-│   ├── test_context/
-│   ├── test_credentials/
-│   ├── test_llm/
-│   ├── test_ui/
-│   ├── test_hub/                   # Agent Hub tests
-│   └── test_cli/                   # CLI client tests
-│
-├── fish/                           # Fish shell plugin (future)
-│   ├── conf.d/
-│   │   └── fin_assist.fish
-│   └── functions/
-│       └── fin_assist.fish
-│
-├── pyproject.toml
-├── justfile
-├── devenv.nix
-├── devenv.yaml
-├── treefmt.toml
-├── .envrc
-├── .gitignore
-├── secretspec.toml
-└── docs/
-    └── architecture.md
+```mermaid
+graph TD
+    EXEC["Executor<br/>(from hub)"]
+
+    subgraph BACKEND_GRP["Backend Layer"]
+        BEH["«protocol» AgentBackend"]
+        PAI["PydanticAIBackend<br/>pydantic-ai Agent · FallbackModel"]
+        SH["StreamHandle<br/>async iter (deltas) + result()"]
+        MCE["MissingCredentialsError<br/>raised when API key absent"]
+    end
+
+    subgraph SPEC_GRP["Agent Specification"]
+        SPEC["AgentSpec<br/>pure config · zero framework deps"]
+    end
+
+    subgraph SHARED["Shared Services"]
+        CREDS["CredentialStore<br/>env → file → keyring"]
+        CONFIG["ConfigLoader<br/>TOML + env (FIN_*)<br/>pydantic-settings"]
+        REG["ProviderRegistry<br/>LLM providers · api_key injected"]
+    end
+
+    LLM["LLM Providers<br/>Anthropic · OpenAI · OpenRouter · Google"]
+
+    EXEC --> BEH
+    BEH -.->|"implemented by"| PAI
+    PAI --> SH
+    PAI -->|"create_model(provider, api_key)"| REG
+    REG --> LLM
+    PAI --> SPEC
+    PAI -.->|"raises on missing key"| MCE
+    SPEC -->|"get_api_key(provider)"| CREDS
+    SPEC --> CONFIG
+
+    classDef external fill:#f5f5f5,stroke:#999,stroke-dasharray: 3 3
+    class EXEC,LLM external
+    classDef error fill:#fff3f3,stroke:#c66
+    class MCE error
 ```
 
----
+**Spec/backend split.** fin-assist splits "what the agent is" from "how it runs":
 
-## Key Interfaces
+- **`AgentSpec`** (`src/fin_assist/agents/spec.py`) — a pure configuration object. Zero framework imports. Answers "what is this agent's system prompt?", "what's its output type?", "what metadata goes on its agent card?". Constructed from an `AgentConfig` (TOML section), the global `Config`, and a `CredentialStore`.
+- **`AgentBackend`** (`src/fin_assist/agents/backend.py`) — a `Protocol` that says how to actually run a spec: stream output, convert A2A messages to framework messages, serialize history, check credentials. The only production implementation is `PydanticAIBackend`, which wraps `pydantic_ai.Agent` + `FallbackModel`.
 
-### Agent Card Metadata (UI Hints)
+The `Executor` (`src/fin_assist/hub/executor.py`) depends on the `AgentBackend` protocol. `AgentSpec` is never imported by the executor — it flows through the backend. This isolates pydantic-ai to one file, so swapping LLM frameworks (or stubbing for tests) touches only `backend.py`.
 
-Static metadata declared by each agent and published in the A2A agent card as an extension. Clients read this to adapt their UI without knowing about specific agent types.
+> **Why no ABC on `AgentSpec`?** There is only one implementation. An ABC with a single impl is ceremony. If we ever need a type bound for DI/mocking, `typing.Protocol` supports structural subtyping without inheritance. A Rust/Gleam agent would not subclass a Python ABC — it would serve its own A2A endpoint over HTTP. The interop boundary is the A2A protocol, not Python inheritance.
 
-```python
-from typing import Literal
-from pydantic import BaseModel
+## Key types
 
-ServingMode = Literal["do", "talk"]
-
-class AgentCardMeta(BaseModel):
-    """Static UI/capability metadata published in the agent card.
-
-    Clients read these fields to determine which UI elements to show/hide.
-    """
-    serving_modes: list[ServingMode] = ["do", "talk"]  # Which CLI modes this agent supports
-    supports_thinking: bool = True       # Show thinking effort selector?
-    supports_model_selection: bool = True # Show model/provider selector?
-    supported_providers: list[str] | None = None  # None = all providers
-    supported_context_types: list[str] = Field(default_factory=list)  # Context types this agent can use
-    color_scheme: str | None = None      # Optional theming hint for client
-    tags: list[str] = Field(default_factory=list)  # Categorization tags
-```
-
-> **Note:** `serving_modes` replaces the former `multi_turn: bool` field. An agent with `serving_modes = ["do"]` is one-shot only (like the former ShellAgent). An agent with `serving_modes = ["talk"]` is multi-turn only. `["do", "talk"]` covers both modes.
-
-> **Phase 11 (TUI client):** `supported_context_types: list[str]` is now part of `AgentCardMeta` so the TUI can show/hide context panels (git diff, shell history, etc.) based on the active agent without a round-trip call. `AgentSpec.supports_context()` already encodes this logic at runtime — the metadata field makes it statically discoverable from the agent card.
-
-### Agent Architecture
-
-fin-assist splits "what the agent is" from "how it runs" across two cooperating pieces:
-
-- **`AgentSpec`** (`src/fin_assist/agents/spec.py`) — a pure configuration object. Zero framework imports (no pydantic-ai, no a2a-sdk). Answers questions like "what is this agent's system prompt?", "what's its output type?", "which providers does it need?", "what metadata goes on its agent card?". Constructed from an `AgentConfig` (TOML section), the global `Config`, and a `CredentialStore`.
-- **`AgentBackend`** (`src/fin_assist/agents/backend.py`) — a `Protocol` that says how to actually run a spec: stream output, convert A2A messages to framework messages, serialize conversation history, check credentials. The only production implementation is `PydanticAIBackend`, which wraps `pydantic_ai.Agent` + `FallbackModel`.
-
-The `Executor` (`src/fin_assist/hub/executor.py`) depends on the `AgentBackend` protocol. `AgentSpec` is never imported by the executor — it flows through the backend. This lets us swap in different LLM frameworks (or stub backends for testing) without touching the hub.
-
-#### AgentSpec
+### `AgentSpec`
 
 ```python
 class AgentSpec:
@@ -385,10 +168,10 @@ class AgentSpec:
     @property
     def description(self) -> str: ...
     @property
-    def system_prompt(self) -> str:        # resolved via SYSTEM_PROMPTS registry
+    def system_prompt(self) -> str:        # via SYSTEM_PROMPTS registry
         ...
     @property
-    def output_type(self) -> type[Any]:    # resolved via OUTPUT_TYPES registry
+    def output_type(self) -> type[Any]:    # via OUTPUT_TYPES registry
         ...
     @property
     def thinking(self) -> ThinkingEffort | None: ...
@@ -397,7 +180,7 @@ class AgentSpec:
     @property
     def agent_card_metadata(self) -> AgentCardMeta: ...
     @property
-    def tools(self) -> list[str]: ...        # derived from skill union
+    def tools(self) -> list[str]: ...      # derived from skill union
 
     def check_credentials(self) -> list[str]:
         """Names of enabled providers with missing API keys (empty = all present)."""
@@ -406,7 +189,7 @@ class AgentSpec:
     def get_enabled_providers(self) -> list[str]: ...
 ```
 
-#### AgentBackend protocol
+### `AgentBackend`
 
 ```python
 @runtime_checkable
@@ -425,164 +208,27 @@ class AgentBackend(Protocol):
 
 `StreamHandle` yields text deltas via async iteration and returns a `RunResult(output, serialized_history, new_message_parts)` from `result()`.
 
-#### PydanticAIBackend
+### `AgentCardMeta`
+
+Static metadata declared by each agent and published in the A2A agent card as an extension. Clients read this to adapt their UI without knowing about specific agent types.
 
 ```python
-class PydanticAIBackend:
-    """AgentBackend implementation for pydantic-ai."""
+ServingMode = Literal["do", "talk"]
 
-    def __init__(self, *, agent_spec: AgentSpec) -> None:
-        self._spec = agent_spec
-
-    # Raises MissingCredentialsError if any required API key is absent.
-    def run_stream(self, *, messages: list[Any], model: Any = None) -> StreamHandle: ...
+class AgentCardMeta(BaseModel):
+    """Static UI/capability metadata published in the agent card."""
+    serving_modes: list[ServingMode] = ["do", "talk"]
+    supports_thinking: bool = True
+    supports_model_selection: bool = True
+    supported_providers: list[str] | None = None    # None = all providers
+    supported_context_types: list[str] = []
+    color_scheme: str | None = None
+    tags: list[str] = []
 ```
 
-> **Why the split?** `AgentSpec` stays trivially testable and stays a candidate for serialization or cross-process transport. The backend layer isolates every pydantic-ai dependency to one file, so replacing the framework — or mocking it for tests — touches only `backend.py`.
+### Output type registry
 
-> **Why no ABC on `AgentSpec`?** There is only one implementation. An ABC with a single impl is ceremony. If we ever need a type bound for DI/mocking, `typing.Protocol` supports structural subtyping without requiring inheritance. A Rust/Gleam agent would not subclass a Python ABC — it would serve its own A2A endpoint over HTTP. The interop boundary is the A2A protocol, not Python inheritance.
-
-### Agent Variants (Config-Driven)
-
-Agents are defined entirely in `config.toml`, not as separate Python classes. A single `AgentSpec` class reads its behavior from `AgentConfig`. There are no built-in agents — every agent is a config entry.
-
-> **Context gathering** works via two paths: **model-driven** (ContextProviders wired as tools through `create_default_registry()`, so the agent can request context during execution) and **user-driven** (`@`-completion in FinPrompt, so the user injects context into the prompt before sending).
-
-#### Current Agent: `test` (`[agents.test]`)
-
-- **Purpose**: Development test agent with file, shell, and git tools
-- **Config**: `system_prompt = "test"`, `output_type = "text"`, `serving_modes = ["do", "talk"]`, `thinking = "medium"`
-- **Skills**: `files`, `git`, `history`, `shell` — each with its own tools and approval rules
-- **Output**: `str` (free-form text response)
-
-#### SDD Agent (`[agents.sdd]`) — future
-
-- **Purpose**: Architectural brainstorming and design
-- **Config**: `enabled = false`, `system_prompt = "sdd"`, `output_type = "text"`, `serving_modes = ["talk"]`
-- **Output**: Free-form text (SketchResult structured output in future)
-
-#### TDD Agent (`[agents.tdd]`) — future
-
-- **Purpose**: Directed implementation with test generation
-- **Config**: `enabled = false`, `system_prompt = "tdd"`, `output_type = "text"`, `serving_modes = ["talk"]`
-- **Output**: Free-form text (TDDResult structured output in future)
-
-### Agent Config (TOML)
-
-```toml
-[general]
-default_agent = "test"
-
-[agents.test]
-description = "Development test agent with file, shell, and git tools."
-system_prompt = "test"
-output_type = "text"
-thinking = "medium"
-serving_modes = ["do", "talk"]
-```
-
-### Git Agent (`[agents.git]`)
-
-The git agent is the first real end-user agent and the first to use **scoped CLI tools** and **skills**.
-
-- **Purpose**: Git workflows — commit, PR, summarize
-- **Config**: `system_prompt = "git"`, `output_type = "text"`, `serving_modes = ["do"]`
-- **Skills**: `git`, `gh`, `commit`, `pr`, `summarize` — each with its own tools and prompt steering
-- **Output**: `str` (free-form text response)
-
-#### Scoped CLI Tools
-
-Instead of per-subcommand tool wrappers (`git_diff`, `git_log`), the platform provides **scoped CLI tools** that wrap a command prefix:
-
-| Tool | Prefix | Approval | Description |
-|------|--------|----------|-------------|
-| `git` | `git` | Per-skill rules | Run any git subcommand |
-| `gh` | `gh` | Per-skill rules | Run any GitHub CLI subcommand |
-
-The LLM chooses the subcommand/args — one tool definition per CLI instead of one per subcommand. This saves prompt tokens and maps naturally to the **API + CLI + Skills** pattern.
-
-#### Skills
-
-Skills are the primary mechanism for organizing agent behavior. Each skill bundles tools, context injection text, and prompt steering. Skills are loaded additively — the agent sees a catalog and calls `load_skill(name)` to activate them, or they can be pre-loaded via the `--skill` CLI flag, positional syntax (`fin do git commit`), or the `/skill:<name>` REPL command. Approval policies are defined at the agent level via `tool_policies`.
-
-```toml
-[agents.git.skills.commit]
-description = "Generate a conventional commit message from current changes."
-tools = ["git", "read_file"]
-prompt_template = "git-commit"
-entry_prompt = "Analyze the current staged and unstaged changes and generate a conventional commit message."
-```
-
-- `fin do git commit` → agent=git, skill=commit (entry_prompt sent as user message, prompt_template injected as context)
-- `fin do git --skill commit` → same, explicit skill flag
-- `fin do git` → agent=git, no skill (LLM routes based on user input, may call `load_skill` from catalog)
-
-```toml
-[agents.test]
-system_prompt = "test"
-output_type = "text"
-thinking = "medium"
-serving_modes = ["do", "talk"]
-
-[agents.test.skills.files]
-description = "Read files from the workspace."
-tools = ["read_file"]
-
-[agents.test.skills.git]
-description = "Git commands with per-subcommand approval."
-tools = ["git"]
-
-[agents.git]
-system_prompt = "git"
-output_type = "text"
-thinking = "medium"
-serving_modes = ["do"]
-base_tools = ["read_file"]
-
-[agents.git.tool_policies.git]
-default = "always"
-rules = [
-  { pattern = "git diff*", mode = "never" },
-  { pattern = "git status*", mode = "never" },
-  { pattern = "git log*", mode = "never" },
-  { pattern = "git add*", mode = "never" },
-  { pattern = "git commit*", mode = "never" },
-]
-
-[agents.git.tool_policies.gh]
-default = "always"
-rules = [
-  { pattern = "gh pr view*", mode = "never" },
-  { pattern = "gh pr list*", mode = "never" },
-]
-
-[agents.git.skills.git]
-description = "Git commands with per-subcommand approval."
-tools = ["git"]
-
-[agents.git.skills.commit]
-description = "Generate a conventional commit message from current changes."
-tools = ["git", "read_file"]
-prompt_template = "git-commit"
-entry_prompt = "Analyze the current staged and unstaged changes and generate a conventional commit message."
-
-[agents.git.skills.pr]
-description = "Create a pull request from current branch to main."
-tools = ["git", "gh", "read_file"]
-prompt_template = "git-pr"
-entry_prompt = "Analyze the current branch changes and create a pull request."
-
-[agents.git.skills.summarize]
-description = "Summarize current changes without executing any commands."
-tools = ["git", "read_file"]
-prompt_template = "git-summarize"
-entry_prompt = "Summarize the current staged and unstaged changes."
-serving_modes = ["do", "talk"]
-```
-
-### Output Type Registry
-
-Maps config names to Python types, enabling TOML to reference types by name:
+Maps config names to Python types so TOML can reference types by name:
 
 ```python
 OUTPUT_TYPES: dict[str, type] = {
@@ -591,7 +237,7 @@ OUTPUT_TYPES: dict[str, type] = {
 }
 ```
 
-### Prompt Registry
+### Prompt registry
 
 Maps config names to prompt constants:
 
@@ -607,25 +253,43 @@ SYSTEM_PROMPTS: dict[str, str] = {
 }
 ```
 
-### Agent Hub
-
-The hub is a module-level factory function, not a class. `create_hub_app()` builds the parent FastAPI app, constructs a single shared `ContextStore`, and mounts one sub-app per enabled agent via `AgentFactory`.
+### `ContextProvider`
 
 ```python
-# src/fin_assist/hub/app.py
-from fastapi import FastAPI
+@dataclass
+class ContextItem:
+    id: str
+    type: Literal["file", "git_diff", "git_log", "git_status", "history", "env"]
+    content: str
+    metadata: dict[str, object]
+    status: ItemStatus = "ready"
+    error_reason: str | None = None
 
-from fin_assist.agents.spec import AgentSpec
-from fin_assist.hub.context_store import ContextStore
-from fin_assist.hub.factory import AgentFactory
+class ContextProvider(ABC):
+    @abstractmethod
+    def search(self, query: str) -> list[ContextItem]: ...
+    @abstractmethod
+    def get_item(self, id: str) -> ContextItem | None: ...
+    @abstractmethod
+    def get_all(self) -> list[ContextItem]: ...
+```
 
+Context gathering works two ways:
+
+- **Model-driven** — `ContextProvider`s are wired as tools via `create_default_registry()`, so the agent can request context during execution.
+- **User-driven** — `@`-completion in `FinPrompt` injects context into the prompt before sending (`@file:path`, `@git:diff`, `@history:query`).
+
+## Hub factory
+
+`create_hub_app()` builds the parent FastAPI app, constructs a single shared `ContextStore`, and mounts one sub-app per enabled agent via `AgentFactory`:
+
+```python
 def create_hub_app(
     config: Config,
     credentials: CredentialStore,
     *,
     db_path: Path,
 ) -> FastAPI:
-    """Build the parent FastAPI app with all enabled agent sub-apps mounted."""
     app = FastAPI(title="fin-assist Agent Hub")
     context_store = ContextStore(db_path=db_path)          # shared across sub-apps
     factory = AgentFactory(context_store=context_store)
@@ -651,121 +315,52 @@ def create_hub_app(
     return app
 ```
 
-### Agent Factory
+`AgentFactory.create_a2a_app(spec)` builds the agent card with an `AgentExtension(uri="fin_assist:meta")` carrying `AgentCardMeta`, constructs a `PydanticAIBackend` wrapping the spec, builds an `Executor` consuming the backend, creates a per-sub-app `InMemoryTaskStore`, and wires through `DefaultRequestHandler`. The result is a FastAPI sub-app with the a2a-sdk JSON-RPC + agent-card routes mounted.
 
-```python
-# src/fin_assist/hub/factory.py
-class AgentFactory:
-    """Translates AgentSpec into a FastAPI sub-app with a2a-sdk route factories."""
+## Request flow overview
 
-    def __init__(self, context_store: ContextStore) -> None:
-        self._context_store = context_store               # shared, not per-agent
+Structural overview of a `SendStreamingMessage` call. The fully instrumented version with tracing spans, HITL pause/resume, and approval flow lives in [`tracing.md`](tracing.md#instrumented-request-flow).
 
-    def create_a2a_app(
-        self,
-        agent: AgentSpec,
-        *,
-        base_url: str = "http://127.0.0.1:4096",
-    ) -> FastAPI:
-        """Build a FastAPI sub-app for a single agent.
+```mermaid
+sequenceDiagram
+    participant C as CLI Client
+    participant H as Agent Hub
+    participant E as Executor
+    participant B as AgentBackend
+    participant CS as ContextStore
+    participant LLM as LLM Provider
 
-        1. Build AgentCard with AgentExtension (fin_assist:meta) for metadata.
-        2. Construct PydanticAIBackend wrapping the spec.
-        3. Construct Executor (AgentBackend consumer) + per-sub-app InMemoryTaskStore.
-        4. Wire through DefaultRequestHandler.
-        5. Mount a2a-sdk route factories (JSON-RPC + agent card).
-        """
-        backend = PydanticAIBackend(agent_spec=agent)
-        executor = Executor(backend=backend, context_store=self._context_store)
-        task_store = InMemoryTaskStore()                  # per sub-app, ephemeral
-        request_handler = DefaultRequestHandler(
-            agent_executor=executor,
-            task_store=task_store,
-            agent_card=agent_card,
-        )
+    C->>H: SendStreamingMessage (JSON-RPC + SSE)
+    H->>E: execute(context, event_queue)
+    E->>B: check_credentials()
+    B-->>E: [] (or raise MissingCredentialsError)
 
-        app = FastAPI(title=f"fin-assist: {agent.name}")
-        app.routes.extend(create_agent_card_routes(agent_card))
-        app.routes.extend(create_jsonrpc_routes(request_handler, rpc_url="/"))
-        return app
+    E->>CS: load(context_id)
+    CS-->>E: prior history bytes (or None)
+    E->>B: deserialize + convert history
+
+    E->>B: run_stream(messages)
+    B->>LLM: (provider call)
+
+    loop Token-by-token
+        B-->>E: text delta
+        E-->>H: updater.add_artifact(append=true)
+        H-->>C: SSE chunk
+    end
+
+    E->>B: await result()
+    B-->>E: RunResult (output, serialized_history)
+    E->>CS: save(context_id, serialized_history)
+    E-->>H: updater.complete() → COMPLETED
+    H-->>C: SSE: TaskStatusUpdateEvent (completed)
 ```
 
-### UI Metadata Flow
+## A2A protocol integration
 
-```
-Static (discovery time):                    Dynamic (per-response):
-┌──────────────────────┐                    ┌──────────────────────────┐
-│ Agent Card            │                    │ Task Artifact             │
-│ (/.well-known/        │                    │ (returned with each      │
-│  agent-card.json)     │                    │  task completion)        │
-│                       │                    │                          │
-│ • name, description  │                    │ • result data            │
-│ • skills[]           │                    │ • metadata: {            │
-│ • extensions: [      │                    │     accept_action: ...,  │
-│   {uri: "fin_assist:│                    │     suggested_next: ..., │
-│    meta", params: {  │                    │   }                      │
-│       serving_modes, │                    │   }                      │
-│       thinking,      │                    │                          │
-│       model_select,  │                    └──────────────────────────┘
-│       color_scheme,  │
-│       supported_     │
-│       context_types  │
-│     }                │
-│   }                  │
-└──────────────────────┘
-```
-
-### Context Provider Interface
-
-```python
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import Literal, object
-
-@dataclass
-class ContextItem:
-    id: str
-    type: Literal["file", "git_diff", "git_log", "git_status", "history", "env"]
-    content: str
-    metadata: dict[str, object]
-    status: ItemStatus = "ready"
-    error_reason: str | None = None
-
-class ContextProvider(ABC):
-    @abstractmethod
-    def search(self, query: str) -> list[ContextItem]: ...
-
-    @abstractmethod
-    def get_item(self, id: str) -> ContextItem | None: ...
-
-    @abstractmethod
-    def get_all(self) -> list[ContextItem]: ...
-```
-
-### Multiplexer Interface (future)
-
-```python
-class Multiplexer(ABC):
-    @classmethod
-    @abstractmethod
-    def is_available(cls) -> bool: ...
-
-    @abstractmethod
-    def launch_floating(self, command: list[str]) -> None: ...
-
-    @abstractmethod
-    def capture_context(self) -> str | None: ...
-```
-
----
-
-## A2A Protocol Integration
-
-### Background
-
-**A2A (Agent-to-Agent)** is an open protocol (originated by Google) for standardized agent communication. **a2a-sdk v1.0** is Google's official Python SDK, supporting JSON-RPC, REST, and gRPC transports from a single protobuf schema.
+A2A is an open protocol (originated by Google) for standardized agent communication. **a2a-sdk v1.0** is Google's official Python SDK, supporting JSON-RPC, REST, and gRPC transports from a single protobuf schema.
 
 Key benefits for fin-assist:
+
 - **Standardized interface** — any A2A-compatible client can talk to the server
 - **Agent discovery** — Agent Cards at `/.well-known/agent-card.json` per agent
 - **Task lifecycle** — built-in task state management (submitted, working, completed, failed, auth-required, canceled)
@@ -774,691 +369,91 @@ Key benefits for fin-assist:
 - **Streaming** — `SendStreamingMessage` method delivers token-by-token SSE output
 - **Auth-required state** — first-class `TaskState.TASK_STATE_AUTH_REQUIRED` for credential-gated agents
 
-### Multi-Path Routing
+### a2a-sdk v1.0 components
 
-The A2A protocol maps 1:1 between a server and an agent card. To host N agents on one server, we use **multi-path routing**: a parent FastAPI app mounts each agent's A2A sub-app at a unique path.
+- **`DefaultRequestHandler`** — routes JSON-RPC methods to the executor.
+- **`Executor`** — implements `AgentExecutor` with `execute()` and `cancel()`. Framework-agnostic: depends on the `AgentBackend` protocol. Owns streaming loop, auth-required detection, and context persistence.
+- **`TaskUpdater`** — SDK helper for state transitions (`start_work`, `complete`, `failed`, `requires_auth`, `add_artifact`).
+- **`InMemoryTaskStore`** — ephemeral task storage managed by the SDK (tasks are lost on server restart).
+- **`ContextStore`** — fin-assist's own SQLite-backed store for pydantic-ai conversation history, persisted across tasks within a conversation.
+- **`AgentExtension`** — publishes `AgentCardMeta` as a proper extension (`uri="fin_assist:meta"`) in the agent card's capabilities.
 
-```
-Parent FastAPI App (127.0.0.1:4096)
-├── GET  /agents                                    → discovery (list all agents)
-├── GET  /health                                    → health check
-├── Mount /agents/{name}/                    → AgentSpec([agents.<name>]) A2A sub-app
-│   ├── GET  /.well-known/agent-card.json           → agent card
-│   └── POST /                                      → JSON-RPC (SendMessage, GetTask, SendStreamingMessage)
-```
-
-Each agent maintains its own context and conversation state. Context IDs are naturally scoped per-agent because tasks are sent to different A2A endpoints.
-
-### a2a-sdk v1.0 Components
-
-- **DefaultRequestHandler** — routes JSON-RPC methods to the executor. Replaces the former `InMemoryBroker`.
-- **Executor** — implements `AgentExecutor` with `execute()` and `cancel()`. Framework-agnostic: it depends on an `AgentBackend` protocol (currently `PydanticAIBackend`) that handles model building, streaming, message conversion, and history serialization. The Executor owns streaming loop, auth-required detection, and context persistence. Replaces the former `FinAssistWorker`.
-- **TaskUpdater** — SDK helper for state transitions (`start_work`, `complete`, `failed`, `requires_auth`, `add_artifact`).
-- **InMemoryTaskStore** — ephemeral task storage managed by the SDK (tasks are lost on server restart).
-- **ContextStore** — our own SQLite-backed store for pydantic-ai conversation history, persisted across tasks within a conversation.
-- **AgentExtension** — publishes `AgentCardMeta` as a proper extension (`uri="fin_assist:meta"`) in the agent card's capabilities, replacing the former `Skill(id="fin_assist:meta")` hack.
-
-### Transport Layer
+### Transport
 
 The A2A protocol defines transport as pluggable. a2a-sdk v1.0 supports JSON-RPC, REST, and gRPC transports from the same protobuf schema. The v1.0 JSON-RPC method names are PascalCase (`SendMessage`, `GetTask`, `CancelTask`, `SendStreamingMessage`) and require the `A2A-Version: 1.0` header.
 
-**Current:** JSON-RPC over HTTP (blocking `SendMessage`) + SSE streaming (`SendStreamingMessage`).
-
-**Modality roadmap:**
-
 | Modality | Transport | Status | Notes |
-|---|---|---|---|
-| Blocking `SendMessage` | JSON-RPC | ✅ Implemented | Hub responds inline when agent finishes |
-| Streaming `SendStreamingMessage` | JSON-RPC SSE | ✅ Implemented | Token-by-token via `TaskUpdater.add_artifact(append=True)` |
-| Non-blocking + polling | JSON-RPC | Later phase | `SendMessage` with `blocking: false`; `_poll_task` fallback exists |
+|----------|-----------|--------|-------|
+| Blocking `SendMessage` | JSON-RPC | Implemented | Hub responds inline when agent finishes |
+| Streaming `SendStreamingMessage` | JSON-RPC SSE | Implemented | Token-by-token via `TaskUpdater.add_artifact(append=True)` |
+| Non-blocking + polling | JSON-RPC | Open | `_poll_task` fallback exists in `cli/client.py` but unused |
 | gRPC | gRPC | Future | Protocol-native; a2a-sdk v1.0 supports it |
 
-The non-blocking polling path is implemented in `cli/client.py` (`_poll_task`)
-as a correct protocol fallback, but is not exercised by the current hub
-which defaults to blocking mode.
+## CLI entry points
 
-### CLI Entry Points
-
-```
+```text
 fin-assist serve                        → start agent hub on 127.0.0.1:4096
 fin-assist agents                       → list available agents (GET /agents)
-fin-assist do "prompt"                  → one-shot query to default_agent from config
-fin-assist do --agent <name> "prompt"   → one-shot query to named agent
-fin-assist do --skill <name> "prompt"   → one-shot query with a skill pre-loaded
+fin-assist do "prompt"                  → one-shot to default_agent from config
+fin-assist do --agent <name> "prompt"   → one-shot to named agent
+fin-assist do --skill <name> "prompt"   → one-shot with a skill pre-loaded
+fin-assist do <agent> <skill>           → positional skill (e.g. fin do git commit)
 fin-assist do --edit                    → open input panel pre-filled with prompt
 fin-assist do                           → no prompt → opens input panel
 fin-assist talk                         → multi-turn session with default_agent
-fin-assist talk --agent <name>          → multi-turn session with named agent
-fin-assist talk --skill <name>          → multi-turn session with a skill pre-loaded
-fin-assist talk --agent <name> --resume <id>   → resume a saved session
-fin-assist talk --agent <name> --list          → list saved sessions for agent
-fin-assist do <agent> <skill>            → one-shot with positional skill (e.g. fin do git commit)
-fin-assist list tools|skills|prompts|output-types     → list registry entries
+fin-assist talk --agent <name>          → multi-turn with named agent
+fin-assist talk --skill <name>          → multi-turn with a skill pre-loaded
+fin-assist talk --resume <id>           → resume a saved session
+fin-assist talk --list                  → list saved sessions for agent
+fin-assist list tools|skills|prompts|output-types  → list registry entries
+```
 
 REPL commands (during multi-turn chat):
-  /skills         → list available skills for the current agent
-  /skill:<name>   → load a skill mid-session (e.g. /skill:commit)
-  /exit           → end the conversation
-  /help           → show available commands
 
-Context injection: use @-completion in FinPrompt (e.g. @file:path, @git:diff) to inject
-context into prompts — replaces former --file/--git-diff/--git-log CLI flags.
+```text
+/skills          list available skills for the current agent
+/skill:<name>    load a skill mid-session (e.g. /skill:commit)
+/exit            end the conversation
+/help            show available commands
 ```
 
-Server lifecycle:
-- **Standalone**: `fin-assist serve` starts the hub server
-- **Auto-start**: `fin-assist do/talk/agents` auto-start the server if not running
+Context injection: `@`-completion in `FinPrompt` (e.g. `@file:path`, `@git:diff`) injects context into prompts before sending.
 
-### Local-Only Security
+**Server lifecycle.** `fin-assist serve` starts the hub standalone; `fin-assist do/talk/agents` auto-start the server if it's not running.
 
-The server binds to `127.0.0.1` by default, ensuring only local processes can communicate with agents. This is intentional — fin-assist is designed for personal use on a trusted machine.
+## UI metadata flow
 
----
-
-## Tracing & Observability
-
-fin-assist emits OpenTelemetry spans across two processes — the CLI and the hub — and joins them so one ``fin`` invocation reads as one browsable flow in Phoenix (or any OTLP-compatible backend).
-
-### Trace topology
-
-```
-CLI process                                Hub process
-━━━━━━━━━━━                                ━━━━━━━━━━━
-cli.do  (root, one per invocation)
-│   fin_assist.cli.invocation_id = <uuid>  (also in Baggage)
-│   fin_assist.cli.command = "do"
-│
-├── GET  /health                     ────► (hub: request span)
-├── GET  /agents                     ────► (hub: request span)
-├── GET  /agents/<name>              ────► (hub: request span)
-└── POST /agents/<name>/:send-msg    ────► POST /agents/<name>/:send-message
-                                              │
-                                              └── fin_assist.task
-                                                  fin_assist.cli.invocation_id = <uuid>  ← join key
-                                                  fin_assist.task.state = running|completed|failed|paused_for_approval
-                                                  ├── fin_assist.step
-                                                  │   ├── fin_assist.tool_execution
-                                                  │   └── running tool          (pydantic-ai)
-                                                  └── (LLM spans: gen_ai.*, llm.*)
+```text
+Static (discovery time):                    Dynamic (per-response):
+┌──────────────────────┐                    ┌──────────────────────────┐
+│ Agent Card            │                    │ Task Artifact             │
+│ /.well-known/         │                    │ (returned with each      │
+│  agent-card.json      │                    │  task completion)        │
+│                       │                    │                          │
+│ • name, description  │                    │ • result data            │
+│ • skills[]           │                    │ • metadata: {            │
+│ • extensions: [      │                    │     accept_action: ...,  │
+│   {uri: "fin_assist:│                    │     suggested_next: ..., │
+│    meta", params: {  │                    │   }                      │
+│       serving_modes, │                    │                          │
+│       thinking,      │                    └──────────────────────────┘
+│       model_select,  │
+│       color_scheme,  │
+│       supported_     │
+│       context_types  │
+│     }                │
+│   }                  │
+└──────────────────────┘
 ```
 
-**Why one CLI trace + one hub trace, not one shared trace_id**: HTTP boundaries already open fresh traces hub-side; making them share a ``trace_id`` would require suppressing the hub's natural request tracing, which would also suppress useful per-request timing data. Instead we join via ``fin_assist.cli.invocation_id`` (Baggage-propagated) — a single attribute lookup in Phoenix shows all spans across both processes for one invocation.
+## Local-only security
 
-### HITL pause/resume
+The server binds to `127.0.0.1` by default — only local processes can communicate with agents. This is intentional: fin-assist is designed for personal use on a trusted machine.
 
-Tool calls requiring human approval pause the hub task (``requires_input``) and the CLI waits for the user's y/N. The resume opens a *new* HTTP request → new hub trace → new ``fin_assist.task`` span. Continuity across the pause:
+## See also
 
-1. At pause, the hub executor emits ``fin_assist.approval_request`` (a zero-duration span — OTel spans cannot be reopened across processes, so the "wait" is represented implicitly by the time-gap between this span's end and the resumed trace's start).
-2. The executor persists the paused span's ``SpanContext`` + original ``user_input`` via ``ContextStore.save_pause_state``.
-3. At resume, the new task span carries a ``Link(resume_from_approval)`` back to the paused ``approval_request`` span, and emits ``fin_assist.approval_decided`` as its first child with a second ``Link(approval_for)`` to the same target.
-4. The CLI root span stays open across the approval wait (no 30-min timeout today — tracked as follow-up), and wraps the y/N prompt in a ``cli.approval_wait`` child so dashboards can subtract human think-time.
-
-In Phoenix the two hub traces appear as siblings, joined by the Link (rendered as "jump to related trace") and by the shared ``fin_assist.cli.invocation_id`` attribute. The CLI trace is a third sibling that contains both hub traces as link targets via its child HTTP spans.
-
-### Task state attribute
-
-``fin_assist.task.state`` (``running`` → ``completed`` / ``failed`` / ``paused_for_approval``) is the canonical Phoenix filter for task-level queries. One attribute with a small enum keeps queries simple — one equality check per state instead of a compound predicate across several booleans.
-
-### Noise suppression
-
-Two upstream instrumentors were disabled because they produce high-volume, low-value spans:
-
-* **a2a-sdk**'s ``@trace_class`` decorator wraps every internal queue / task-store method with a ``SpanKind.SERVER`` span. Disabled via ``OTEL_INSTRUMENTATION_A2A_SDK_ENABLED=false`` (vendor-supported env off-switch, set by ``setup_tracing`` via ``os.environ.setdefault`` so operators can re-enable for debugging).
-* **FastAPIInstrumentor**'s per-SSE-chunk ``http.response.body`` span. Dropped in the export pipeline by ``_DropSpansProcessor`` (key on ``asgi.event.type = "http.response.body"``, not on span name, so instrumentor-version renames don't break us).
-
-### Attribute hygiene
-
-Three classes of leaked/duplicate attributes are scrubbed at ``on_end`` before export:
-
-* ``logfire.*`` — pydantic-ai uses logfire as its internal tracing front-end; the ``logfire.msg`` / ``logfire.json_schema`` attrs ride along with no value for downstream consumers.
-* ``final_result`` on ``agent run`` spans — already duplicated as ``output.value`` (OpenInference) and ``pydantic_ai.all_messages``. Dropping saves ~5–30KB per trace.
-* Duplicate ``session.id`` when identical to ``fin_assist.context.id``.
-
-### Files
-
-* `src/fin_assist/hub/tracing.py` — vendor-agnostic TracerProvider builder (OTLP + JSONL file sink, plus drop + truncate + scrub processors).
-* `src/fin_assist/hub/tracing_attrs.py` — centralized attribute names and enum values (``FinAssistAttributes``, ``TaskStateValues``, ``SpanNames``).
-* `src/fin_assist/cli/tracing.py` — CLI-side tracer; ``cli_root_span`` / ``approval_wait_span`` context managers + ``HTTPXClientInstrumentor`` integration.
-* `src/fin_assist/agents/pydantic_ai_tracing.py` — pydantic-ai → OpenInference bridge (the one place that imports ``openinference.instrumentation.pydantic_ai``; kept isolated so the hub stays framework-neutral).
-
-## Configuration
-
-### Config File
-
-Config is loaded from the first available location:
-1. Explicit path (API parameter)
-2. `FIN_CONFIG_PATH` environment variable
-3. `./config.toml` (project-local override in current working directory)
-4. `~/.config/fin/config.toml` (user default)
-
-```toml
-[general]
-default_provider = "anthropic"
-default_model = "claude-sonnet-4-6"
-default_agent = "test"
-
-[server]
-host = "127.0.0.1"
-port = 4096
-db_path = "~/.local/share/fin/hub.db"  # SQLite storage
-
-[agents.test]
-description = "Development test agent with file, shell, and git tools."
-system_prompt = "test"
-output_type = "text"
-thinking = "medium"
-serving_modes = ["do", "talk"]
-
-[agents.test.skills.files]
-description = "Read files from the workspace."
-tools = ["read_file"]
-
-[agents.test.skills.git]
-description = "Git commands with per-subcommand approval."
-tools = ["git"]
-approval.default = "always"
-approval.rules = [
-  { pattern = "git diff*", mode = "never" },
-  { pattern = "git status*", mode = "never" },
-  { pattern = "git log*", mode = "never" },
-]
-
-[agents.test.skills.shell]
-description = "Execute arbitrary shell commands (requires approval)."
-tools = ["run_shell"]
-
-[providers.anthropic]
-# API key stored separately in credentials
-
-[providers.openrouter]
-# API key stored separately in credentials
-
-[providers.ollama]
-base_url = "http://localhost:11434"
-```
-
-### Credential Storage (~/.local/share/fin/credentials.json)
-
-Credentials stored separately from config (0600 permissions). Supports env var -> file -> keyring fallback chain.
-
----
-
-## Implementation Phases
-
-### Phase 1: Repo Setup ✅
-- [x] Initialize devenv (devenv.nix, devenv.yaml)
-- [x] Create pyproject.toml with dependencies
-- [x] Set up justfile with common tasks
-- [x] Configure treefmt.toml for formatting
-- [x] Add .gitignore, .envrc
-- [x] Create secretspec.toml for dev secrets
-- [x] Enable branch protections (PR requirement + no force push)
-
-### Phase 2: Core Package Structure ✅
-- [x] Create src/fin_assist/ package layout
-- [x] Add GitHub Actions CI workflow (using nix shell approach)
-- [x] Re-enable required status checks in branch protections
-- [x] Implement config loading (config/schema.py, config/loader.py)
-- [x] Set up pydantic settings
-
-### Phase 3: LLM Module ✅
-- [x] Integrate pydantic-ai for provider abstraction
-- [x] Implement Agent wrapper (llm/agent.py)
-- [x] Create provider registry (llm/providers.py)
-- [x] Write system prompts (llm/prompts.py)
-
-### Phase 4: Credential Management ✅
-- [x] Implement /connect command UI (ui/connect.py)
-- [x] Create credential store (credentials/store.py)
-- [x] Add optional OS keyring backend (credentials/keyring.py)
-
-### Phase 5: Context Module ✅
-- [x] Implement ContextProvider ABC (context/base.py)
-- [x] File finder with find (context/files.py)
-- [x] Git context gatherer (context/git.py)
-- [x] Fish history parser (context/history.py)
-- [x] Environment context (context/environment.py)
-
-### Phase 6: Agent Protocol & Registry ✅
-- [x] Define `BaseAgent` ABC with `AgentResult`
-- [x] ~~Create `AgentRegistry`~~ (removed — superseded by hub's explicit agent list)
-- [x] Implement `DefaultAgent` (chain-of-thought base)
-- [x] TUI foundation (Textual widgets — set aside, usable as future client)
-
-### Phase 7: Agent Hub Server ✅
-- [x] Extend `BaseAgent` with `AgentCardMeta` dataclass
-- [x] Create `ShellAgent` — one-shot command generation, `multi_turn=False`
-- [x] Implement `hub/storage.py` — SQLite-backed fasta2a `Storage` ABC ~~(superseded by `InMemoryTaskStore` (a2a-sdk) + `ContextStore` (`hub/context_store.py`))~~
-- [x] Implement `hub/factory.py` — BaseAgent → pydantic-ai Agent → `.to_a2a()` with shared storage
-- [x] Implement `hub/app.py` — parent FastAPI app, mount agents at `/agents/{name}/`, `GET /agents` discovery endpoint
-- [x] Implement `hub/worker.py` — FinAssistWorker with `auth-required` state for missing credentials ~~(superseded by `Executor` (`hub/executor.py`))~~
-- [x] Implement `hub/logging.py` — RotatingFileHandler for background hub
-- [x] Wire entry point — `fin-assist serve` starts the hub via uvicorn
-- [x] Tests — hub creation, agent mounting, discovery endpoint, storage CRUD, worker auth-required
-
-### Phase 8: CLI Client ✅
-- [x] Implement `cli/client.py` — A2A client using httpx + a2a-sdk ClientFactory
-- [x] Implement `cli/display.py` — Rich-based output formatting
-- [x] Implement `cli/server.py` — auto-start server with health polling + backoff
-- [x] Implement `cli/interaction/approve.py` — approval widget (`ApprovalAction`)
-- [x] Implement `cli/interaction/chat.py` — multi-turn chat loop with streaming
-- [x] Implement `cli/main.py` — `serve`, `agents`, `do`, `talk` commands with `_hub_client` context manager
-- [x] Session persistence — `~/.local/share/fin/sessions/{agent}/{slug}.json` with coolname slugs
-- [x] Tests — CLI client, display, server, interaction modules
-
-### Phase 8b: CLI REPL Mode ✅
-- [x] Implement `cli/interaction/prompt.py` — `FinPrompt` with prompt-toolkit fuzzy completion
-- [x] Wire `FinPrompt` into `chat.py` and `approve.py` (replaces `rich.prompt.Prompt`)
-- [x] Agent name tab completion via `agents` parameter
-- [x] Persistent input history (`~/.local/share/fin/history`)
-- [x] Slash-command fuzzy completion (`/exit`, `/help`, `/sessions`)
-- [x] `prompt-toolkit>=3.0` added as explicit dependency
-- [x] Tests — 8 new tests for `FinPrompt`
-
-### Config-Driven Redesign 📐
-- [x] Step 1: `ServingMode` enum + `serving_modes` field on `AgentCardMeta`
-- [x] Step 2: Output type + prompt registries (`OUTPUT_TYPES`, `SYSTEM_PROMPTS`)
-- [x] Step 3: Per-agent TOML config sections (`AgentConfig` in `config/schema.py`)
-- [x] Step 4: Collapse to single `ConfigAgent` class (remove `BaseAgent` ABC, `DefaultAgent`, `ShellAgent`). Later split into `AgentSpec` (pure config) + `PydanticAIBackend` (framework glue) — see commit `a16ba70`.
-- [x] Step 5: Direct `Worker[Context]` implementation (close #68)
-- [x] Step 6: Default agent shortcut (`fin do "prompt"` → `[agents.default]`)
-- [x] Step 7: Context injection for `do` (`--file`/`--git-diff` implemented, later replaced by `@`-completion)
-- [x] Step 8: Context injection for `talk` (`@`-completion implemented in FinPrompt)
-- [ ] Step 9: Approval "add context" option for structured output in talk mode
-
-### a2a-sdk Migration ✅
-- [x] Replace fasta2a with a2a-sdk v1.0 (Google's official A2A Python SDK)
-- [x] Replace Starlette with FastAPI (sub-apps from a2a-sdk route factories)
-- [x] Replace `InMemoryBroker` + `FinAssistWorker` with `DefaultRequestHandler` + `Executor`
-- [x] Replace `Skill(id="fin_assist:meta")` with `AgentExtension(uri="fin_assist:meta")`
-- [x] Split `SQLiteStorage` into `InMemoryTaskStore` (SDK) + `ContextStore` (SQLite)
-- [x] Implement token-by-token streaming via `TaskUpdater.add_artifact(append=True)`
-- [x] Implement `stream_agent()` in `cli/client.py` with SSE + `StreamEvent` model
-- [x] Update `cli/interaction/chat.py` with Rich `Live` streaming rendering
-- [x] Fix all type errors (protobuf-native types: `Part`, `Struct`, `Sequence[Part]`)
-- [x] Fix runtime bugs (Task enqueue requirement, async `get_output()`, v1.0 protocol)
-- [x] Update e2e tests for v1.0 protocol (`SendMessage`, `A2A-Version: 1.0`)
-- [x] 446 tests passing, lint clean, typecheck clean
-
-### Phase 9: Streaming + Integration Tests ✅
-
-- [x] Implement `stream_agent()` in `cli/client.py` using `SendStreamingMessage` + SSE
-- [x] Update `cli/interaction/chat.py` to render streaming output progressively
-- [x] Handle `TaskStatusUpdateEvent` and `TaskArtifactUpdateEvent` frames
-- [x] Wire to `talk` command — streaming as default if agent card supports it
-- [x] Executor unit tests — streaming artifact chunks
-- [x] Streaming e2e test — `FakeBackend` integration tests for streaming and step events
-
-### Phase 11: Multiplexer Integration ⬜
-- [ ] Multiplexer ABC (multiplexer/base.py)
-- [ ] tmux implementation (multiplexer/tmux.py)
-- [ ] zellij implementation (multiplexer/zellij.py)
-- [ ] Fallback (alternate screen) (multiplexer/fallback.py)
-- [ ] Launch CLI/TUI in floating pane
-
-### Phase 12: Fish Plugin ⬜
-- [ ] Create fish plugin (fish/conf.d/fin_assist.fish)
-- [ ] Keybinding for CLI/TUI launch
-- [ ] Command insertion (receive shell agent output, insert into command line)
-- [ ] Server auto-start (launch server if not running)
-
-### Phase 13: TUI Client ⬜
-- [ ] Refactor existing Textual widgets as A2A client (reuse ui/ code)
-- [ ] Wire TUI to agent hub via A2A client (not direct agent calls)
-- [ ] Per-agent UI adaptation driven by agent card metadata
-
-### Phase 14: Testing Infrastructure (Deep Evals) ⬜
-- [ ] Set up deep evals framework (pytest-compatible)
-- [ ] Define must/must-not/should criteria per agent
-- [ ] Implement LLM-as-judge evaluator (default, configurable per agent)
-- [ ] Create eval suite for `AgentSpec` (default and shell configs)
-- [ ] Per-agent eval configuration
-
-### Phase 15: Skills + MCP Integration ✅ (Skills API v0.1 shipped)
-- [x] Skills framework (configurable behaviors per agent)
-- [x] Agent-level tool policies (replaces per-skill approval)
-- [x] Tool gating — skills must be loaded before their tools are available
-- [x] `base_tools` on `AgentConfig` for always-available safe/read-only tools
-- [x] `skills/invoke` A2A Method Extension for pre-loading skills server-side
-- [x] REPL `/skills` command and `/skill:<name>` pattern for mid-session loading
-- [x] `SkillCompleter` with rapidfuzz fuzzy matching (mirrors `@file:` pattern)
-- [x] Skill tracing (`fin_assist.skill_load` spans, `fin_assist.cli.skill` attribute)
-- [x] Context templates: SKILL.md files with YAML frontmatter + markdown body
-- [x] Skill auto-discovery from `.fin/skills/` and `~/.config/fin/skills/`
-- [x] Dynamic skill loading via `load_skill` tool + catalog in system prompt
-- [x] `fin list skills` command (grouped by agent)
-- [x] `--skill` CLI flag for pre-loading skills
-- [x] Positional skill syntax (`fin do git commit`)
-- [ ] MCP client integration
-- [ ] Per-project skill/MCP configuration
-
-See the Skills Architecture section below for details on the v0.1 implementation.
-
----
-
-## Skills Architecture
-
-An agent is a collection of skills within an environment (system prompt). A **skill** curates tools, context injection text, and prompt steering. Skills are the primary mechanism for organizing agent behavior — tools attach through skills; `AgentSpec.skill_tool_names` derives from the union of skill tool lists, but tools are only *registered* when their skill is loaded.
-
-Approval policies are defined at the **agent level** via `AgentConfig.tool_policies`, not per-skill. This eliminates merge conflicts when multiple skills reference the same tool — each tool has exactly one policy definition.
-
-### Key Types
-
-| Type | Location | Purpose |
-|------|----------|---------|
-| `SkillDefinition` | `agents/skills.py` | Runtime representation of a resolved skill (no approval_policy) |
-| `SkillCatalog` | `agents/skills.py` | Generates catalog text for the system prompt |
-| `SkillLoader` | `agents/skills.py` | Resolves `SkillConfig` or SKILL.md files into `SkillDefinition` instances |
-| `SkillManager` | `agents/skills.py` | Tracks loaded skills, provides `load_skill` callable, `loaded_tool_names()`, generates catalog |
-| `SkillConfig` | `config/schema.py` | Per-skill TOML config (tools, prompt_template, entry_prompt, context) — no approval |
-| `ToolPolicyConfig` | `config/schema.py` | Agent-level tool approval policy (default mode + rules) |
-| `ToolPolicyRuleConfig` | `config/schema.py` | Single fnmatch-based approval rule in config |
-| `ApprovalPolicy` | `agents/tools.py` | Policy with `evaluate(args)` — first-match rules, default fallback |
-| `AgentConfig.base_tools` | `config/schema.py` | Always-available safe/read-only tools (default: `["read_file"]`) |
-| `AgentConfig.tool_policies` | `config/schema.py` | Agent-level tool approval policies (dict keyed by tool name) |
-
-### Skill Lifecycle
-
-1. **Config time** — Skills are defined in `config.toml` under `[agents.<name>.skills.<skill>]` or as SKILL.md files in `.fin/skills/<name>/SKILL.md` or `~/.config/fin/skills/<name>/SKILL.md`. Tool approval policies are defined at the agent level under `[agents.<name>.tool_policies.<tool>]`.
-2. **Agent startup** — `SkillLoader` resolves all skill configs into `SkillDefinition` instances. `AgentSpec.skill_tool_names` derives from the union of all skill tool lists. `AgentSpec.base_tools` lists always-available tools.
-3. **Backend init** — `PydanticAIBackend._get_skill_manager()` creates a `SkillManager` from the spec's skill definitions. Only `base_tools` are registered initially. If any skills are available but not yet loaded, the `load_skill` tool is registered and the skill catalog is appended to the system prompt.
-4. **Skill loading** — Skills can be loaded via: (a) `--skill` CLI flag or positional syntax (`fin do git commit`), which calls the `skills/invoke` endpoint server-side; (b) `/skill:<name>` in the REPL; (c) agent-driven `load_skill` tool call. All paths call `SkillManager.load_skill()` which marks the skill as loaded.
-5. **Tool gating** — `_build_pydantic_agent()` registers only `base_tools` + `SkillManager.loaded_tool_names()` tools. Skills that aren't loaded have their tools excluded from the agent. `_build_pydantic_agent()` is called on every `step()`, so loading takes effect on the next turn.
-6. **Agent-level policies** — `_get_agent_tool_policy()` resolves `AgentConfig.tool_policies` into `ApprovalPolicy` instances. Each tool has exactly one policy; no merge conflicts across skills.
-
-### Tool Gating
-
-The key change from the pre-refactor design: **tools are no longer registered all at once**. Before the refactor, `_build_pydantic_agent()` registered the union of all skill tools regardless of load state, and `SkillManager._loaded` only controlled catalog text — the LLM could use any tool at any time, making skill boundaries meaningless.
-
-Now, `_build_pydantic_agent()` registers only:
-- `base_tools` (always available, default `["read_file"]`)
-- `SkillManager.loaded_tool_names()` (tools from loaded skills)
-
-This means the LLM can only use tools from loaded skills. Unloaded skills' tools simply don't exist from the agent's perspective.
-
-### Agent-Level Tool Policies
-
-Instead of per-skill `approval` blocks (which duplicated rules across skills and caused merge conflicts), policies are defined at the agent level:
-
-```toml
-[agents.git]
-system_prompt = "git"
-output_type = "text"
-base_tools = ["read_file"]
-
-[agents.git.tool_policies.git]
-default = "always"
-rules = [
-  { pattern = "git diff*", mode = "never" },
-  { pattern = "git status*", mode = "never" },
-  { pattern = "git log*", mode = "never" },
-  { pattern = "git add*", mode = "never" },
-  { pattern = "git commit*", mode = "never" },
-]
-
-[agents.git.tool_policies.gh]
-default = "always"
-rules = [
-  { pattern = "gh pr view*", mode = "never" },
-  { pattern = "gh pr list*", mode = "never" },
-]
-```
-
-Each tool has exactly one policy definition — no merging needed, no conflicts possible.
-
-### skills/invoke Endpoint
-
-The `POST /agents/{name}/skills/invoke` endpoint (A2A Method Extension) is the primary server-side skill entry point. It:
-
-1. Validates the skill name against the agent's config
-2. Calls `SkillManager.load_skill()` to mark the skill as loaded
-3. Returns the effective prompt, prompt_template, and tools for the loaded skill
-
-The CLI calls this endpoint before streaming when a skill is resolved via `--skill` flag or positional syntax. The REPL's `/skill:<name>` command also calls this endpoint.
-
-### REPL Skill Commands
-
-- `/skills` — Lists available skills for the current agent (calls `GET /agents/{name}/skills`)
-- `/skill:<name>` — Loads a skill mid-session (calls `POST /agents/{name}/skills/invoke`), e.g. `/skill:commit`
-- `SkillCompleter` provides fuzzy completion after `/skill:`, using rapidfuzz `fuzz.WRatio` (same scorer and pattern as `AtCompleter` for `@file:`)
-
-### Skill Tracing
-
-- **CLI-side**: `cli_root_span(skill="commit")` stamps `fin_assist.cli.skill` on the CLI root span
-- **Hub-side**: `fin_assist.skill_load` span emitted via `_TaskTracer.emit_skill_load_span()` when a skill is loaded during a task (agent-driven `load_skill` tool). Carries `fin_assist.skill.id`, `fin_assist.skill.entry_point`, and `fin_assist.skill.tools_unlocked`.
-- **Task span**: `start_task_span(skill_id="commit")` stamps `fin_assist.skill.id` on the task span when the skill was pre-loaded before the task started
-
-### Approval Rules
-
-Agent-level `ToolPolicyConfig` defines approval policies per tool. Rules use fnmatch patterns matched against the tool's args string:
-
-```toml
-[agents.git.tool_policies.git]
-default = "always"
-rules = [
-  { pattern = "git diff*", mode = "never" },
-  { pattern = "git status*", mode = "never" },
-  { pattern = "git log*", mode = "never" },
-]
-```
-
-`ApprovalPolicy.evaluate(args)` checks rules in first-match order. If no rule matches, the `default` mode is used. This is conservative in v0.1: if `default="always"` or any rule has `mode="always"`, the tool gets `requires_approval=True` at registration time. Fine-grained per-subcommand evaluation at the executor level is planned for v0.1.1.
-
-### SKILL.md Format
-
-SKILL.md files follow the agentskills.io open standard: YAML frontmatter between `---` delimiters + markdown body. fin-assist extensions live under `metadata.fin-assist.*`:
-
-```markdown
----
-name: commit
-description: Generate a conventional commit message.
-allowed-tools:
-  - git
-  - read_file
-metadata:
-  fin-assist:
-    prompt-template: git-commit
-    entry-prompt: Analyze the current changes and generate a commit message.
----
-## Guidelines for commit messages
-
-Use conventional commits format. Keep the subject line under 50 characters.
-```
-
-Discovery paths (project takes precedence for same-name skills):
-- Project: `.fin/skills/<name>/SKILL.md`
-- User: `~/.config/fin/skills/<name>/SKILL.md`
-
-### Key Design Decisions
-
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| Skills are additive | No unloading in v0.1 | Simplicity; once tools are registered, removal is complex |
-| Tools shared across skills | Name collisions = config error | Single tool registry; same tool name must map to same callable |
-| Tool gating by loaded skills | `base_tools` + `loaded_tool_names()` only | Makes skill boundaries meaningful; LLM can't use unloaded tools |
-| Agent-level tool policies | `tool_policies` on `AgentConfig`, not per-skill | Each tool has exactly one policy — no merge/conflict |
-| `base_tools` default `["read_file"]` | Safe/read-only tools always available | Agents always need file reading; no skill load required |
-| Agent-driven + CLI skill loading | `load_skill` tool + `skills/invoke` endpoint + `--skill` flag | Multiple entry points for different workflows |
-| `/skill:<name>` REPL pattern | Mirrors `@file:` pattern with `SkillCompleter` | Consistent UX; fuzzy completion via rapidfuzz |
-| SKILL.md follows agentskills.io | Standard format with `metadata.fin-assist.*` extensions | Interoperability with other agent platforms |
-| Skill tracing via OTel | `fin_assist.skill_load` span + `fin_assist.cli.skill` attribute | Observable skill activations in Phoenix/traces.jsonl |
-
-### Post-v0.1 Roadmap
-
-| Version | Feature |
-|---------|---------|
-| v0.1.1 | MCP tool source — `MCPToolset` registers discovered tools into `ToolRegistry` |
-| v0.1.1 | Pluggable base system prompts — user-overridable prompt templates, not hardcoded Python constants |
-| v0.1.1 | Registry consistency + policy resolution audit — compare ToolRegistry, SkillManager, ContextProviders, CredentialStore, ProviderRegistry APIs; review policy resolution flow (schema → evaluate → backend → executor) for end-user understandability |
-| v0.1.1 | Per-subcommand approval evaluation at executor level |
-| v0.2 | Skill composability (skills invoking skills) + agent-to-agent orchestration |
-| v0.3 | Eval harness |
-
-### Phase 16: Additional Agents ⬜
-- [x] Git agent (`[agents.git]`) — commit, PR, summarize skills with scoped `git`/`gh` tools
-- [ ] Create `agents/sdd.py` (design brainstorming)
-- [ ] Define `SketchResult` model
-- [ ] Implement tools: `read_file`, `write_file`, `list_docs`
-- [ ] Create `agents/tdd.py` (test-driven development)
-- [ ] Define `TDDResult` model
-- [ ] Implement tools: `read_file`, `write_file`, `run_command`, `list_files`
-- [ ] Code review agent, computer use agent, journaling agent, etc.
-
-### Phase 17: Multi-Agent Workflows ⬜
-- [ ] Agent-to-agent communication via A2A (SDD → TDD handoff)
-- [ ] Orchestration patterns (sequential, parallel, DAG-based)
-- [ ] Hyper-agent exploration
-
-### Phase 18: Documentation ⬜
-- [ ] User documentation
-- [ ] Installation guide
-- [ ] Update architecture.md if needed
-
----
-
-## Open Questions
-
-Decisions deferred until the relevant phase. Resolved decisions are noted.
-
-> **Pointer to in-flight work.** Some formerly open items have been resolved (see table below). Remaining open items' design + implementation notes live in `handoff.md`.
->
-> 1. ~~**Executor loop rework**~~ — **Resolved** (PR #87). Unified Executor with multi-step tool calling, HITL approval, and step events.
-> 2. ~~**ContextProviders integration (Steps 7-8)**~~ — **Resolved**. Model-driven: wired as tools via `create_default_registry()`. User-driven: `@`-completion in FinPrompt.
-> 3. ~~**HITL approval model**~~ — **Resolved** (PR #87 Phase C). Per-tool `ApprovalPolicy` with deferred tool flow.
-> 4. **`AgentBackend` protocol simplification** — The current protocol has ~6 methods, several of which leak pydantic-ai shape. Tracked as [#80](https://github.com/ColeB1722/fin-assist/issues/80) (enhancement / tech-debt); revisit when a second backend is actually implemented.
-
-| Question | Phase | Status | Resolution |
-|----------|-------|--------|------------|
-| Conversation storage | Phase 7 | **Resolved** | SQLite `ContextStore` for conversation history; `InMemoryTaskStore` for A2A tasks |
-| Server lifecycle | Phase 8 | **Resolved** | `fin-assist serve` standalone; auto-start via `ensure_server_running` |
-| Multi-agent routing | Phase 7 | **Resolved** | Multi-path: one FastAPI parent, N A2A sub-apps at `/agents/{name}/` |
-| UI metadata transport | Phase 7 | **Resolved** | Split: static in agent card, dynamic in task artifact metadata |
-| Parent ASGI framework | Phase 7 | **Resolved** | FastAPI (a2a-sdk sub-apps are FastAPI; consistent framework) |
-| Agent card extensions format | Phase 7 | **Resolved** | `AgentExtension(uri="fin_assist:meta", params=Struct)` — proper a2a-sdk extension |
-| Agent execution pattern | Migration | **Resolved** | `Executor(AgentExecutor)` + `DefaultRequestHandler` replaces broker/worker (framework-agnostic via `AgentBackend` protocol) |
-| Streaming | Phase 9 | **Resolved** | Token-by-token via `TaskUpdater.add_artifact(append=True)` + `SendStreamingMessage` SSE |
-| gRPC transport | Future | Open | A2A protocol supports gRPC; a2a-sdk v1.0 supports it, not yet used by fin-assist |
-| Agent architecture | Redesign | **Resolved** | Config-driven: single `Agent` class, behavior from `AgentConfig` in TOML |
-| ShellAgent vs DefaultAgent | Redesign | **Resolved** | Merged into a single `AgentSpec` (pure config); `ShellAgent` behavior is `[agents.shell]` config. Framework glue isolated in `PydanticAIBackend`. |
-| `multi_turn: bool` vs `ServingMode` | Redesign | **Resolved** | `ServingMode = Literal["do", "talk"]` — more expressive |
-| Private `AgentWorker` import (#68) | Redesign | **Resolved** | Direct `Worker[list[ModelMessage]]` implementation using public APIs |
-| Thinking configuration | Redesign | **Resolved** | Per-agent `thinking` field in `AgentConfig`, not `DefaultAgent` override |
-| Default agent shortcut | Redesign | **Resolved** | `fin do "prompt"` / `fin talk` → `[general] default_agent` config; agent arg optional |
-| Context injection for `do` | Redesign | **Resolved** | Implemented via `@`-completion in FinPrompt (replaces `--file`/`--git-diff` CLI flags) |
-| Context injection for `talk` | Redesign | **Resolved** | Implemented via `@`-completion in FinPrompt |
-| Executor loop (one-shot → multi-step) | TBD | **Resolved** | Unified Executor with multi-step tool calling, HITL approval, and step events (PR #87 Phases A–C) |
-| HITL approval model | TBD | **Resolved** | Per-tool `ApprovalPolicy` with deferred tool flow (PR #87 Phase C) |
-| AgentBackend protocol shape | Cleanup | Open — [#80](https://github.com/ColeB1722/fin-assist/issues/80) | Protocol currently reflects pydantic-ai shape in ~5 of 6 methods. Revisit when a second backend is actually needed. |
-| External agent federation | Future | Open | Hub can register external A2A servers (any language) in discovery; deferred until real external agent exists to validate config schema |
-| Non-blocking agents | Phase 10 | Open | `SendMessage` with `blocking: false`; `_poll_task` fallback already implemented |
-| Deep evals criteria | Phase 14 | Open | Must/must-not/should per agent, LLM-as-judge default |
-| Hub server logging | Phase 9 | **Resolved** | Configurable via `[server] log_path` (default `~/.local/share/fin/hub.log`). Startup errors captured via subprocess stderr redirect. `configure_logging()` called before `create_hub_app()` to catch early import/initialization errors. Full structured logging (per-module loggers, log levels in config) deferred to Phase 9 when streaming makes observability matter. |
-
----
-
-## Future Considerations
-
-### External Agent Federation
-
-The hub currently only mounts **internal** agents — Python `AgentSpec` instances running in-process as A2A sub-apps. The A2A protocol is language-agnostic, so the hub can also register **external** agents: any process that serves the two A2A endpoints (`GET /.well-known/agent-card.json` + `POST /` JSON-RPC), regardless of implementation language.
-
-**Two pluggability levels:**
-
-| Level | What | Current support |
-|-------|------|-----------------|
-| Config plugins | New agent behaviors via TOML (different prompt, output type, serving modes) | Done |
-| Process plugins | External A2A servers in any language, registered with the hub via URL | Not yet |
-
-**Federation model — hub as registry, not proxy:**
-
-External agents register their URL in config. The hub lists them in the discovery endpoint (`GET /agents`) alongside internal agents. Clients talk to external agents directly — the hub is a directory service, not a proxy. This aligns with A2A's design: agent cards already have a `url` field, and the discovery endpoint already returns per-agent URLs.
-
-**Config schema (when implemented):**
-
-```toml
-[agents.myrust]
-mode = "external"                          # new field; internal is default
-url = "http://127.0.0.1:5001"             # A2A endpoint of the external agent
-
-[agents.claude-code]
-mode = "external"
-url = "http://127.0.0.1:5002"
-```
-
-**What changes when implemented:**
-
-1. `AgentConfig` gets `mode: Literal["internal", "external"]` and `url: str | None`
-2. `create_hub_app()` distinguishes internal (mount sub-app) vs external (register URL in discovery only)
-3. Discovery endpoint already returns agent URLs — minimal change needed
-4. Client, CLI, streaming all work as-is — they're protocol-native
-
-**What external agents don't get:**
-
-`ContextStore`, `CredentialStore`, `ContextProviders` are in-process Python services. External agents manage their own credentials, context, and conversation history. This is the correct boundary: shared services are an implementation convenience for internal agents, not a protocol requirement.
-
-**Why defer:** No external agents exist yet. The change is small and well-understood (~50 lines), but designing the config schema without a real external process to validate against risks over-fitting. Once a toy Rust/Gleam agent exists, the schema will be obvious. The discovery endpoint is already forward-compatible — agent entries include a `url` field that can point externally.
-
-### Near-term (Phases 13-15)
-- **Skills API v0.1** — ✅ Shipped. Skills bundle tools, approval rules, context injection, and prompt steering. Per-subcommand approval via fnmatch rules. SKILL.md file format. Dynamic `load_skill` tool.
-- **MCP integration (v0.1.1)** — Natural language interface to configurable MCP tools/servers; skill→tool binding is source-agnostic
-- **Additional agents** — SDD, TDD, code review, shell completion, computer use, journaling
-- **Multi-agent workflows** — Agent-to-agent via A2A, orchestration patterns
-
-### Long-term
-- **Web client** — HTML/JS frontend as A2A client
-- **Hyper-agents** — Meta-agents that orchestrate specialized agents
-- **Shell expansion** — bash, zsh support after fish is stable
-- **Ghostty support** — when popup feature lands (upstream issue #3197)
-- **Command history learning** — learn from accepted commands
-- **Custom prompts** — user-defined prompt templates
-- **Per-project config** — Agent/skill/MCP configuration per project via TOML
-
-### Deferred (No Timeline)
-- **RabbitMQ dispatch** — Work queue with N concurrent TDD agents (from AI-Directed-Dev-Pipeline)
-- **DAG-based task execution** — Task dependencies mapped to architectural boundaries
-
----
-
-## Related Documents
-
-- [AI-Directed-Dev-Pipeline](../sebs-vault/Brainstorming/AI-Directed-Dev-Pipeline.md) — Long-term vision for agent swarm-driven development
-
----
-
-## Related Issues
-
-- #14: LLM evals for shell command generation
-- #15: MCP tool integration for extended capabilities
-- #16: Validation and test cleanup for LLM/credentials modules
-- #45: Test quality: improve assertions and remove private state access
-- #58: display.py: derive credentials path from shared constant
-- #60: config/loader.py: warn when FIN_CONFIG_PATH points to non-existent file
-- #75: ContextStore: async I/O + close() method
-- #76: test_client.py: refactor _send_and_wait tests to use public API
-
----
-
-## Appendix: Design Decisions
-
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| A2A SDK | a2a-sdk v1.0 (Google) | Official SDK; fasta2a abandoned; v1.0 supports JSON-RPC, REST, gRPC from protobuf schema |
-| Multi-path routing | N agents, N agent cards, one server | True A2A compliance, enables agent-to-agent workflows |
-| Parent ASGI framework | FastAPI | a2a-sdk route factories produce FastAPI-compatible routes; consistent framework across sub-apps |
-| Config-driven agents | TOML config defines agent behavior | Enables adding new agents without writing Python classes; `AgentSpec` is the only spec implementation |
-| Spec/backend split | `AgentSpec` (pure config) + `AgentBackend` protocol (framework glue) | Isolates pydantic-ai to one file (`agents/backend.py`); spec is trivially testable and transport-ready; backend swap touches one module |
-| No ABC for specs | Single `AgentSpec` class, no `BaseAgent` ABC | Only one implementation exists; `Protocol` for DI/mocking if needed later; multi-language agents use A2A protocol, not Python inheritance |
-| Executor over Worker/Broker | `Executor(AgentExecutor)` + `DefaultRequestHandler` | a2a-sdk pattern; no broker needed; `TaskUpdater` for state transitions; Executor depends on `AgentBackend` protocol, not pydantic-ai directly |
-| Agent card metadata | `AgentExtension(uri="fin_assist:meta", params=Struct)` | Proper a2a-sdk extension; replaces `Skill(id="fin_assist:meta")` hack |
-| Streaming | Token-by-token via `TaskUpdater.add_artifact(append=True)` + SSE | Progressive output via `SendStreamingMessage`; Rich `Live` rendering on client |
-| Task storage | `InMemoryTaskStore` (ephemeral) | a2a-sdk managed; tasks lost on server restart; acceptable for personal local-first tool |
-| Conversation storage | SQLite `ContextStore` | Persists pydantic-ai message history across tasks; `context_id` for threading |
-| `serving_modes` over `multi_turn` | `ServingMode = Literal["do", "talk"]` | More expressive than boolean; declares which CLI modes an agent supports |
-| Default agent shortcut | `fin do "prompt"` → `[general] default_agent` config | Reduces friction for common case; agent arg optional; reads from config not hardcoded |
-| Context for `do` | Implemented via `@`-completion in FinPrompt (replaces `--file`/`--git-diff` CLI flags) | No TUI required; context injected inline before sending |
-| Context for `talk` | Implemented via `@`-completion in FinPrompt | Uses `ContextProvider.search()`; user injects context before sending |
-| Local-only server | Bind 127.0.0.1 | Personal tool, no network exposure; future opt-in |
-| CLI-first development | CLI before TUI | Faster iteration on hub + agent behavior; TUI becomes a client later |
-| UI metadata transport | Static in agent card, dynamic in artifacts | Agent card declares capabilities; per-response hints in artifact metadata |
-| Agent creation | TOML config entries, not Python classes | `ShellAgent` behavior is a config variant; adding agents is editing TOML |
-| Testing approach | Deep evals + CI | LLM-as-judge by default, pytest-compatible, post-merge regression checks |
+- [`docs/configuration.md`](configuration.md) — TOML schema, file precedence, credentials
+- [`docs/skills.md`](skills.md) — skills lifecycle, tool gating, approval policies
+- [`docs/tracing.md`](tracing.md) — OTel instrumentation, HITL trace continuity
+- [`docs/decisions.md`](decisions.md) — design decisions and open questions
+- [`AGENTS.md`](../AGENTS.md) — development workflow, conventions, skill authoring

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,30 @@ Developer reference for fin-assist's internals. For the user-facing pitch, see [
 
 **CLI-first, TUI-later.** Start with a simple CLI client for fast iteration and testing, then layer on TUI and other clients. The server is the stable core; clients are interchangeable.
 
+## Deliverables: Hub vs Client
+
+fin-assist is two distinct deliverables in one repository, separated by the A2A protocol:
+
+| Deliverable | Role | Lives in | Talks to clients via |
+|-------------|------|----------|----------------------|
+| **Agent Hub** | Platform — hosts agents, routes A2A traffic, persists context, manages credentials | `src/fin_assist/hub/` + `src/fin_assist/agents/` + supporting infra (`config/`, `context/`, `credentials/`, `llm/`, `providers.py`) | A2A (JSON-RPC over HTTP, SSE for streaming) |
+| **CLI** | Client — one of N possible A2A clients; today the only one. REPL, prompt, rendering, session storage | `src/fin_assist/cli/` | n/a (it *is* the user interface) |
+
+**The protocol is the contract.** The hub does not know what kind of client is talking to it. The CLI does not know any hub internals — it only knows the A2A wire format and the `fin_assist:meta` agent-card extension. A future TUI, web UI, or remote-Tailscale deployment is a different *client* or *deployment topology*, not a different product.
+
+**Import-firewall rule.** Code in `hub/` must never import from `cli/`. Code in `cli/` must never import from `hub/` *for client purposes* — the only allowed direction is the in-process launcher path used by `fin-assist serve` (which loads `hub.app`/`logging`/`pidfile`/`tracing` to boot the FastAPI app in this process).
+
+The rule is enforced by [`import-linter`](https://import-linter.readthedocs.io/) via two `forbidden` contracts in `pyproject.toml` under `[tool.importlinter]`. Run with `just lint-imports` (also part of `just ci`). The launcher allowlist is currently:
+
+- `cli/main.py → hub.app` / `hub.logging` / `hub.pidfile` / `hub.tracing` — `_serve_command` boots the FastAPI hub in-process
+- `cli/tracing.py → hub.file_exporter` — CLI-side spans share the hub's JSONL sink
+
+Notably, `cli/server.py` (process-lifecycle: `start`/`stop`/`status`/`ensure_running`) is *not* on the allowlist — it spawns the hub as a subprocess via `httpx` + `Popen` and never imports `hub.*`. That cross-process boundary is the cleanest possible separation and should stay that way.
+
+**New `cli/` code talking to the hub must go through `cli/client.py`** (the A2A client), not direct `hub.*` imports. If you legitimately need to extend the launcher path, add the specific `module -> module` line to `ignore_imports` in `pyproject.toml` with a justifying comment — don't weaken the contract itself.
+
+**Why this matters now.** Today the boundary is already clean (hub has zero CLI imports; CLI's only hub imports are the two launcher files). Pinning the rule with `import-linter` prevents drift before a second client (TUI, future workspace-split — see [`decisions.md`](decisions.md)) makes the cost of drift concrete. When the workspace split lands ([#128](https://github.com/ColeB1722/fin-assist/issues/128)), the contracts become per-package and the launcher allowlist either disappears (launcher moves into the hub package) or shrinks to a single declared dependency edge.
+
 ## Design principles
 
 1. **Config-driven agents** — Behavior (system prompt, output type, thinking, serving modes, approval, skills) lives in TOML, not Python subclasses. New agents are config entries, not new classes.
@@ -27,6 +51,7 @@ Developer reference for fin-assist's internals. For the user-facing pitch, see [
 4. **Local-first** — Server binds to `127.0.0.1` only; no network exposure by default.
 5. **Hub-first development** — Build the agent hub (server) as the stable core, then iterate on clients.
 6. **Metadata-driven clients** — Clients read agent capabilities from agent cards and adapt dynamically. No client-side agent-specific code.
+7. **Protocol is the contract** — The hub and its clients communicate only through A2A + the `fin_assist:meta` extension. `cli/` does not import from `hub/` (except the in-process launcher path for `fin-assist serve`); `hub/` never imports from `cli/`. See *Deliverables: Hub vs Client* above.
 
 ## Non-goals
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,8 +25,11 @@ fin-assist is two distinct deliverables in one repository, separated by the A2A 
 
 | Deliverable | Role | Lives in | Talks to clients via |
 |-------------|------|----------|----------------------|
-| **Agent Hub** | Platform — hosts agents, routes A2A traffic, persists context, manages credentials | `src/fin_assist/hub/` + `src/fin_assist/agents/` + supporting infra (`config/`, `context/`, `credentials/`, `llm/`, `providers.py`) | A2A (JSON-RPC over HTTP, SSE for streaming) |
+| **Agent Hub** | Platform server — hosts agents, routes A2A traffic, persists context | `src/fin_assist/hub/` | A2A (JSON-RPC over HTTP, SSE for streaming) |
+| **Platform abstractions** | Shared infra used by both products — specs, backends, tools, skills, config, context, credentials, LLM registry | `src/fin_assist/agents/`, `config/`, `context/`, `credentials/`, `llm/`, `providers.py` | n/a (internal, not a networked service) |
 | **CLI** | Client — one of N possible A2A clients; today the only one. REPL, prompt, rendering, session storage | `src/fin_assist/cli/` | n/a (it *is* the user interface) |
+
+These sibling packages sit alongside `hub/` and `cli/` in the flat namespace (`src/fin_assist/`), not nested under either deliverable. They are platform types consumed by both sides — the CLI imports `agents.metadata` and `config.loader`, the hub imports `agents.backend` and `agents.tools`. Nesting them under `hub/` would break the import firewall. The workspace split ([#128](https://github.com/ColeB1722/fin-assist/issues/128)) is the right moment to reorganize into a shared `fin-protocol` package.
 
 **The protocol is the contract.** The hub does not know what kind of client is talking to it. The CLI does not know any hub internals — it only knows the A2A wire format and the `fin_assist:meta` agent-card extension. A future TUI, web UI, or remote-Tailscale deployment is a different *client* or *deployment topology*, not a different product.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,21 +51,23 @@ Notably, `cli/server.py` (process-lifecycle: `start`/`stop`/`status`/`ensure_run
 1. **Config-driven agents** — Behavior (system prompt, output type, thinking, serving modes, approval, skills) lives in TOML, not Python subclasses. New agents are config entries, not new classes.
 2. **Protocol-native** — A2A via a2a-sdk v1.0 for standardized agent communication. Multi-path routing: N agents, N agent cards, one server.
 3. **Platform owns abstractions, backends adapt them** — Tools, approval, context, step events, tracing are framework-agnostic platform types in `agents/`. LLM frameworks plug in via backends that adapt platform concepts to their APIs. The platform never imports from backends.
-4. **Local-first** — Server binds to `127.0.0.1` only; no network exposure by default.
+4. **Local-first** — Server binds to `127.0.0.1` only; no network exposure by default. Local-first for iteration speed (fast feedback, no infra overhead), not as a permanent constraint. Remote topologies (Tailscale, remote workstation) are planned once the local experience is stable — same pattern as CLI-first, TUI-later.
 5. **Hub-first development** — Build the agent hub (server) as the stable core, then iterate on clients.
 6. **Metadata-driven clients** — Clients read agent capabilities from agent cards and adapt dynamically. No client-side agent-specific code.
 7. **Protocol is the contract** — The hub and its clients communicate only through A2A + the `fin_assist:meta` extension. `cli/` does not import from `hub/` (except the in-process launcher path for `fin-assist serve`); `hub/` never imports from `cli/`. See *Deliverables: Hub vs Client* above.
 
 ## Non-goals
 
-- Network-accessible deployment (personal use only, local-first)
+- Network-accessible deployment (personal use only, local-first — remote topologies planned post-v0.2)
 - Real-time command suggestions (on-demand only)
 - IDE/editor integration (beyond future MCP)
 - TOML-based agent *creation* — agents are defined via TOML config, but `AgentSpec` is the only spec implementation. There is no `fin ingest` to create new agent classes from TOML.
 
 ## Maintenance contract
 
-When a structural change to the system lands, update the relevant doc(s) in the same commit. Any claim in this document that a subsystem is "integrated" or a design decision is "Resolved" must cite a real call site (`file:line`) somewhere in `src/` — not just a test or a TOML field.
+When a structural change lands, update the relevant doc(s) before the milestone closes — not necessarily in the same commit, but before the work is considered shipped. Design sketches live in `handoff.md` during development; once the shape stabilizes, the durable claims move here.
+
+Any status claim ("integrated", "resolved", "implemented") must be **verifiable** — a reader who opens the referenced module should be able to confirm it. Use module-level references (`agents/backend.py`, `hub/executor.py`), not line numbers. Line numbers rot at this project's velocity and become false priors for agents consuming this doc as context. If a claim can't be verified without a specific line, it's too narrow to be a forever-doc claim — it belongs in a PR description or `handoff.md`.
 
 ## Hub internals
 
@@ -124,7 +126,9 @@ Parent FastAPI App (127.0.0.1:4096)
 
 ## Backend layer
 
-How the Executor reaches the LLM.
+How the Executor reaches the LLM, and how config flows through the stack.
+
+**Ownership chain:** `AgentFactory` constructs a `PydanticAIBackend(spec=agent_spec)`. The backend holds the spec as `self._spec` and reads all runtime config from it (system prompt, output type, thinking, tool policies, skill definitions, credential checks). The spec wraps `Config` and `CredentialStore` — the backend never touches them directly. When the backend needs an LLM model, it lazily creates its own `ProviderRegistry` and calls `spec.get_api_key()` / `spec.get_model_name()` to get provider-specific credentials and model names.
 
 ```mermaid
 graph TD
@@ -132,32 +136,29 @@ graph TD
 
     subgraph BACKEND_GRP["Backend Layer"]
         BEH["«protocol» AgentBackend"]
-        PAI["PydanticAIBackend<br/>pydantic-ai Agent · FallbackModel"]
-        SH["StreamHandle<br/>async iter (deltas) + result()"]
+        PAI["PydanticAIBackend"]
+        SH["StepHandle<br/>async iter · StepEvents · result()"]
         MCE["MissingCredentialsError<br/>raised when API key absent"]
+        REG["ProviderRegistry<br/>backend-owned · lazy"]
     end
 
     subgraph SPEC_GRP["Agent Specification"]
         SPEC["AgentSpec<br/>pure config · zero framework deps"]
-    end
-
-    subgraph SHARED["Shared Services"]
         CREDS["CredentialStore<br/>env → file → keyring"]
-        CONFIG["ConfigLoader<br/>TOML + env (FIN_*)<br/>pydantic-settings"]
-        REG["ProviderRegistry<br/>LLM providers · api_key injected"]
+        CONFIG["Config<br/>TOML + env (FIN_*)<br/>pydantic-settings"]
     end
 
     LLM["LLM Providers<br/>Anthropic · OpenAI · OpenRouter · Google"]
 
-    EXEC --> BEH
+    EXEC -->|"depends on"| BEH
     BEH -.->|"implemented by"| PAI
-    PAI --> SH
-    PAI -->|"create_model(provider, api_key)"| REG
-    REG --> LLM
-    PAI --> SPEC
+    PAI -->|"yields events"| SH
+    PAI -->|"holds ref · reads config"| SPEC
+    PAI -->|"lazy creates · create_model()"| REG
     PAI -.->|"raises on missing key"| MCE
-    SPEC -->|"get_api_key(provider)"| CREDS
-    SPEC --> CONFIG
+    REG -->|"provider API calls"| LLM
+    SPEC -->|"wraps · delegates get_api_key()"| CREDS
+    SPEC -->|"wraps · delegates model names"| CONFIG
 
     classDef external fill:#f5f5f5,stroke:#999,stroke-dasharray: 3 3
     class EXEC,LLM external
@@ -165,10 +166,13 @@ graph TD
     class MCE error
 ```
 
+Arrow semantics: solid = direct dependency (calls, holds, yields to); dashed = implements or raises; edge labels clarify the relationship where the arrow direction alone is ambiguous.
+
 **Spec/backend split.** fin-assist splits "what the agent is" from "how it runs":
 
-- **`AgentSpec`** (`src/fin_assist/agents/spec.py`) — a pure configuration object. Zero framework imports. Answers "what is this agent's system prompt?", "what's its output type?", "what metadata goes on its agent card?". Constructed from an `AgentConfig` (TOML section), the global `Config`, and a `CredentialStore`.
-- **`AgentBackend`** (`src/fin_assist/agents/backend.py`) — a `Protocol` that says how to actually run a spec: stream output, convert A2A messages to framework messages, serialize history, check credentials. The only production implementation is `PydanticAIBackend`, which wraps `pydantic_ai.Agent` + `FallbackModel`.
+- **`AgentSpec`** (`agents/spec.py`) — a pure configuration object. Zero framework imports. Wraps `Config` and `CredentialStore`; answers "what is this agent's system prompt?", "what's its output type?", "what metadata goes on its agent card?", "which providers have API keys?". The backend reads all runtime config through the spec and never touches `Config` or `CredentialStore` directly.
+- **`AgentBackend`** (`agents/backend.py`) — a `Protocol` that says how to actually run a spec: stream output, convert A2A messages to framework messages, serialize history, check credentials. The only production implementation is `PydanticAIBackend`, which wraps `pydantic_ai.Agent` + `FallbackModel`.
+- **`ProviderRegistry`** — not a shared service. Each `PydanticAIBackend` lazily creates its own `ProviderRegistry` the first time it builds a model. The registry translates `(provider_name, model_name, api_key)` into a pydantic-ai `Model` instance.
 
 The `Executor` (`src/fin_assist/hub/executor.py`) depends on the `AgentBackend` protocol. `AgentSpec` is never imported by the executor — it flows through the backend. This isolates pydantic-ai to one file, so swapping LLM frameworks (or stubbing for tests) touches only `backend.py`.
 
@@ -492,7 +496,7 @@ Static (discovery time):                    Dynamic (per-response):
 
 ## Local-only security
 
-The server binds to `127.0.0.1` by default — only local processes can communicate with agents. This is intentional: fin-assist is designed for personal use on a trusted machine.
+The server binds to `127.0.0.1` by default — only local processes can communicate with agents. This is intentional: fin-assist is designed for personal use on a trusted machine. The local-only default is an iteration-speed choice, not a permanent limitation. Remote deployment topologies (Tailscale tunneling, remote workstations) are planned once the local experience stabilizes. When remote topologies land, the workspace split ([#128](https://github.com/ColeB1722/fin-assist/issues/128)) makes deployment boundaries explicit in the package structure.
 
 ## See also
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,13 +174,13 @@ class AgentSpec:
     def output_type(self) -> type[Any]:    # via OUTPUT_TYPES registry
         ...
     @property
-    def thinking(self) -> ThinkingEffort | None: ...
+    def thinking(self) -> Literal["off", "low", "medium", "high"] | None: ...
     @property
     def default_model(self) -> str: ...
     @property
     def agent_card_metadata(self) -> AgentCardMeta: ...
     @property
-    def tools(self) -> list[str]: ...      # derived from skill union
+    def skill_tool_names(self) -> list[str]: ...   # union of tools across all skills
 
     def check_credentials(self) -> list[str]:
         """Names of enabled providers with missing API keys (empty = all present)."""
@@ -195,18 +195,30 @@ class AgentSpec:
 @runtime_checkable
 class AgentBackend(Protocol):
     def check_credentials(self) -> list[str]: ...
-    def run_stream(
+    def convert_history(self, a2a_messages: Sequence[Any]) -> list[Any]: ...
+    def run_steps(
         self,
         *,
         messages: list[Any],
         model: Any = None,
-    ) -> StreamHandle: ...
-    def convert_history(self, messages: list[Message]) -> list[Any]: ...
-    def deserialize_history(self, raw: bytes) -> list[Any]: ...
-    def convert_result_to_part(self, output: Any) -> Part: ...
+        deferred_tool_results: Any = None,
+    ) -> StepHandle: ...
+    def serialize_history(self, messages: list[Any]) -> bytes: ...
+    def deserialize_history(self, data: bytes) -> list[Any]: ...
+    def convert_result_to_part(self, result: Any) -> Part: ...
+    def convert_response_parts(self, parts: Sequence[Any]) -> list[Part]: ...
+    def build_deferred_results(self, decisions: list[ApprovalDecision]) -> Any: ...
+    # Optional — backends may implement for framework-specific tracing
+    def install_tracing(
+        self,
+        provider: TracerProvider,
+        *,
+        include_content: bool,
+        event_mode: str,
+    ) -> None: ...
 ```
 
-`StreamHandle` yields text deltas via async iteration and returns a `RunResult(output, serialized_history, new_message_parts)` from `result()`.
+`StepHandle` yields `StepEvent`s via async iteration — discriminated by `kind` (`text_delta`, `thinking_delta`, `tool_call`, `tool_result`, `step_start`, `step_end`, `deferred`) — and returns a `RunResult(output, serialized_history, new_message_parts)` from `result()`. The `tool_call`/`deferred` events drive HITL approval.
 
 ### `AgentCardMeta`
 
@@ -262,7 +274,7 @@ class ContextItem:
     type: Literal["file", "git_diff", "git_log", "git_status", "history", "env"]
     content: str
     metadata: dict[str, object]
-    status: ItemStatus = "ready"
+    status: Literal["available", "not_found", "excluded", "error"] = "available"
     error_reason: str | None = None
 
 class ContextProvider(ABC):
@@ -281,33 +293,33 @@ Context gathering works two ways:
 
 ## Hub factory
 
-`create_hub_app()` builds the parent FastAPI app, constructs a single shared `ContextStore`, and mounts one sub-app per enabled agent via `AgentFactory`:
+`create_hub_app()` takes a pre-built sequence of `AgentSpec`s (constructed by the caller, e.g. `_serve_command` in `cli/main.py`), builds the parent FastAPI app, constructs a single shared `ContextStore`, and mounts one sub-app per spec via `AgentFactory`:
 
 ```python
 def create_hub_app(
-    config: Config,
-    credentials: CredentialStore,
-    *,
-    db_path: Path,
+    agents: Sequence[AgentSpec] | None = None,
+    db_path: str = ":memory:",
+    base_url: str = "http://127.0.0.1:4096",
+    backend_factory: Callable[[AgentSpec], AgentBackend] | None = None,
+    context_settings: ContextSettings | None = None,
 ) -> FastAPI:
     app = FastAPI(title="fin-assist Agent Hub")
     context_store = ContextStore(db_path=db_path)          # shared across sub-apps
-    factory = AgentFactory(context_store=context_store)
+    factory = AgentFactory(
+        context_store=context_store,
+        context_settings=context_settings,
+    )
 
-    for name, agent_config in config.agents.items():
-        if not agent_config.enabled:
-            continue
-        spec = AgentSpec(
-            name=name,
-            agent_config=agent_config,
-            config=config,
-            credentials=credentials,
+    for spec in agents or []:
+        sub_app = factory.create_a2a_app(
+            spec,
+            base_url=base_url,
+            backend=backend_factory(spec) if backend_factory else None,
         )
-        sub_app = factory.create_a2a_app(spec)
-        app.mount(f"/agents/{name}", sub_app)
+        app.mount(f"/agents/{spec.name}", sub_app)
 
     @app.get("/agents")
-    async def discovery(): ...     # returns each sub-app's agent card URL + metadata
+    async def discovery(): ...     # returns each agent's name, description, card URL, card_meta
 
     @app.get("/health")
     async def health(): ...
@@ -315,7 +327,9 @@ def create_hub_app(
     return app
 ```
 
-`AgentFactory.create_a2a_app(spec)` builds the agent card with an `AgentExtension(uri="fin_assist:meta")` carrying `AgentCardMeta`, constructs a `PydanticAIBackend` wrapping the spec, builds an `Executor` consuming the backend, creates a per-sub-app `InMemoryTaskStore`, and wires through `DefaultRequestHandler`. The result is a FastAPI sub-app with the a2a-sdk JSON-RPC + agent-card routes mounted.
+The split between "build specs" (in the CLI command) and "mount specs" (in the factory) lets the caller wire backends, tracing, and tool registries before the app exists — see `cli/main.py:_serve_command` for the full ordering (specs → backends → `setup_tracing` → `create_hub_app` → `FastAPIInstrumentor`).
+
+`AgentFactory.create_a2a_app(spec, ...)` builds the agent card with an `AgentExtension(uri="fin_assist:meta")` carrying `AgentCardMeta`, constructs (or accepts) a `PydanticAIBackend` wrapping the spec, builds an `Executor` consuming the backend, creates a per-sub-app `InMemoryTaskStore`, mounts a `POST /skills/invoke` route for the skill-loading A2A method extension, and wires through `DefaultRequestHandler`. The result is a FastAPI sub-app with the a2a-sdk JSON-RPC + agent-card routes mounted.
 
 ## Request flow overview
 
@@ -380,33 +394,35 @@ Key benefits for fin-assist:
 
 ### Transport
 
-The A2A protocol defines transport as pluggable. a2a-sdk v1.0 supports JSON-RPC, REST, and gRPC transports from the same protobuf schema. The v1.0 JSON-RPC method names are PascalCase (`SendMessage`, `GetTask`, `CancelTask`, `SendStreamingMessage`) and require the `A2A-Version: 1.0` header.
+The A2A protocol defines transport as pluggable. a2a-sdk v1.0 supports JSON-RPC, REST, and gRPC transports from the same protobuf schema. fin-assist uses the SDK's JSON-RPC transport via the `Client.send_message(SendMessageRequest(...))` API (`cli/client.py`); request/response wire formats and method dispatch are handled inside a2a-sdk.
 
 | Modality | Transport | Status | Notes |
 |----------|-----------|--------|-------|
-| Blocking `SendMessage` | JSON-RPC | Implemented | Hub responds inline when agent finishes |
-| Streaming `SendStreamingMessage` | JSON-RPC SSE | Implemented | Token-by-token via `TaskUpdater.add_artifact(append=True)` |
-| Non-blocking + polling | JSON-RPC | Open | `_poll_task` fallback exists in `cli/client.py` but unused |
+| Blocking message | JSON-RPC | Implemented | Hub responds inline when agent finishes |
+| Streaming | JSON-RPC SSE | Implemented | Token-by-token via `TaskUpdater.add_artifact(append=True)` |
+| Non-blocking + polling | JSON-RPC | Future | Not yet wired |
 | gRPC | gRPC | Future | Protocol-native; a2a-sdk v1.0 supports it |
 
 ## CLI entry points
 
 ```text
-fin-assist serve                        → start agent hub on 127.0.0.1:4096
-fin-assist agents                       → list available agents (GET /agents)
-fin-assist do "prompt"                  → one-shot to default_agent from config
-fin-assist do --agent <name> "prompt"   → one-shot to named agent
-fin-assist do --skill <name> "prompt"   → one-shot with a skill pre-loaded
-fin-assist do <agent> <skill>           → positional skill (e.g. fin do git commit)
-fin-assist do --edit                    → open input panel pre-filled with prompt
-fin-assist do                           → no prompt → opens input panel
-fin-assist talk                         → multi-turn session with default_agent
-fin-assist talk --agent <name>          → multi-turn with named agent
-fin-assist talk --skill <name>          → multi-turn with a skill pre-loaded
-fin-assist talk --resume <id>           → resume a saved session
-fin-assist talk --list                  → list saved sessions for agent
+fin-assist serve                            → start agent hub in foreground on 127.0.0.1:4096
+fin-assist start | stop | status            → background hub lifecycle
+fin-assist agents                           → list available agents (GET /agents)
+fin-assist do "prompt"                      → one-shot to default_agent from config
+fin-assist do --agent <name> "prompt"       → one-shot to named agent
+fin-assist do --agent <name> --skill <name> → one-shot with a skill pre-loaded
+fin-assist do --agent <name> <skill>        → prompt-as-skill: prompt is auto-promoted
+                                              to the skill name when it matches one
+fin-assist do --edit "prompt"               → open input panel pre-filled with prompt
+fin-assist do                               → no prompt → opens input panel
+fin-assist talk [--agent <n>] [--skill <n>] → multi-turn session
+fin-assist talk --resume <id>               → resume a saved session
+fin-assist talk --list                      → list saved sessions for agent
 fin-assist list tools|skills|prompts|output-types  → list registry entries
 ```
+
+> Note: the `--agent` flag is required when you want a non-default agent. There is no bare positional `fin do <agent> <skill>` form — the `do` parser has only one positional argument (`prompt`). What works is the *prompt-as-skill* shortcut: `fin do --agent git commit` is parsed as `prompt="commit"` and then auto-promoted to `skill=commit` because `commit` is a registered skill on `git`.
 
 REPL commands (during multi-turn chat):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,127 @@
+# Configuration
+
+fin-assist is config-driven: agent behavior, providers, skills, and tool approval policies are all declared in TOML. New agents are config entries, not new Python classes.
+
+## File discovery
+
+Config is loaded from the first available location:
+
+1. Explicit path (API parameter)
+2. `FIN_CONFIG_PATH` environment variable
+3. `./config.toml` (project-local override in current working directory)
+4. `~/.config/fin/config.toml` (user default)
+
+Source precedence (highest first): init args → env (`FIN_*`) → TOML → defaults.
+
+## Env var naming
+
+See [`AGENTS.md`](../AGENTS.md#env-var-naming-convention) for the full convention. Summary:
+
+- `FIN_<NAME>` (single underscore) — bootstrap vars read with `os.environ.get()` before pydantic loads (e.g. `FIN_DATA_DIR`).
+- `FIN_<SECTION>__<FIELD>` (double underscore) — pydantic-settings nested config (e.g. `FIN_GENERAL__DEFAULT_MODEL`, `FIN_SERVER__PORT`).
+
+## Example config
+
+```toml
+[general]
+default_provider = "anthropic"
+default_model = "claude-sonnet-4-6"
+default_agent = "test"
+
+[server]
+host = "127.0.0.1"
+port = 4096
+db_path = "~/.local/share/fin/hub.db"
+
+[providers.anthropic]
+# API key stored separately in credentials
+
+[providers.openrouter]
+# API key stored separately in credentials
+
+[providers.ollama]
+base_url = "http://localhost:11434"
+
+[agents.test]
+description = "Development test agent with file, shell, and git tools."
+system_prompt = "test"
+output_type = "text"
+thinking = "medium"
+serving_modes = ["do", "talk"]
+
+[agents.test.skills.files]
+description = "Read files from the workspace."
+tools = ["read_file"]
+
+[agents.test.skills.git]
+description = "Git commands with per-subcommand approval."
+tools = ["git"]
+
+[agents.test.tool_policies.git]
+default = "always"
+rules = [
+  { pattern = "git diff*", mode = "never" },
+  { pattern = "git status*", mode = "never" },
+  { pattern = "git log*", mode = "never" },
+]
+
+[agents.test.skills.shell]
+description = "Execute arbitrary shell commands (requires approval)."
+tools = ["run_shell"]
+```
+
+## Agent config schema
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `description` | str | `""` | Human-readable description, surfaced in the agent card |
+| `system_prompt` | str | required | Key into `SYSTEM_PROMPTS` registry |
+| `output_type` | str | `"text"` | Key into `OUTPUT_TYPES` registry (`"text"` → `str`, `"command"` → `CommandResult`) |
+| `thinking` | `"low"`/`"medium"`/`"high"` or null | null | Pydantic-AI thinking effort |
+| `serving_modes` | list[`"do"`/`"talk"`] | `["do", "talk"]` | Which CLI modes this agent supports |
+| `enabled` | bool | true | Whether to mount this agent in the hub |
+| `base_tools` | list[str] | `["read_file"]` | Always-available tools (no skill load required) |
+| `skills` | dict[str, SkillConfig] | `{}` | Per-skill config (see [`docs/skills.md`](skills.md)) |
+| `tool_policies` | dict[str, ToolPolicyConfig] | `{}` | Per-tool approval policy (agent-level, not per-skill) |
+
+## Tool approval policies
+
+Policies are defined at the **agent level**, keyed by tool name. Each tool has exactly one policy — no merge conflicts when multiple skills reference the same tool.
+
+```toml
+[agents.git.tool_policies.git]
+default = "always"        # require approval for any git invocation by default
+rules = [
+  { pattern = "git diff*",   mode = "never" },   # but auto-approve diff/status/log
+  { pattern = "git status*", mode = "never" },
+  { pattern = "git log*",    mode = "never" },
+]
+```
+
+`ApprovalPolicy.evaluate(args)` checks `rules` in first-match order; if no rule matches, `default` applies. See [`docs/skills.md`](skills.md#approval-rules) for the full evaluation flow and v0.1 limitations.
+
+## Provider config
+
+```toml
+[providers.<name>]
+base_url = "..."           # optional; defaults vary per provider
+# API keys live in credentials, not config
+```
+
+`ProviderRegistry` reads `[providers.*]` and constructs pydantic-ai providers on demand, injecting the API key from `CredentialStore` per `create_model()` call.
+
+## Credential storage
+
+Credentials are stored separately from config (so config can be checked into a dotfiles repo without leaking secrets). Default path: `$FIN_DATA_DIR/credentials.json` with `0600` permissions.
+
+Lookup chain (highest precedence first):
+
+1. Environment variable (e.g. `ANTHROPIC_API_KEY`)
+2. Credentials file (`credentials.json`)
+3. OS keyring (if `keyring` is installed and a key is stored)
+
+Use `fin-assist /connect` to set up provider credentials interactively.
+
+## Runtime paths
+
+All runtime state derives from `FIN_DATA_DIR` (default `~/.local/share/fin`). For local development, set `FIN_DATA_DIR=./.fin` to keep state colocated with the repo. See [`AGENTS.md`](../AGENTS.md#local-development-paths) for the full table of paths.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,9 +75,9 @@ tools = ["run_shell"]
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `description` | str | `""` | Human-readable description, surfaced in the agent card |
-| `system_prompt` | str | required | Key into `SYSTEM_PROMPTS` registry |
+| `system_prompt` | str | `"chain-of-thought"` | Key into `SYSTEM_PROMPTS` registry |
 | `output_type` | str | `"text"` | Key into `OUTPUT_TYPES` registry (`"text"` → `str`, `"command"` → `CommandResult`) |
-| `thinking` | `"low"`/`"medium"`/`"high"` or null | null | Pydantic-AI thinking effort |
+| `thinking` | `"off"`/`"low"`/`"medium"`/`"high"` or null | `"medium"` | Pydantic-AI thinking effort; `"off"` disables, `null` inherits from `[general]` |
 | `serving_modes` | list[`"do"`/`"talk"`] | `["do", "talk"]` | Which CLI modes this agent supports |
 | `enabled` | bool | true | Whether to mount this agent in the hub |
 | `base_tools` | list[str] | `["read_file"]` | Always-available tools (no skill load required) |
@@ -108,7 +108,7 @@ base_url = "..."           # optional; defaults vary per provider
 # API keys live in credentials, not config
 ```
 
-`ProviderRegistry` reads `[providers.*]` and constructs pydantic-ai providers on demand, injecting the API key from `CredentialStore` per `create_model()` call.
+The `[providers.*]` section is read by `AgentSpec` (which exposes `get_api_key(provider)` and `get_base_url(provider)` to the backend). `ProviderRegistry` (in `llm/model_registry.py`) is a stateless factory: `create_model(provider, model, api_key=..., base_url=...)` — the spec resolves credentials and passes them through per call.
 
 ## Credential storage
 
@@ -120,7 +120,7 @@ Lookup chain (highest precedence first):
 2. Credentials file (`credentials.json`)
 3. OS keyring (if `keyring` is installed and a key is stored)
 
-Use `fin-assist /connect` to set up provider credentials interactively.
+Today, set credentials by either exporting the env var (`export ANTHROPIC_API_KEY=...`) or hand-editing `$FIN_DATA_DIR/credentials.json` (a flat `{"anthropic": "sk-..."}` JSON object). An interactive `/connect` setup command is planned — see [#124](https://github.com/ColeB1722/fin-assist/issues/124).
 
 ## Runtime paths
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ tools = ["run_shell"]
 | `thinking` | `"off"`/`"low"`/`"medium"`/`"high"` or null | `"medium"` | Pydantic-AI thinking effort; `"off"` disables, `null` inherits from `[general]` |
 | `serving_modes` | list[`"do"`/`"talk"`] | `["do", "talk"]` | Which CLI modes this agent supports |
 | `enabled` | bool | true | Whether to mount this agent in the hub |
-| `base_tools` | list[str] | `["read_file"]` | Always-available tools (no skill load required) |
+| `base_tools` | list[str] | `[]` | Always-available tools (opt in via config or skills) |
 | `skills` | dict[str, SkillConfig] | `{}` | Per-skill config (see [`docs/skills.md`](skills.md)) |
 | `tool_policies` | dict[str, ToolPolicyConfig] | `{}` | Per-tool approval policy (agent-level, not per-skill) |
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -42,7 +42,7 @@ Decisions deferred until the relevant work picks them up.
 | `AgentBackend` protocol shape | Open — [#80](https://github.com/ColeB1722/fin-assist/issues/80) | Protocol currently reflects pydantic-ai shape in ~5 of 6 methods. Revisit when a second backend is actually needed |
 | External agent federation | Open — deferred | Hub can register external A2A servers (any language) in discovery; deferred until a real external agent exists to validate config schema. See [§External agent federation](#external-agent-federation) below |
 | gRPC transport | Open — deferred | A2A protocol supports gRPC; a2a-sdk v1.0 supports it; not yet used by fin-assist |
-| Non-blocking agents | Open | `SendMessage` with `blocking: false`; `_poll_task` fallback already implemented in `cli/client.py` but unused |
+| Non-blocking agents | Open | `SendMessage` with `blocking: false`; client-side polling not yet wired |
 | Deep evals criteria | Open | Must/must-not/should per agent, LLM-as-judge default — designed when eval harness is built (v0.3) |
 
 ## External agent federation

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,82 @@
+# Design Decisions
+
+The "why" behind structural choices. New decisions go here when they shape the platform's contracts; small implementation choices stay in code comments or commit messages.
+
+## Architecture
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| A2A SDK | a2a-sdk v1.0 (Google) | Official SDK; fasta2a abandoned; v1.0 supports JSON-RPC, REST, gRPC from a single protobuf schema |
+| Multi-path routing | N agents, N agent cards, one server | True A2A compliance, enables agent-to-agent workflows |
+| Parent ASGI framework | FastAPI | a2a-sdk route factories produce FastAPI-compatible routes; consistent framework across sub-apps |
+| Config-driven agents | TOML config defines agent behavior | Adding agents = editing TOML, not writing Python classes |
+| Spec/backend split | `AgentSpec` (pure config) + `AgentBackend` protocol (framework glue) | Isolates pydantic-ai to one file (`agents/backend.py`); spec is trivially testable and transport-ready; backend swap touches one module |
+| No ABC for specs | Single `AgentSpec` class, no `BaseAgent` ABC | Only one implementation exists; `Protocol` for DI/mocking if needed later; multi-language agents use A2A protocol, not Python inheritance |
+| Executor over Worker/Broker | `Executor(AgentExecutor)` + `DefaultRequestHandler` | a2a-sdk pattern; no broker needed; `TaskUpdater` for state transitions; Executor depends on `AgentBackend` protocol, not pydantic-ai directly |
+| Agent card metadata | `AgentExtension(uri="fin_assist:meta", params=Struct)` | Proper a2a-sdk extension; replaces earlier `Skill(id="fin_assist:meta")` hack |
+| Streaming | Token-by-token via `TaskUpdater.add_artifact(append=True)` + SSE | Progressive output via `SendStreamingMessage`; Rich `Live` rendering on client |
+| Task storage | `InMemoryTaskStore` (ephemeral) | a2a-sdk managed; tasks lost on server restart; acceptable for personal local-first tool |
+| Conversation storage | SQLite `ContextStore` | Persists pydantic-ai message history across tasks; `context_id` for threading |
+| `serving_modes` over `multi_turn` | `ServingMode = Literal["do", "talk"]` | More expressive than boolean; declares which CLI modes an agent supports |
+| Default agent shortcut | `fin do "prompt"` → `[general] default_agent` | Reduces friction for common case; agent arg optional |
+| Context for `do` / `talk` | `@`-completion in FinPrompt | Replaces `--file`/`--git-diff` CLI flags; context injected inline before sending |
+| Local-only server | Bind 127.0.0.1 | Personal tool, no network exposure; future opt-in |
+| CLI-first development | CLI before TUI | Faster iteration on hub + agent behavior; TUI becomes a client later |
+| UI metadata transport | Static in agent card, dynamic in artifacts | Agent card declares capabilities; per-response hints in artifact metadata |
+| Testing approach | Deep evals + CI | LLM-as-judge by default, pytest-compatible, post-merge regression checks |
+
+## Skills
+
+See [`docs/skills.md`](skills.md#design-decisions) for skill-specific design decisions (tool gating, agent-level policies, SKILL.md format, etc.).
+
+## Tracing
+
+See [`docs/tracing.md`](tracing.md) for tracing-specific decisions (CLI-side trace ID joining, HITL pause/resume continuity, attribute hygiene, noise suppression).
+
+## Open questions
+
+Decisions deferred until the relevant work picks them up.
+
+| Question | Status | Notes |
+|----------|--------|-------|
+| `AgentBackend` protocol shape | Open — [#80](https://github.com/ColeB1722/fin-assist/issues/80) | Protocol currently reflects pydantic-ai shape in ~5 of 6 methods. Revisit when a second backend is actually needed |
+| External agent federation | Open — deferred | Hub can register external A2A servers (any language) in discovery; deferred until a real external agent exists to validate config schema. See [§External agent federation](#external-agent-federation) below |
+| gRPC transport | Open — deferred | A2A protocol supports gRPC; a2a-sdk v1.0 supports it; not yet used by fin-assist |
+| Non-blocking agents | Open | `SendMessage` with `blocking: false`; `_poll_task` fallback already implemented in `cli/client.py` but unused |
+| Deep evals criteria | Open | Must/must-not/should per agent, LLM-as-judge default — designed when eval harness is built (v0.3) |
+
+## External agent federation
+
+The hub currently only mounts **internal** agents — Python `AgentSpec` instances running in-process as A2A sub-apps. The A2A protocol is language-agnostic, so the hub *can* also register **external** agents: any process that serves the two A2A endpoints (`GET /.well-known/agent-card.json` + `POST /` JSON-RPC), regardless of implementation language.
+
+**Two pluggability levels:**
+
+| Level | What | Current support |
+|-------|------|-----------------|
+| Config plugins | New agent behaviors via TOML (different prompt, output type, serving modes) | Done |
+| Process plugins | External A2A servers in any language, registered with the hub via URL | Not yet |
+
+**Federation model — hub as registry, not proxy.** External agents register their URL in config. The hub lists them in the discovery endpoint (`GET /agents`) alongside internal agents. Clients talk to external agents directly — the hub is a directory service, not a proxy. This aligns with A2A's design: agent cards already have a `url` field.
+
+**Config schema (when implemented):**
+
+```toml
+[agents.myrust]
+mode = "external"                          # new field; "internal" is default
+url = "http://127.0.0.1:5001"
+
+[agents.claude-code]
+mode = "external"
+url = "http://127.0.0.1:5002"
+```
+
+**What changes when implemented:**
+
+1. `AgentConfig` gets `mode: Literal["internal", "external"]` and `url: str | None`
+2. `create_hub_app()` distinguishes internal (mount sub-app) vs external (register URL only)
+3. Discovery endpoint already returns agent URLs — minimal change
+4. Client, CLI, streaming all work as-is — they're protocol-native
+
+**What external agents don't get:** `ContextStore`, `CredentialStore`, `ContextProviders` are in-process Python services. External agents manage their own credentials, context, and conversation history. This is the correct boundary: shared services are an implementation convenience for internal agents, not a protocol requirement.
+
+**Why defer:** No external agents exist yet. The change is small (~50 lines) but designing the schema without a real external process to validate against risks over-fitting. Once a toy Rust/Gleam agent exists, the schema will be obvious.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -37,7 +37,7 @@ flowchart LR
 | `ToolPolicyConfig` | `config/schema.py` | Agent-level tool approval policy (default mode + rules) |
 | `ToolPolicyRuleConfig` | `config/schema.py` | Single fnmatch-based approval rule in config |
 | `ApprovalPolicy` | `agents/tools.py` | Runtime policy: `evaluate(args) -> tuple[mode, description]` (first-match rules, default fallback) |
-| `AgentConfig.base_tools` | `config/schema.py` | Always-available safe/read-only tools (default: `["read_file"]`) |
+| `AgentConfig.base_tools` | `config/schema.py` | Always-available tools (default: `[]`; agents opt in via config or skills) |
 | `AgentConfig.tool_policies` | `config/schema.py` | Agent-level tool approval policies (dict keyed by tool name) |
 
 ## Skill lifecycle
@@ -58,7 +58,7 @@ flowchart LR
 
 The key behavior: **tools are not all registered up front**. `_build_pydantic_agent()` registers only:
 
-- `base_tools` (always available, default `["read_file"]`)
+- `base_tools` (always available, default `[]`)
 - `SkillManager.loaded_tool_names()` (tools from loaded skills)
 
 The LLM can only use tools from loaded skills. Unloaded skills' tools simply don't exist from the agent's perspective — skill boundaries are enforced, not advisory.
@@ -191,7 +191,7 @@ CLI usage:
 | Tools shared across skills | Name collisions = config error | Single tool registry; same tool name must map to same callable |
 | Tool gating by loaded skills | `base_tools` + `loaded_tool_names()` only | Makes skill boundaries meaningful; LLM can't use unloaded tools |
 | Agent-level tool policies | `tool_policies` on `AgentConfig`, not per-skill | Each tool has exactly one policy — no merge/conflict |
-| `base_tools` default `["read_file"]` | Safe/read-only tools always available | Agents always need file reading; no skill load required |
+| `base_tools` default `[]` | No tools implied; agents opt in | Tool availability is explicit — no hidden dependencies on implicit defaults |
 | Agent-driven + CLI skill loading | `load_skill` tool + `skills/invoke` endpoint + `--skill` flag | Multiple entry points for different workflows |
 | `/skill:<name>` REPL pattern | Mirrors `@file:` pattern with `SkillCompleter` | Consistent UX; fuzzy completion via rapidfuzz |
 | SKILL.md follows agentskills.io | Standard format with `metadata.fin-assist.*` extensions | Interoperability with other agent platforms |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,183 @@
+# Skills
+
+A fin-assist agent is a collection of **skills** within an environment (system prompt). A skill curates tools, context injection text, and prompt steering. Skills are the primary mechanism for organizing agent behavior — tools attach through skills, and tools are only registered when their skill is loaded.
+
+Approval policies are defined at the **agent level** via `tool_policies`, not per-skill. This eliminates merge conflicts when multiple skills reference the same tool.
+
+## Key types
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `SkillDefinition` | `agents/skills.py` | Runtime representation of a resolved skill |
+| `SkillCatalog` | `agents/skills.py` | Generates catalog text for the system prompt |
+| `SkillLoader` | `agents/skills.py` | Resolves `SkillConfig` or SKILL.md files into `SkillDefinition` instances |
+| `SkillManager` | `agents/skills.py` | Tracks loaded skills, provides `load_skill` callable, `loaded_tool_names()`, generates catalog |
+| `SkillConfig` | `config/schema.py` | Per-skill TOML config (tools, prompt_template, entry_prompt, context) |
+| `ToolPolicyConfig` | `config/schema.py` | Agent-level tool approval policy (default mode + rules) |
+| `ToolPolicyRuleConfig` | `config/schema.py` | Single fnmatch-based approval rule in config |
+| `ApprovalPolicy` | `agents/tools.py` | Policy with `evaluate(args)` — first-match rules, default fallback |
+| `AgentConfig.base_tools` | `config/schema.py` | Always-available safe/read-only tools (default: `["read_file"]`) |
+| `AgentConfig.tool_policies` | `config/schema.py` | Agent-level tool approval policies (dict keyed by tool name) |
+
+## Skill lifecycle
+
+1. **Config time** — Skills are defined in `config.toml` under `[agents.<name>.skills.<skill>]` or as SKILL.md files in `.fin/skills/<name>/SKILL.md` (project) or `~/.config/fin/skills/<name>/SKILL.md` (user). Project-level skills take precedence for same-name skills. Tool approval policies are defined at the agent level under `[agents.<name>.tool_policies.<tool>]`.
+2. **Agent startup** — `SkillLoader` resolves all skill configs into `SkillDefinition` instances. `AgentSpec.skill_tool_names` derives from the union of all skill tool lists. `AgentSpec.base_tools` lists always-available tools.
+3. **Backend init** — `PydanticAIBackend._get_skill_manager()` creates a `SkillManager` from the spec's skill definitions. Only `base_tools` are registered initially. If any skills are available but not yet loaded, the `load_skill` tool is registered and the skill catalog is appended to the system prompt.
+4. **Skill loading** — Skills can be loaded via:
+   - `--skill` CLI flag or positional syntax (`fin do git commit`) — calls the `skills/invoke` endpoint server-side
+   - `/skill:<name>` in the REPL
+   - Agent-driven `load_skill` tool call
+
+   All paths call `SkillManager.load_skill()` which marks the skill as loaded.
+5. **Tool gating** — `_build_pydantic_agent()` registers only `base_tools` + `SkillManager.loaded_tool_names()`. Skills that aren't loaded have their tools excluded from the agent. `_build_pydantic_agent()` is called on every `step()`, so loading takes effect on the next turn.
+6. **Agent-level policies** — `_get_agent_tool_policy()` resolves `AgentConfig.tool_policies` into `ApprovalPolicy` instances. Each tool has exactly one policy.
+
+## Tool gating
+
+The key behavior: **tools are not all registered up front**. `_build_pydantic_agent()` registers only:
+
+- `base_tools` (always available, default `["read_file"]`)
+- `SkillManager.loaded_tool_names()` (tools from loaded skills)
+
+The LLM can only use tools from loaded skills. Unloaded skills' tools simply don't exist from the agent's perspective — skill boundaries are enforced, not advisory.
+
+## Agent-level tool policies
+
+Instead of per-skill `approval` blocks (which duplicated rules across skills), policies live at the agent level keyed by tool name:
+
+```toml
+[agents.git]
+system_prompt = "git"
+output_type = "text"
+base_tools = ["read_file"]
+
+[agents.git.tool_policies.git]
+default = "always"
+rules = [
+  { pattern = "git diff*",   mode = "never" },
+  { pattern = "git status*", mode = "never" },
+  { pattern = "git log*",    mode = "never" },
+  { pattern = "git add*",    mode = "never" },
+  { pattern = "git commit*", mode = "never" },
+]
+
+[agents.git.tool_policies.gh]
+default = "always"
+rules = [
+  { pattern = "gh pr view*", mode = "never" },
+  { pattern = "gh pr list*", mode = "never" },
+]
+```
+
+Each tool has exactly one policy definition — no merging, no conflicts.
+
+## Approval rules
+
+Rules use fnmatch patterns matched against the tool's args string. `ApprovalPolicy.evaluate(args)` checks rules in first-match order; if no rule matches, `default` applies.
+
+This is conservative in v0.1: if `default="always"` or any rule has `mode="always"`, the tool gets `requires_approval=True` at registration time. Fine-grained per-subcommand evaluation at the executor level is planned for v0.1.1.
+
+## skills/invoke endpoint
+
+`POST /agents/{name}/skills/invoke` (A2A Method Extension) is the primary server-side skill entry point. It:
+
+1. Validates the skill name against the agent's config
+2. Calls `SkillManager.load_skill()` to mark the skill as loaded
+3. Returns the effective prompt, prompt_template, and tools for the loaded skill
+
+The CLI calls this endpoint before streaming when a skill is resolved via `--skill` or positional syntax. The REPL's `/skill:<name>` command also calls this endpoint.
+
+## REPL skill commands
+
+- `/skills` — Lists available skills for the current agent (calls `GET /agents/{name}/skills`)
+- `/skill:<name>` — Loads a skill mid-session (calls `POST /agents/{name}/skills/invoke`), e.g. `/skill:commit`
+- `SkillCompleter` provides fuzzy completion after `/skill:`, using rapidfuzz `fuzz.WRatio` (same scorer and pattern as `AtCompleter` for `@file:`)
+
+## Skill tracing
+
+- **CLI-side**: `cli_root_span(skill="commit")` stamps `fin_assist.cli.skill` on the CLI root span
+- **Hub-side**: `fin_assist.skill_load` span emitted via `_TaskTracer.emit_skill_load_span()` when a skill is loaded during a task (agent-driven `load_skill` tool). Carries `fin_assist.skill.id`, `fin_assist.skill.entry_point`, and `fin_assist.skill.tools_unlocked`.
+- **Task span**: `start_task_span(skill_id="commit")` stamps `fin_assist.skill.id` on the task span when the skill was pre-loaded before the task started
+
+See [`docs/tracing.md`](tracing.md) for the broader tracing model.
+
+## SKILL.md format
+
+SKILL.md files follow the [agentskills.io](https://agentskills.io) open standard: YAML frontmatter between `---` delimiters + markdown body. fin-assist extensions live under `metadata.fin-assist.*`:
+
+```markdown
+---
+name: commit
+description: Generate a conventional commit message.
+allowed-tools:
+  - git
+  - read_file
+metadata:
+  fin-assist:
+    prompt-template: git-commit
+    entry-prompt: Analyze the current changes and generate a commit message.
+---
+## Guidelines for commit messages
+
+Use conventional commits format. Keep the subject line under 50 characters.
+```
+
+Discovery paths (project takes precedence for same-name skills):
+
+- Project: `.fin/skills/<name>/SKILL.md`
+- User: `~/.config/fin/skills/<name>/SKILL.md`
+
+## Inline TOML skills
+
+For skills with light context, define them inline in `config.toml`:
+
+```toml
+[agents.git]
+base_tools = ["read_file"]
+
+[agents.git.skills.commit]
+description = "Generate a conventional commit message from current changes."
+tools = ["git"]
+prompt_template = "git-commit"
+entry_prompt = "Analyze the current staged and unstaged changes and generate a conventional commit message."
+```
+
+CLI usage:
+
+- `fin do git commit` → agent=git, skill=commit (entry_prompt sent as user message, prompt_template injected as context)
+- `fin do git --skill commit` → same, explicit skill flag
+- `fin do git` → agent=git, no skill (LLM routes based on user input, may call `load_skill` from catalog)
+
+## Adding a new skill
+
+1. Add the skill to `config.toml` under the appropriate agent (or create `.fin/skills/<name>/SKILL.md`).
+2. If the skill needs a new tool, add it to `create_default_registry()` in `agents/tools.py`.
+3. Write tests in `tests/test_agents/test_skills.py` (loader, catalog, manager).
+4. Run `just ci` to verify.
+5. Update this doc if the skill introduces new patterns.
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Skills are additive | No unloading in v0.1 | Simplicity; once tools are registered, removal is complex |
+| Tools shared across skills | Name collisions = config error | Single tool registry; same tool name must map to same callable |
+| Tool gating by loaded skills | `base_tools` + `loaded_tool_names()` only | Makes skill boundaries meaningful; LLM can't use unloaded tools |
+| Agent-level tool policies | `tool_policies` on `AgentConfig`, not per-skill | Each tool has exactly one policy — no merge/conflict |
+| `base_tools` default `["read_file"]` | Safe/read-only tools always available | Agents always need file reading; no skill load required |
+| Agent-driven + CLI skill loading | `load_skill` tool + `skills/invoke` endpoint + `--skill` flag | Multiple entry points for different workflows |
+| `/skill:<name>` REPL pattern | Mirrors `@file:` pattern with `SkillCompleter` | Consistent UX; fuzzy completion via rapidfuzz |
+| SKILL.md follows agentskills.io | Standard format with `metadata.fin-assist.*` extensions | Interoperability with other agent platforms |
+| Skill tracing via OTel | `fin_assist.skill_load` span + `fin_assist.cli.skill` attribute | Observable skill activations in Phoenix/traces.jsonl |
+
+## Roadmap
+
+| Version | Feature |
+|---------|---------|
+| v0.1.1 | MCP tool source — `MCPToolset` registers discovered tools into `ToolRegistry` |
+| v0.1.1 | Pluggable base system prompts — user-overridable prompt templates, not hardcoded Python constants |
+| v0.1.1 | Per-subcommand approval evaluation at executor level |
+| v0.1.1 | Registry consistency + policy resolution audit |
+| v0.2 | Skill composability (skills invoking skills) + agent-to-agent orchestration |
+| v0.3 | Eval harness |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,6 +6,27 @@ Approval policies are defined at the **agent level** via `tool_policies`, not pe
 
 ## Key types
 
+```mermaid
+flowchart LR
+    subgraph config ["Config layer (config/schema.py)"]
+        AC[AgentConfig] -->|skills.*| SC[SkillConfig]
+        AC -->|tool_policies.*| TPC[ToolPolicyConfig]
+        TPC -->|rules| TPRC[ToolPolicyRuleConfig]
+    end
+
+    subgraph runtime ["Runtime layer (agents/)"]
+        SC -->|resolved by| SL[SkillLoader]
+        SL -->|produces| SD[SkillDefinition]
+        SD -->|feeds| SM[SkillManager]
+        SM -->|generates| SCat[SkillCatalog]
+        TPC -->|resolved into| AP[ApprovalPolicy]
+    end
+
+    AC -.->|base_tools| RT[Registered tools]
+    SM -->|loaded_tool_names| RT
+    AP -->|evaluate| RT
+```
+
 | Type | Location | Purpose |
 |------|----------|---------|
 | `SkillDefinition` | `agents/skills.py` | Runtime representation of a resolved skill |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -12,17 +12,17 @@ Approval policies are defined at the **agent level** via `tool_policies`, not pe
 | `SkillCatalog` | `agents/skills.py` | Generates catalog text for the system prompt |
 | `SkillLoader` | `agents/skills.py` | Resolves `SkillConfig` or SKILL.md files into `SkillDefinition` instances |
 | `SkillManager` | `agents/skills.py` | Tracks loaded skills, provides `load_skill` callable, `loaded_tool_names()`, generates catalog |
-| `SkillConfig` | `config/schema.py` | Per-skill TOML config (tools, prompt_template, entry_prompt, context) |
+| `SkillConfig` | `config/schema.py` | Per-skill TOML config (tools, prompt_template, entry_prompt, context, serving_modes) |
 | `ToolPolicyConfig` | `config/schema.py` | Agent-level tool approval policy (default mode + rules) |
 | `ToolPolicyRuleConfig` | `config/schema.py` | Single fnmatch-based approval rule in config |
-| `ApprovalPolicy` | `agents/tools.py` | Policy with `evaluate(args)` — first-match rules, default fallback |
+| `ApprovalPolicy` | `agents/tools.py` | Runtime policy: `evaluate(args) -> tuple[mode, description]` (first-match rules, default fallback) |
 | `AgentConfig.base_tools` | `config/schema.py` | Always-available safe/read-only tools (default: `["read_file"]`) |
 | `AgentConfig.tool_policies` | `config/schema.py` | Agent-level tool approval policies (dict keyed by tool name) |
 
 ## Skill lifecycle
 
-1. **Config time** — Skills are defined in `config.toml` under `[agents.<name>.skills.<skill>]` or as SKILL.md files in `.fin/skills/<name>/SKILL.md` (project) or `~/.config/fin/skills/<name>/SKILL.md` (user). Project-level skills take precedence for same-name skills. Tool approval policies are defined at the agent level under `[agents.<name>.tool_policies.<tool>]`.
-2. **Agent startup** — `SkillLoader` resolves all skill configs into `SkillDefinition` instances. `AgentSpec.skill_tool_names` derives from the union of all skill tool lists. `AgentSpec.base_tools` lists always-available tools.
+1. **Config time** — Skills are defined in `config.toml` under `[agents.<name>.skills.<skill>]`. SKILL.md files (under `$FIN_DATA_DIR/skills/<name>/SKILL.md`) are discoverable today via `fin list skills` but are **not loaded into running agents** — the runtime `SkillManager` is built only from inline TOML config (`AgentSpec.get_skill_definitions()` calls only `loader.load_all_from_agent_config`). Wiring SKILL.md files into the runtime, plus a real project-vs-user precedence model and the cross-agent binding question, is tracked as [#125](https://github.com/ColeB1722/fin-assist/issues/125). Tool approval policies are defined at the agent level under `[agents.<name>.tool_policies.<tool>]`.
+2. **Agent startup** — `SkillLoader` resolves the inline-config skills into `SkillDefinition` instances. `AgentSpec.skill_tool_names` derives from the union of all skill tool lists. `AgentSpec.base_tools` lists always-available tools.
 3. **Backend init** — `PydanticAIBackend._get_skill_manager()` creates a `SkillManager` from the spec's skill definitions. Only `base_tools` are registered initially. If any skills are available but not yet loaded, the `load_skill` tool is registered and the skill catalog is appended to the system prompt.
 4. **Skill loading** — Skills can be loaded via:
    - `--skill` CLI flag or positional syntax (`fin do git commit`) — calls the `skills/invoke` endpoint server-side
@@ -96,9 +96,14 @@ The CLI calls this endpoint before streaming when a skill is resolved via `--ski
 
 ## Skill tracing
 
-- **CLI-side**: `cli_root_span(skill="commit")` stamps `fin_assist.cli.skill` on the CLI root span
-- **Hub-side**: `fin_assist.skill_load` span emitted via `_TaskTracer.emit_skill_load_span()` when a skill is loaded during a task (agent-driven `load_skill` tool). Carries `fin_assist.skill.id`, `fin_assist.skill.entry_point`, and `fin_assist.skill.tools_unlocked`.
-- **Task span**: `start_task_span(skill_id="commit")` stamps `fin_assist.skill.id` on the task span when the skill was pre-loaded before the task started
+Today, only one piece of skill activity is observable in traces:
+
+- **CLI-side**: `cli_root_span(skill="commit")` stamps `fin_assist.cli.skill` on the CLI root span when a skill is pre-loaded via `--skill` flag or the prompt-as-skill shortcut.
+
+Two further hooks exist as scaffolding but are **not yet invoked** — tracked as [#123](https://github.com/ColeB1722/fin-assist/issues/123):
+
+- `_TaskTracer.emit_skill_load_span()` (defined; would emit `fin_assist.skill_load` with `fin_assist.skill.id`, `fin_assist.skill.entry_point`, `fin_assist.skill.tools_unlocked`) — would fire when a skill loads during a task.
+- `start_task_span(skill_id=...)` (parameter accepted; would stamp `fin_assist.skill.id` on the `fin_assist.task` span) — would fire when a skill was pre-loaded before the task started.
 
 See [`docs/tracing.md`](tracing.md) for the broader tracing model.
 
@@ -123,10 +128,10 @@ metadata:
 Use conventional commits format. Keep the subject line under 50 characters.
 ```
 
-Discovery paths (project takes precedence for same-name skills):
+Discovery paths (used by `fin list skills` only — see lifecycle note above; runtime loading is tracked as [#125](https://github.com/ColeB1722/fin-assist/issues/125)):
 
-- Project: `.fin/skills/<name>/SKILL.md`
-- User: `~/.config/fin/skills/<name>/SKILL.md`
+- `$FIN_DATA_DIR/skills/<name>/SKILL.md` (with `FIN_DATA_DIR=./.fin` for project-local skills in dev)
+- `~/.config/fin/skills/<name>/SKILL.md` (user)
 
 ## Inline TOML skills
 

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -11,18 +11,22 @@ cli.do  (root, one per invocation)
 │   fin_assist.cli.invocation_id = <uuid>  (also in Baggage)
 │   fin_assist.cli.command = "do"
 │
-├── GET  /health                     ────► (hub: request span)
-├── GET  /agents                     ────► (hub: request span)
-├── GET  /agents/<name>              ────► (hub: request span)
-└── POST /agents/<name>/:send-msg    ────► POST /agents/<name>/:send-message
+├── HTTP GET  /health                 ────► (hub: FastAPIInstrumentor span)
+├── HTTP GET  /agents                 ────► (hub: FastAPIInstrumentor span)
+├── HTTP GET  /agents/<name>          ────► (hub: FastAPIInstrumentor span)
+└── HTTP POST /agents/<name>/         ────► HTTP POST /agents/<name>/
+       (a2a-sdk Client.send_message)         (a2a-sdk DefaultRequestHandler)
                                               │
                                               └── fin_assist.task
                                                   fin_assist.cli.invocation_id = <uuid>  ← join key
-                                                  fin_assist.task.state = running|completed|failed|paused_for_approval
+                                                  fin_assist.task.state = running | paused_for_approval
+                                                                          | resumed_from_approval (transient)
+                                                                          | completed | failed
                                                   ├── fin_assist.step
-                                                  │   ├── fin_assist.tool_execution
-                                                  │   └── running tool          (pydantic-ai)
-                                                  └── (LLM spans: gen_ai.*, llm.*)
+                                                  │   └── fin_assist.tool_execution
+                                                  └── (upstream LLM/tool spans from
+                                                       pydantic-ai → OpenInference bridge:
+                                                       gen_ai.*, llm.*)
 ```
 
 **Why one CLI trace + one hub trace, not one shared `trace_id`:** HTTP boundaries already open fresh traces hub-side; making them share a `trace_id` would require suppressing the hub's natural request tracing, which would also suppress useful per-request timing data. Instead we join via `fin_assist.cli.invocation_id` (Baggage-propagated) — a single attribute lookup in Phoenix shows all spans across both processes for one invocation.
@@ -133,22 +137,33 @@ In Phoenix the two hub traces appear as siblings, joined by the Link (rendered a
 
 ## Task state attribute
 
-`fin_assist.task.state` (`running` → `completed` / `failed` / `paused_for_approval`) is the canonical Phoenix filter for task-level queries. One attribute with a small enum keeps queries simple — one equality check per state instead of a compound predicate across several booleans.
+`fin_assist.task.state` is the canonical Phoenix filter for task-level queries. Values come from `TaskStateValues` in `hub/tracing_attrs.py`:
+
+- `running` — initial state when the task span starts
+- `paused_for_approval` — set when an approval-gated tool call pauses execution
+- `resumed_from_approval` — set transiently when a paused task is resumed; overwritten by `completed`/`failed` before the span ends, so it's only observable on in-flight spans
+- `completed` — terminal success
+- `failed` — terminal failure
+
+One attribute with a small enum keeps queries simple — one equality check per state instead of a compound predicate across several booleans.
 
 ## Skill spans
 
-Skill activations are observable:
+Today, only the CLI-side stamp is wired:
 
-- **CLI-side**: `cli_root_span(skill="commit")` stamps `fin_assist.cli.skill` on the CLI root span when a skill is pre-loaded via `--skill` flag or positional syntax
-- **Hub-side**: `fin_assist.skill_load` span emitted via `_TaskTracer.emit_skill_load_span()` when a skill is loaded during a task (agent-driven `load_skill` tool). Carries `fin_assist.skill.id`, `fin_assist.skill.entry_point`, `fin_assist.skill.tools_unlocked`
-- **Task span**: `start_task_span(skill_id="commit")` stamps `fin_assist.skill.id` on the task span when the skill was pre-loaded before the task started
+- **CLI-side**: `cli_root_span(skill="commit")` stamps `fin_assist.cli.skill` on the CLI root span when a skill is pre-loaded via `--skill` flag or the prompt-as-skill shortcut.
+
+Two further hooks exist as scaffolding but are **not yet invoked** — tracked as [#123](https://github.com/ColeB1722/fin-assist/issues/123):
+
+- `_TaskTracer.emit_skill_load_span()` (defined; would emit `fin_assist.skill_load` carrying `fin_assist.skill.id`, `fin_assist.skill.entry_point`, `fin_assist.skill.tools_unlocked`) — would fire when a skill loads during a task.
+- `start_task_span(skill_id=...)` (parameter accepted; would stamp `fin_assist.skill.id` on the `fin_assist.task` span) — would fire when a skill was pre-loaded before the task started.
 
 ## Noise suppression
 
 Two upstream instrumentors were disabled because they produce high-volume, low-value spans:
 
-- **a2a-sdk**'s `@trace_class` decorator wraps every internal queue / task-store method with a `SpanKind.SERVER` span. Disabled via `OTEL_INSTRUMENTATION_A2A_SDK_ENABLED=false` (vendor-supported env off-switch, set by `setup_tracing` via `os.environ.setdefault` so operators can re-enable for debugging).
-- **FastAPIInstrumentor**'s per-SSE-chunk `http.response.body` span. Dropped in the export pipeline by `_DropSpansProcessor` (key on `asgi.event.type = "http.response.body"`, not on span name, so instrumentor-version renames don't break us).
+- **a2a-sdk**'s `@trace_class` decorator wraps every internal queue / task-store method with a `SpanKind.SERVER` span. Disabled via `OTEL_INSTRUMENTATION_A2A_SDK_ENABLED=false` (vendor-supported env off-switch). The `os.environ.setdefault(...)` call lives in `src/fin_assist/__init__.py`, not in `setup_tracing` — it must run *before* `a2a` is imported, since a2a-sdk reads the env var at module top level. Operators can override by exporting the var explicitly before launching.
+- **FastAPIInstrumentor**'s per-SSE-chunk `http.response.body` span. Dropped in the export pipeline by `DropSpansProcessor` (in `tracing_shared.py`), which keys on `asgi.event.type = "http.response.body"` (not span name, so instrumentor-version renames don't break us).
 
 ## Attribute hygiene
 
@@ -160,9 +175,11 @@ Three classes of leaked/duplicate attributes are scrubbed at `on_end` before exp
 
 ## Files
 
-- `src/fin_assist/hub/tracing.py` — vendor-agnostic TracerProvider builder (OTLP + JSONL file sink, plus drop + truncate + scrub processors)
+- `src/fin_assist/tracing_shared.py` — process-agnostic processors and helpers shared by the CLI and hub: `DropSpansProcessor`, `TruncatingSpanProcessor`, attribute scrubbing, and `_GracefulOTLPExporter` (the OTLP exporter that degrades cleanly when Phoenix isn't running)
+- `src/fin_assist/hub/tracing.py` — hub-side TracerProvider builder (composes the shared processors with OTLP + JSONL file sinks)
 - `src/fin_assist/hub/tracing_attrs.py` — centralized attribute names and enum values (`FinAssistAttributes`, `TaskStateValues`, `SpanNames`)
 - `src/fin_assist/cli/tracing.py` — CLI-side tracer; `cli_root_span` / `approval_wait_span` context managers + `HTTPXClientInstrumentor` integration
+- `src/fin_assist/__init__.py` — sets `OTEL_INSTRUMENTATION_A2A_SDK_ENABLED=false` at import time (must precede a2a-sdk import)
 - `src/fin_assist/agents/pydantic_ai_tracing.py` — pydantic-ai → OpenInference bridge (the one place that imports `openinference.instrumentation.pydantic_ai`; kept isolated so the hub stays framework-neutral)
 
 ## Local trace inspection

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,173 @@
+# Tracing & Observability
+
+fin-assist emits OpenTelemetry spans across two processes — the CLI and the hub — and joins them so one `fin` invocation reads as one browsable flow in Phoenix (or any OTLP-compatible backend).
+
+## Trace topology
+
+```text
+CLI process                                Hub process
+━━━━━━━━━━━                                ━━━━━━━━━━━
+cli.do  (root, one per invocation)
+│   fin_assist.cli.invocation_id = <uuid>  (also in Baggage)
+│   fin_assist.cli.command = "do"
+│
+├── GET  /health                     ────► (hub: request span)
+├── GET  /agents                     ────► (hub: request span)
+├── GET  /agents/<name>              ────► (hub: request span)
+└── POST /agents/<name>/:send-msg    ────► POST /agents/<name>/:send-message
+                                              │
+                                              └── fin_assist.task
+                                                  fin_assist.cli.invocation_id = <uuid>  ← join key
+                                                  fin_assist.task.state = running|completed|failed|paused_for_approval
+                                                  ├── fin_assist.step
+                                                  │   ├── fin_assist.tool_execution
+                                                  │   └── running tool          (pydantic-ai)
+                                                  └── (LLM spans: gen_ai.*, llm.*)
+```
+
+**Why one CLI trace + one hub trace, not one shared `trace_id`:** HTTP boundaries already open fresh traces hub-side; making them share a `trace_id` would require suppressing the hub's natural request tracing, which would also suppress useful per-request timing data. Instead we join via `fin_assist.cli.invocation_id` (Baggage-propagated) — a single attribute lookup in Phoenix shows all spans across both processes for one invocation.
+
+## Instrumented request flow
+
+Full sequence diagram of a `SendStreamingMessage` call, with span emissions and state transitions called out. The structural overview without spans lives in [`docs/architecture.md`](architecture.md#request-flow-overview).
+
+```mermaid
+sequenceDiagram
+    participant C as CLI Client
+    participant H as Hub<br/>(sub-app + DefaultRequestHandler)
+    participant E as Executor
+    participant B as AgentBackend<br/>(PydanticAIBackend)
+    participant SH as StreamHandle
+    participant CS as ContextStore
+    participant LLM as LLM Provider
+
+    C->>C: cli_root_span (invocation_id in Baggage)
+    C->>H: SendStreamingMessage (JSON-RPC + SSE)
+    Note over C,H: invocation_id propagated via Baggage header
+
+    H->>E: execute(context, event_queue)
+    E->>E: start fin_assist.task span<br/>state=running
+    E->>E: updater.start_work() → WORKING
+
+    E->>B: check_credentials()
+    B-->>E: [] or [missing providers]
+
+    alt Credentials missing
+        Note over E,B: raises MissingCredentialsError
+        E->>E: task.state=failed
+        E->>E: updater.requires_auth() → AUTH_REQUIRED
+        H-->>C: SSE: TaskStatusUpdateEvent (auth_required)
+    else Credentials present
+        E->>CS: load(context_id)
+        CS-->>E: bytes or None
+        E->>B: deserialize_history(bytes)
+        B-->>E: message_history (prior turns)
+
+        E->>B: convert_history([current_message])
+        B-->>E: framework messages (this turn)
+
+        E->>B: run_stream(messages=history)
+        B-->>E: StreamHandle
+        Note over B,LLM: backend holds LLM connection<br/>emits gen_ai.* / llm.* spans
+
+        loop Token-by-token
+            SH-->>E: text delta (async iter)
+            E->>H: updater.add_artifact(append=true, last_chunk=false)
+            H-->>C: SSE: TaskArtifactUpdateEvent
+        end
+
+        E->>H: updater.add_artifact("", last_chunk=true)
+        H-->>C: SSE: TaskArtifactUpdateEvent (last_chunk=true)
+
+        alt Tool call needs approval
+            E->>E: emit fin_assist.approval_request span
+            E->>CS: save_pause_state(SpanContext, user_input)
+            E->>E: task.state=paused_for_approval
+            E->>E: updater.requires_input() → AUTH_REQUIRED
+            H-->>C: SSE: TaskStatusUpdateEvent (paused)
+            Note over C: cli.approval_wait child span<br/>(human think-time, subtractable)
+            C->>H: resume (new HTTP request → new hub trace)
+            H->>E: new fin_assist.task span<br/>Link(resume_from_approval)
+            E->>E: emit fin_assist.approval_decided span<br/>Link(approval_for)
+        end
+
+        alt Exception during stream
+            E->>E: task.state=failed
+            E->>E: updater.failed() → FAILED
+            H-->>C: SSE: TaskStatusUpdateEvent (failed)
+        end
+
+        E->>SH: await result()
+        SH-->>E: RunResult (output, serialized_history, new_message_parts)
+
+        E->>CS: save(context_id, serialized_history)
+
+        loop new_message_parts (thinking blocks, etc.)
+            E->>H: updater.update_status(WORKING, message=part)
+            H-->>C: SSE: TaskStatusUpdateEvent (WORKING + message)
+        end
+
+        alt Structured output (non-str)
+            E->>B: convert_result_to_part(output)
+            B-->>E: Part (data + json_schema metadata)
+            E->>H: updater.add_artifact(structured, new artifact_id)
+            H-->>C: SSE: TaskArtifactUpdateEvent (structured)
+        end
+
+        E->>E: task.state=completed
+        E->>E: updater.complete() → COMPLETED
+        H-->>C: SSE: TaskStatusUpdateEvent (completed)
+    end
+```
+
+## HITL pause/resume
+
+Tool calls requiring human approval pause the hub task (`requires_input`) and the CLI waits for the user's y/N. The resume opens a **new** HTTP request → new hub trace → new `fin_assist.task` span. Continuity across the pause:
+
+1. At pause, the hub executor emits `fin_assist.approval_request` (a zero-duration span — OTel spans cannot be reopened across processes, so the "wait" is represented implicitly by the time-gap between this span's end and the resumed trace's start).
+2. The executor persists the paused span's `SpanContext` + original `user_input` via `ContextStore.save_pause_state`.
+3. At resume, the new task span carries a `Link(resume_from_approval)` back to the paused `approval_request` span, and emits `fin_assist.approval_decided` as its first child with a second `Link(approval_for)` to the same target.
+4. The CLI root span stays open across the approval wait (no 30-min timeout today — tracked as follow-up), and wraps the y/N prompt in a `cli.approval_wait` child so dashboards can subtract human think-time.
+
+In Phoenix the two hub traces appear as siblings, joined by the Link (rendered as "jump to related trace") and by the shared `fin_assist.cli.invocation_id` attribute. The CLI trace is a third sibling that contains both hub traces as link targets via its child HTTP spans.
+
+## Task state attribute
+
+`fin_assist.task.state` (`running` → `completed` / `failed` / `paused_for_approval`) is the canonical Phoenix filter for task-level queries. One attribute with a small enum keeps queries simple — one equality check per state instead of a compound predicate across several booleans.
+
+## Skill spans
+
+Skill activations are observable:
+
+- **CLI-side**: `cli_root_span(skill="commit")` stamps `fin_assist.cli.skill` on the CLI root span when a skill is pre-loaded via `--skill` flag or positional syntax
+- **Hub-side**: `fin_assist.skill_load` span emitted via `_TaskTracer.emit_skill_load_span()` when a skill is loaded during a task (agent-driven `load_skill` tool). Carries `fin_assist.skill.id`, `fin_assist.skill.entry_point`, `fin_assist.skill.tools_unlocked`
+- **Task span**: `start_task_span(skill_id="commit")` stamps `fin_assist.skill.id` on the task span when the skill was pre-loaded before the task started
+
+## Noise suppression
+
+Two upstream instrumentors were disabled because they produce high-volume, low-value spans:
+
+- **a2a-sdk**'s `@trace_class` decorator wraps every internal queue / task-store method with a `SpanKind.SERVER` span. Disabled via `OTEL_INSTRUMENTATION_A2A_SDK_ENABLED=false` (vendor-supported env off-switch, set by `setup_tracing` via `os.environ.setdefault` so operators can re-enable for debugging).
+- **FastAPIInstrumentor**'s per-SSE-chunk `http.response.body` span. Dropped in the export pipeline by `_DropSpansProcessor` (key on `asgi.event.type = "http.response.body"`, not on span name, so instrumentor-version renames don't break us).
+
+## Attribute hygiene
+
+Three classes of leaked/duplicate attributes are scrubbed at `on_end` before export:
+
+- `logfire.*` — pydantic-ai uses logfire as its internal tracing front-end; the `logfire.msg` / `logfire.json_schema` attrs ride along with no value for downstream consumers.
+- `final_result` on `agent run` spans — already duplicated as `output.value` (OpenInference) and `pydantic_ai.all_messages`. Dropping saves ~5–30KB per trace.
+- Duplicate `session.id` when identical to `fin_assist.context.id`.
+
+## Files
+
+- `src/fin_assist/hub/tracing.py` — vendor-agnostic TracerProvider builder (OTLP + JSONL file sink, plus drop + truncate + scrub processors)
+- `src/fin_assist/hub/tracing_attrs.py` — centralized attribute names and enum values (`FinAssistAttributes`, `TaskStateValues`, `SpanNames`)
+- `src/fin_assist/cli/tracing.py` — CLI-side tracer; `cli_root_span` / `approval_wait_span` context managers + `HTTPXClientInstrumentor` integration
+- `src/fin_assist/agents/pydantic_ai_tracing.py` — pydantic-ai → OpenInference bridge (the one place that imports `openinference.instrumentation.pydantic_ai`; kept isolated so the hub stays framework-neutral)
+
+## Local trace inspection
+
+Tracing is enabled by default in dev (`FIN_TRACING__ENABLED=true` in `devenv.nix`). Spans are written to:
+
+- **Phoenix** if running at `localhost:6006` (rich UI for trace exploration)
+- **`./.fin/traces.jsonl`** always — line-delimited JSON for grep/jq inspection without a UI

--- a/handoff.md
+++ b/handoff.md
@@ -15,6 +15,8 @@ In-flight design sketches and rolling session context. See `AGENTS.md` for what 
 
 ## Current state
 
+**2026-05-10:** Added "ToolProvider Protocol" design sketch — unifies tool registration across builtin, MCP, and file-based sources. Informs v0.1.1 (#84) architecture; ships progressively through v0.3. Updated milestone descriptions for v0.1.1, v0.2, v0.3 with ToolProvider context. Added comment to #84 with implementation sequence.
+
 **2026-05-09:** v0.1 shipped (PR #114, tag `v0.1`). 940 tests passing. v0.2 planning complete: backlog groomed (84 → 57 open issues), four-phase roadmap captured as milestones (v0.1.1 → v0.2 → v0.2.1 → v0.3). v0.2 anchor is in-process sub-agents as a context-compression primitive — see Design Sketch below.
 
 **Context-strategy refactor (across three sessions):** documented the issue/milestone split and doc-surface roles in `AGENTS.md`; pruned this file from 625 → ~220 lines; split the 1464-line `docs/architecture.md` into `architecture.md` (slim contracts + diagrams), `tracing.md`, `skills.md`, `decisions.md`, `configuration.md`; rewrote `README.md` with user-lens framing; ran code-validation pass and corrected ~25 drift items (signatures, defaults, phantom commands, unwired features).
@@ -23,7 +25,7 @@ In-flight design sketches and rolling session context. See `AGENTS.md` for what 
 
 **Recommended picks (in priority order):**
 
-1. **Begin v0.1.1 work** — slimmed to 7 focused issues: MCP ([#84](https://github.com/ColeB1722/fin-assist/issues/84)), pluggable prompts ([#89](https://github.com/ColeB1722/fin-assist/issues/89)), GitContext size limits ([#85](https://github.com/ColeB1722/fin-assist/issues/85)), Environment context ([#115](https://github.com/ColeB1722/fin-assist/issues/115)), and the three drift-wiring issues from doc-validation ([#123](https://github.com/ColeB1722/fin-assist/issues/123) skill tracing, [#124](https://github.com/ColeB1722/fin-assist/issues/124) `/connect`, [#125](https://github.com/ColeB1722/fin-assist/issues/125) SKILL.md runtime). Per-subcommand approval is still in v0.1.x scope but not yet filed as an issue.
+1. **Begin v0.1.1 work** — slimmed to 7 focused issues. Start with the `ToolProvider` protocol extraction (Phase A from the new Design Sketch) before #84 MCP implementation — it's a ~50-line refactor that prevents MCP from being bolted onto `create_default_registry()`. Then proceed with #84, #89, #85, #115, and the three drift-wiring issues (#123, #124, #125).
 2. **Resolve open questions in the sub-agents Design Sketch below** before implementation begins. There are 5 questions; answering them unblocks v0.2.
 
 **Sequence:** v0.1.1 (foundations) → [v0.1.2](https://github.com/ColeB1722/fin-assist/milestone/5) (visibility — badges + demo gif, [#127](https://github.com/ColeB1722/fin-assist/issues/127)) → v0.2 (sub-agents).
@@ -141,6 +143,140 @@ Sub-agents are the anchor, but several issues become much more useful once sub-a
 - **HITL inside sub-agents** — v0.3
 - **`report_format` argument** — v0.3
 - **Cross-agent skill invocation outside sub-agents** — explicitly NOT a feature; if you want skill B's tools while running agent A's skill, invoke a sub-agent with skill B loaded.
+
+---
+
+### ToolProvider Protocol: Unifying Tool Registration (sketched 2026-05-10)
+
+**Status:** Design sketch. Informs v0.1.1 (#84 MCP) architecture; ship progressively through v0.2–v0.3.
+
+**Problem:** `create_default_registry()` hardcodes 5 tools into `ToolRegistry`. Skills *reference* tools by name but can't *define* them. MCP (#84) adds a second tool source. The platform is becoming a tool host, but the registration architecture is still "platform defines, agents consume." This is the anti-pattern — tools should be discoverable from the agent's own repo/context, not hardcoded in the platform.
+
+**Concept:** Introduce a `ToolProvider` protocol that decouples tool *discovery* from tool *registration*. `ToolRegistry` becomes an aggregator of providers rather than a flat dict. Each provider contributes tools at startup (or lazily). This unifies three tool sources under one API:
+
+```text
+ToolProvider (protocol)
+├── BuiltinToolProvider     — migrated from create_default_registry()
+├── MCPToolProvider         — v0.1.1 (#84)
+└── FileToolProvider        — discovers .py tool files from configured directories
+```
+
+#### Industry patterns researched (2026-05-10)
+
+| Pattern | Framework | Mechanism |
+|---------|-----------|-----------|
+| Decorator + file discovery | Strands, Selectools | `@tool` on functions; auto-scan `.py` from directories; hot-reload |
+| Manifest + implementation | mcpp | `tool.yaml` (schema) + `mcpptool.py` (execute); lazy import on first call |
+| Extension registration | Pi | `pi.registerTool()` at runtime; progressive disclosure; dynamic add/remove |
+| Filesystem browsing | AgentPatterns.ai | Tools as files in directory tree; agent navigates on-demand (98% token reduction vs upfront registration) |
+| Auto-discovery from modules | InitRunner | `custom` tool type: import module, scan for public functions → register all |
+| Plugin registry | R2R | Built-in path + user-tools path; `inspect` for `Tool` subclasses |
+
+Key takeaway: the two dominant models are **decorator-based auto-discovery** (scan `.py`, find `@tool` functions — most Pythonic) and **manifest + implementation** (separate schema from code — most portable). We should support both.
+
+#### ToolProvider protocol
+
+```python
+class ToolProvider(Protocol):
+    """Discovers and contributes ToolDefinitions to the registry."""
+
+    def discover(self) -> list[ToolDefinition]:
+        """Return all tools this provider contributes. Called at startup."""
+        ...
+
+    @property
+    def name(self) -> str:
+        """Provider identifier for logging and debugging."""
+        ...
+```
+
+`ToolRegistry` gains a provider-aggregation layer:
+
+```python
+class ToolRegistry:
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolDefinition] = {}
+        self._providers: dict[str, ToolProvider] = {}
+
+    def add_provider(self, provider: ToolProvider) -> None:
+        """Register a provider and merge its tools into the registry."""
+        self._providers[provider.name] = provider
+        for tool in provider.discover():
+            self.register(tool)
+
+    def get_provider(self, name: str) -> ToolProvider | None: ...
+```
+
+Existing `register()` / `get()` / `get_for_agent()` APIs unchanged — providers are an *ingestion path*, not a new query interface.
+
+#### FileToolProvider — file-based tool discovery
+
+This is the new capability. Analogous to how skills are discovered from `.fin/skills/`, tools are discovered from `.fin/tools/` (project-local) and `~/.config/fin/tools/` (user-global).
+
+**Directory convention:**
+
+```text
+.fin/tools/
+├── deploy.py          # single-function tool
+├── db_query.py        # module with multiple tools
+└── s3/
+    ├── __init__.py
+    ├── list_objects.py
+    └── upload.py
+```
+
+**Discovery rules:**
+1. Scan `.fin/tools/` and `~/.config/fin/tools/` for `.py` files
+2. For each file, import the module and scan for functions decorated with `@tool` (our own decorator, not pydantic-ai's)
+3. If no `@tool` functions found, fall back to scanning for public callables with type-hinted signatures + docstrings (InitRunner pattern)
+4. Project-local takes precedence over user-global for name collisions
+5. Skip files starting with `_`
+
+**`@tool` decorator:**
+
+```python
+from fin_assist.agents.tools import tool, ApprovalPolicy
+
+@tool(
+    description="Deploy the current branch to staging",
+    approval=ApprovalPolicy(default="always"),
+)
+def deploy(branch: str, env: str = "staging") -> str:
+    """Deploy the current branch."""
+    ...
+```
+
+The decorator is optional — plain functions with type hints and docstrings auto-register (schema derived from signature, like pydantic-ai's `tools=` argument). The decorator just lets you override description, approval policy, and name.
+
+**How this differs from skills:**
+- Skills *reference* tools by name; they don't define them
+- File-based tools *define* new callables; they're a tool *source*
+- A skill can reference a file-based tool the same way it references `git` or `read_file` — by name in `tools = [...]`
+
+#### Progressive shipping plan
+
+| Phase | What | Milestone |
+|-------|------|-----------|
+| **A: Protocol + BuiltinToolProvider** | Extract `ToolProvider` protocol; refactor `create_default_registry()` into `BuiltinToolProvider`; `ToolRegistry.add_provider()`. Zero behavior change — same 5 tools, same API. | v0.1.1 (#84 dependency) |
+| **B: MCPToolProvider** | Implement as part of #84. MCP servers discovered from config → `MCPToolProvider.discover()` returns `ToolDefinition` per MCP tool. | v0.1.1 (#84) |
+| **C: FileToolProvider** | New provider; `@tool` decorator; `.fin/tools/` discovery. First new capability — tools not defined by the platform. | v0.2 (sub-agents need per-agent tool sets) |
+| **D: Repo-as-tool-package** | Agent experiment repos ship with `.fin/tools/` + `.fin/skills/` + `evals/`; clone → discover → run. Tool packages as a first-class concept. | v0.3 (federated agents + eval) |
+
+Phase A is the critical path — if #84 ships without `ToolProvider`, MCP tools get bolted onto `create_default_registry()` and the retrofit is harder. The protocol costs ~50 lines; it should land before or alongside #84.
+
+#### Relation to sub-agents (v0.2)
+
+Sub-agents (`invoke_subagent`) construct a fresh `AgentSpec` with a constrained tool set. With `FileToolProvider`, a sub-agent's tools can come from its own `.fin/tools/` directory rather than the global registry. The `Executor.run_subtask()` call creates a scoped `ToolRegistry` with only the sub-agent's providers.
+
+This also means `invoke_subagent` can be replaced: instead of a hardcoded built-in tool, it becomes a file-defined tool in `.fin/tools/subagent.py`. The platform ships *defaults*, not *mandates*.
+
+#### Open questions
+
+1. **Lazy vs eager discovery.** Should `FileToolProvider.discover()` import all `.py` files at startup (eager, like current `create_default_registry`) or defer imports until the tool is first called (lazy, like mcpp)? Lean: eager at startup — simpler, errors surface early, and the tool count is small (<50 per project).
+2. **Approval policy for file-based tools.** Should file-defined tools default to `always` (safe) or `never` (convenient)? Lean: `always` — file-based tools are user code, unvetted. Explicit `@tool(approval=ApprovalPolicy(default="never"))` to opt out.
+3. **Tool name collision resolution.** What happens when a file-based tool has the same name as a built-in or MCP tool? Lean: raise at startup with a clear error (consistent with `ToolRegistry.register()` duplicate-name behavior). Override via explicit allowlist in config if needed.
+4. **`@tool` decorator location.** Should `@tool` live in `fin_assist.agents.tools` (next to `ToolDefinition`) or a new `fin_assist.agents.tool_decorator` module? Lean: `fin_assist.agents.tools` — keeps the tool API in one place.
+5. **Package-level discovery.** Should we support `fin_assist.tools` namespace packages (like R2R's built-in path)? Or just filesystem directories? Lean: filesystem only for now — namespace packages are an advanced pattern that can come later if needed.
 
 ---
 

--- a/handoff.md
+++ b/handoff.md
@@ -17,15 +17,15 @@ In-flight design sketches and rolling session context. See `AGENTS.md` for what 
 
 **2026-05-09:** v0.1 shipped (PR #114, tag `v0.1`). 940 tests passing. v0.2 planning complete: backlog groomed (84 → 57 open issues), four-phase roadmap captured as milestones (v0.1.1 → v0.2 → v0.2.1 → v0.3). v0.2 anchor is in-process sub-agents as a context-compression primitive — see Design Sketch below.
 
-**Context-strategy refactor (this session):** documented the issue/milestone split and the doc-surface roles in `AGENTS.md`; pruned this file from the previous 625-line accumulator down to its actual job (sketches + rolling context).
+**Context-strategy refactor (across two sessions):** documented the issue/milestone split and doc-surface roles in `AGENTS.md`; pruned this file from 625 → 210 lines; split the 1464-line `docs/architecture.md` into `architecture.md` (slim contracts + diagrams), `tracing.md`, `skills.md`, `decisions.md`, `configuration.md`; rewrote `README.md` with user-lens framing and a single user-friendly diagram surfacing skills/tools/agents.
 
 ## Next session
 
 **Recommended picks (in priority order):**
 
-1. **Begin v0.1.1 work** — start with MCP tool source ([#84](https://github.com/ColeB1722/fin-assist/issues/84)) or per-subcommand approval at executor level (see [v0.1.1 milestone](https://github.com/ColeB1722/fin-assist/milestone/1) for the full set).
-2. **Resolve open questions in the sub-agents Design Sketch below** before implementation begins. There are 5 questions; answering them unblocks v0.2.
-3. **Eventually:** split `docs/architecture.md` into focused files (`architecture.md` slim + `tracing.md` + `skills.md` + `decisions.md`) and beef up the README's "project soul" framing. Tracked as the next pass on the context-strategy refactor.
+1. **Commit the doc-split work** — five new docs + rewritten README + AGENTS.md/handoff.md/skills.py link fixups are unstaged.
+2. **Begin v0.1.1 work** — start with MCP tool source ([#84](https://github.com/ColeB1722/fin-assist/issues/84)) or per-subcommand approval at executor level (see [v0.1.1 milestone](https://github.com/ColeB1722/fin-assist/milestone/1) for the full set).
+3. **Resolve open questions in the sub-agents Design Sketch below** before implementation begins. There are 5 questions; answering them unblocks v0.2.
 
 ---
 
@@ -193,7 +193,19 @@ phase = "experimental"
 
 ## Recent work
 
-### 2026-05-09 — Context-strategy refactor
+### 2026-05-09 (later) — Doc split + README "project soul" pass
+
+- Split `docs/architecture.md` (1464 lines) into focused docs:
+  - `docs/architecture.md` (~330 lines) — slim: principles, contracts, hub structure, A2A integration, structural request flow. Keeps Hub Internals + Backend Layer Mermaid diagrams.
+  - `docs/tracing.md` (~140 lines) — extracted tracing prose plus the full instrumented request-flow sequence diagram (with HITL pause/resume).
+  - `docs/skills.md` (~170 lines) — extracted skills section.
+  - `docs/decisions.md` (~70 lines) — Appendix Design Decisions + Open Questions table + External Federation deep-dive.
+  - `docs/configuration.md` (~110 lines) — extracted config schema, env var convention pointer, credential storage.
+- Rewrote `README.md` (256 → ~140 lines) with a user-lens framing: example `fin do git commit` interaction up top, single user-friendly Mermaid diagram surfacing skills/tools/agents/approval (replaces the 4 developer-lens diagrams which moved to `docs/`), getting-started flow, 30-second config example. Deleted the 17-row Status phase table (milestones own that now).
+- Deleted from old architecture.md: ASCII System Overview + Component Diagram (160 lines, redundant with new Mermaid), Directory Structure tree (110 lines), Implementation Phases (150 lines, git log territory), Future Considerations long-term/deferred bullets, Related Documents/Issues sections.
+- Fixed link references: `AGENTS.md` x5 (architecture.md → specific deep-dives where relevant), `handoff.md` x1, `src/fin_assist/agents/skills.py:19` (architecture.md → docs/skills.md). `.coderabbit.yaml` references kept (architecture.md still canonical for component contracts).
+
+### 2026-05-09 (earlier) — Context-strategy refactor
 
 - Added `Context Strategy` section to `AGENTS.md` documenting the surface/job/cadence table and the issue-vs-milestone rule.
 - Slimmed `AGENTS.md` "Session Handoffs" subsection to match handoff.md's narrowed role.

--- a/handoff.md
+++ b/handoff.md
@@ -1,111 +1,31 @@
 # Handoff Document
 
-Rolling context for session handoffs. Updated as checkpoints are reached.
+In-flight design sketches and rolling session context. See `AGENTS.md` for what this file is and isn't.
 
-**Current state (2026-05-09):** v0.1 shipped (PR #114, tag `v0.1`). 940 tests passing. v0.2 planning complete: backlog groomed (84 → 57 open), four-phase roadmap (v0.1.1 → v0.2 → v0.2.1 → v0.3), sub-agent design sketch captured. v0.2 anchor is in-process sub-agents as a context-compression primitive — see Design Sketch.
+**Forever-docs:**
+- Project overview & status table → [README.md](README.md)
+- Architecture → [docs/architecture.md](docs/architecture.md)
+- Workflow & conventions → [AGENTS.md](AGENTS.md)
 
-**Recent work (this session):**
-
-1. **Steps 11–14: Skill loading refactor completion** — Implemented REPL `/skills` + `/skill:<name>` commands with `SkillCompleter` (rapidfuzz fuzzy matching, mirrors `@file:` pattern), skill tracing attributes/spans (`fin_assist.skill_load`, `fin_assist.cli.skill`), and updated all docs (architecture.md Skills Architecture rewrite, AGENTS.md skill authoring section, Phase 15 checklist)
-2. **Steps 1–10, 13 (previous session)** — Config schema migration (`ApprovalConfig` → `ToolPolicyConfig`, `base_tools`, `tool_policies`), `AgentSpec` tool gating, `SkillManager.loaded_tool_names()`, `_build_pydantic_agent()` gates tools by loaded skills, `skills/invoke` + `GET /skills` endpoints, CLI `invoke_skill()`/`list_skills()` client methods, `_resolve_skill()` 3-tuple return, all existing tests updated
-
-**Core platform status:**
-
-| Area | Status |
-|------|--------|
-| Executor rework + tool calling | ✅ Complete (PR #87) |
-| HITL approval | ✅ Complete |
-| ContextProviders dual path | ✅ Complete |
-| Streaming UX | ✅ Complete |
-| `fin do` input panel + `--edit` | ✅ Complete |
-| `@`-completion | ✅ Complete |
-| `fin list` capabilities | ✅ Complete |
-| Remove built-in agents | ✅ Complete |
-| Client artifact-merge fix | ✅ Complete |
-| Git agent (#79) | ✅ Complete |
-| Observability / tracing | ✅ Complete (PR #103 + hardening + UX pass) |
-
-**Remaining tracked items:**
-
-- AgentBackend protocol simplification ([#80](https://github.com/ColeB1722/fin-assist/issues/80))
-- `supported_context_types` / `_CONTEXT_TYPE_HINTS` — CLI/BFF boundary not drawn explicitly; context-to-tool mapping lives in `agents/spec.py` but is a client concern. Needs broader architecture discussion: define CLI (display) vs BFF (context resolution, prompt shaping) vs hub/agent boundary, AgentCardMeta cleanup, and where context ownership should land.
-- MCP tool source — v0.1.1 ([#84](https://github.com/ColeB1722/fin-assist/issues/84))
-- Per-subcommand approval evaluation at executor level — v0.1.1
-- Sub-agents (in-process, context-compression primitive) — v0.2 (see Design Sketch below)
-- Sub-agents (federated via A2A) + Eval harness — v0.3
-- Phase 4 architectural discussions — issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94)
+**Live planning:**
+- Committed work → [GitHub milestones](https://github.com/ColeB1722/fin-assist/milestones)
+- Discussions / ideas / out-of-scope bugs → [GitHub issues](https://github.com/ColeB1722/fin-assist/issues)
 
 ---
 
-## Next Session
+## Current state
+
+**2026-05-09:** v0.1 shipped (PR #114, tag `v0.1`). 940 tests passing. v0.2 planning complete: backlog groomed (84 → 57 open issues), four-phase roadmap captured as milestones (v0.1.1 → v0.2 → v0.2.1 → v0.3). v0.2 anchor is in-process sub-agents as a context-compression primitive — see Design Sketch below.
+
+**Context-strategy refactor (this session):** documented the issue/milestone split and the doc-surface roles in `AGENTS.md`; pruned this file from the previous 625-line accumulator down to its actual job (sketches + rolling context).
+
+## Next session
 
 **Recommended picks (in priority order):**
 
-1. **Manual review of skill loading refactor** — Verify tool gating works end-to-end (unloaded skill tools unavailable), `/skills` and `/skill:<name>` in REPL, agent-level policies applied correctly, tracing spans emitted.
-2. **Part 2 interactive manual tests** — Run through `docs/manual-testing.md` sections 2a-2f at a TTY.
-3. **Tag v0.1.0** — After manual review + interactive test pass.
-
-### Sequenced roadmap
-
-Post-v0.1 work is organized into four phases. Each phase ships under its own tag.
-
-**Pre-v0.1.1 — Backlog grooming** (✅ complete 2026-05-09): closed 27 stale issues (84 → 57 open). Verified shipped items, removed Textual-era issues (UI module deleted), collapsed duplicates, marked superseded items.
-
-| Phase | Tag | Scope | Status |
-|-------|-----|-------|--------|
-| 1 | **v0.1.1** | MCP tool source ([#84](https://github.com/ColeB1722/fin-assist/issues/84)), per-subcommand approval at executor level, pluggable system prompts ([#89](https://github.com/ColeB1722/fin-assist/issues/89)), registry consistency + policy resolution audit, SQLite/storage hardening ([#40](https://github.com/ColeB1722/fin-assist/issues/40), [#42](https://github.com/ColeB1722/fin-assist/issues/42), [#75](https://github.com/ColeB1722/fin-assist/issues/75)), constant placement ([#122](https://github.com/ColeB1722/fin-assist/issues/122)), chore-batch (#26, #33, #41, #43, #45, #46, #65, #76, #116, #117, #118, #119) | ⬜ Queued |
-| 2 | **v0.2** | Sub-agents in-process — context-compression primitive (see Design Sketch). Includes: HITL rationale ([#121](https://github.com/ColeB1722/fin-assist/issues/121)), context-aware compaction ([#102](https://github.com/ColeB1722/fin-assist/issues/102)), workflow chaining ([#63](https://github.com/ColeB1722/fin-assist/issues/63)), background tasks ([#110](https://github.com/ColeB1722/fin-assist/issues/110)), multi-choice HITL ([#113](https://github.com/ColeB1722/fin-assist/issues/113)). Exit gate: [#31](https://github.com/ColeB1722/fin-assist/issues/31) SDD+TDD pipeline runs end-to-end | ⬜ Queued |
-| 3 | **v0.2.1** | UX polish — render_stream simplification ([#92](https://github.com/ColeB1722/fin-assist/issues/92)), progressive thinking ([#72](https://github.com/ColeB1722/fin-assist/issues/72)), richer tool_result ([#91](https://github.com/ColeB1722/fin-assist/issues/91)), CLI constants ([#90](https://github.com/ColeB1722/fin-assist/issues/90)), `/spec` command ([#95](https://github.com/ColeB1722/fin-assist/issues/95)), `$EDITOR` for `--edit` ([#97](https://github.com/ColeB1722/fin-assist/issues/97)), `fin do` vs `fin prompt` clarity ([#94](https://github.com/ColeB1722/fin-assist/issues/94)), tracing follow-ups (#106, #107, #108, #109) | ⬜ Queued |
-| 4 | **v0.3** | Sub-agents federated via A2A (Flavor 2) + per-agent eval harness | ⬜ Queued |
-
-**Already shipped pre-v0.1:**
-
-- Tracing: OTel + OpenInference bridge — follow-ups #106-#109 deferred to v0.2.1
-- Skills API v0.1 (PR #114) — 940 tests, tool gating, agent-level policies, REPL `/skills`
-
----
-
-## Implementation Progress
-
-| Phase | Description | Status |
-|-------|-------------|--------|
-| 1–8b | Core platform (repo setup → CLI REPL) | ✅ Complete |
-| — | Config-Driven Redesign | ✅ Complete |
-| — | a2a-sdk migration | ✅ Complete |
-| — | Backend Extraction (AgentSpec pure config) | ✅ Complete |
-| — | Auth-Required Credential Pre-Check | ✅ Complete |
-| — | Reliable Server Lifecycle (fcntl PID lock) | ✅ Complete |
-| — | Shared Render Pipeline | ✅ Complete |
-| — | Streaming UX Refactor | ✅ Complete |
-| — | Unified Executor + Tools + HITL (PR #87) | ✅ Complete |
-| — | `FIN_DATA_DIR` unified path | ✅ Complete |
-| — | Remove built-in agents | ✅ Complete |
-| — | `fin do` + `--edit` + `--agent` | ✅ Complete |
-| — | `@`-completion | ✅ Complete |
-| — | `fin list` capabilities | ✅ Complete |
-| — | Client artifact-merge fix | ✅ Complete |
-| — | ContextSettings forwarded to tool callables | ✅ Complete |
-| — | PR #87 self-review triage | ✅ Complete |
-| — | Phase 4 architecture discussions | 📐 Filed as #89–#94 |
-| — | Documentation sync | ✅ Complete (architecture.md, manual-testing.md, README, AGENTS.md) |
-| — | Git agent (#79) | ✅ Complete |
-| — | Phoenix/OTel tracing (PR #103) | ✅ Complete |
-| — | Telemetry Hardening Phase 2 | ✅ Complete |
-| — | JSONL file exporter (#105) | ✅ Complete |
-| — | Tracing UX pass (#104) | ✅ Complete |
-| — | PR #103 code review fixes | ✅ Complete |
-| — | Skill loading refactor (tool gating + agent-level policies) | ✅ Complete — Steps 1–14, 940 tests |
-| 9b | Full SSE Streaming | ✅ Covered by a2a-sdk migration |
-| 10 | Non-blocking + interactive tasks | 📐 Superseded by deferred tools |
-| 11 | Multiplexer Integration | ⬜ Not Started |
-| 12 | Fish Plugin | ⬜ Not Started |
-| 13 | TUI Client | ⬜ Not Started |
-| 14 | Testing Infrastructure (Deep Evals) | ⬜ Queued |
-| 15 | Skills + MCP Integration | ✅ Skills API v0.1 shipped + skill loading refactor (tool gating, agent-level policies, REPL commands, tracing); MCP queued for v0.1.1 |
-| 16 | Additional Agents | 🔄 Git shipped |
-| 17 | Multi-Agent Workflows | ⬜ Not Started |
-| 18 | Documentation | ⬜ Not Started |
-| — | Nix/Home Manager packaging | 📐 Sketched |
+1. **Begin v0.1.1 work** — start with MCP tool source ([#84](https://github.com/ColeB1722/fin-assist/issues/84)) or per-subcommand approval at executor level (see [v0.1.1 milestone](https://github.com/ColeB1722/fin-assist/milestone/1) for the full set).
+2. **Resolve open questions in the sub-agents Design Sketch below** before implementation begins. There are 5 questions; answering them unblocks v0.2.
+3. **Eventually:** split `docs/architecture.md` into focused files (`architecture.md` slim + `tracing.md` + `skills.md` + `decisions.md`) and beef up the README's "project soul" framing. Tracked as the next pass on the context-strategy refactor.
 
 ---
 
@@ -271,355 +191,20 @@ phase = "experimental"
 
 ---
 
-### Tracing (OTel + OpenInference, shipped 2026-04-29)
+## Recent work
 
-Three incremental phases, all shipped:
+### 2026-05-09 — Context-strategy refactor
 
-**Phase 1 — Baseline OTel spans** (PR #103): `setup_tracing` in `hub/tracing.py` builds a vendor-agnostic `TracerProvider` + `OTLPSpanExporter`. Executor emits `fin_assist.task`, `fin_assist.step`, `fin_assist.tool_execution`, `fin_assist.approval_request`/`approval_decided` spans with OpenInference semantic convention attributes. Backends install their own instrumentation via `AgentBackend.install_tracing(provider)` hook. `hub/tracing_attrs.py` is the single source of truth for attribute/span constants.
+- Added `Context Strategy` section to `AGENTS.md` documenting the surface/job/cadence table and the issue-vs-milestone rule.
+- Slimmed `AGENTS.md` "Session Handoffs" subsection to match handoff.md's narrowed role.
+- Pruned `handoff.md` from 625 lines to its actual job: current state header + Design Sketches + rolling session log. Removed the Implementation Progress table, the Sequenced Roadmap table (milestones own this now), the Tracing/_TaskTracer/Skills-API historical implementation logs (git log territory), the Historical Reference section, and the duplicated Notes/Quick-Start sections.
 
-**Phase 2 — OpenInference bridge + HITL continuity**: `agents/pydantic_ai_tracing.py` adds `OpenInferenceSpanProcessor` (translates `gen_ai.*` → `llm.*` + `openinference.span.kind=LLM`). HITL two-span model: at pause, `approval_request` span ended + `save_pause_state` persists SpanContext + user_input; at resume, new task span with `Link(prev_ctx)`, `approval_decided` child span. `TracingSettings` has `sampling_ratio`, `headers`, `event_mode`, `include_content` knobs. JSONL file exporter (`hub/file_exporter.py`) always writes to `paths.TRACES_PATH` when tracing is enabled — no config knob, toggled via `enabled`.
+### 2026-05-09 (earlier) — v0.2 planning
 
-**Phase 3 — UX pass** (#104): CLI tracer (`cli/tracing.py`) with `cli.<command>` root spans + `HTTPXClientInstrumentor` + Baggage-propagated `fin_assist.cli.invocation_id`. `_DropSpansProcessor` filters ASGI/a2a-sdk noise. `FinAssistAttributes.TASK_STATE` enum replaces binary flag. `_scrub_span_attributes` strips `logfire.*`, `final_result`, duplicate `session.id`. One `fin do` = 1 CLI trace + 1 hub trace, ~30-40 useful spans.
+- Backlog grooming pass: 84 → 57 open issues. Closed 27 stale items (shipped, Textual-era, duplicates, superseded). Chore-batched 9 small items into v0.1.1.
+- Created four GitHub milestones with descriptions: [v0.1.1](https://github.com/ColeB1722/fin-assist/milestone/1), [v0.2](https://github.com/ColeB1722/fin-assist/milestone/2), [v0.2.1](https://github.com/ColeB1722/fin-assist/milestone/3), [v0.3](https://github.com/ColeB1722/fin-assist/milestone/4).
+- Aligned on sub-agents as v0.2 anchor (rejecting transitive `requires` field on skills); split into in-process (v0.2) vs federated (v0.3) flavors with shared caller-side API. Captured as Design Sketch above.
 
-**Key architectural invariants:**
+### 2026-05-03 — Skill loading refactor (v0.1)
 
-- `hub/tracing.py` and `hub/executor.py` never import from `openinference.instrumentation.*` — only backends do
-- `hub/tracing_attrs.py` re-exports semconv constants — treated as pure spec, not coupling
-- OpenInference is semantic conventions (attribute *names* like `input.value`, `tool.name`), not a framework — any OTel backend stores spans with these attributes
-- JSONL sink is always-on when tracing enabled, writes to `$FIN_DATA_DIR/traces.jsonl` via `paths.TRACES_PATH`
-- `OTEL_INSTRUMENTATION_A2A_SDK_ENABLED=false` set in `__init__.py` (before a2a-sdk import) to suppress `@trace_class` noise
-
-**Span hierarchy:**
-
-```text
-HTTP POST /agents/{name}/ (FastAPI auto-instrumentation)
-  └── fin_assist.task (AGENT)
-        ├── fin_assist.step (CHAIN)
-        │     └── chat {model} (CLIENT, via instrument_all)
-        ├── fin_assist.step (CHAIN)
-        │     ├── fin_assist.tool_execution (TOOL)
-        │     └── chat {model} (CLIENT)
-        ├── fin_assist.step (CHAIN)
-        │     └── fin_assist.approval_request (TOOL, paused)
-        └── (resume: new trace with Link back)
-              └── fin_assist.approval_decided (TOOL)
-```
-
-**Initialization order** (`fin serve` / `fin do`):
-
-1. Backends constructed
-2. `setup_tracing(config.tracing, backends)` — builds provider, calls `backend.install_tracing(provider)` for each
-3. `create_hub_app`
-4. `FastAPIInstrumentor.instrument_app(app)`
-5. CLI: `setup_cli_tracing(config.tracing)` — separate provider writing to same JSONL
-
-**Follow-up issues:** [#104](https://github.com/ColeB1722/fin-assist/issues/104) (W3C traceparent), [#106](https://github.com/ColeB1722/fin-assist/issues/106) (multi-exporter), [#107](https://github.com/ColeB1722/fin-assist/issues/107) (event_mode=logs), [#108](https://github.com/ColeB1722/fin-assist/issues/108) (retry-aware tool spans), [#109](https://github.com/ColeB1722/fin-assist/issues/109) (OTLP probing), [#111](https://github.com/ColeB1722/fin-assist/issues/111) (code review quality improvements).
-
----
-
-### _TaskTracer Extraction (completed)
-
-**Status:** Implemented in `hub/_task_tracer.py`.
-
-**What changed:** `executor.py` had 6 tracing fields on `_ExecutionContext` and 8 tracing methods on `Executor`, interleaving A2A task lifecycle and OTel span lifecycle. Extracted all span creation, attribute setting, and context token management into `_TaskTracer` (new file `hub/_task_tracer.py`). `_ExecutionContext` now has a single `tracer: _TaskTracer` field; the executor delegates span operations via `ctx.tracer.start_task_span(...)`, `ctx.tracer.end_step_span()`, etc.
-
-**Results:**
-- `_ExecutionContext`: 13 fields → 8 (6 tracing fields → 1 `tracer` reference)
-- `Executor`: lost `_start_step_span`, `_end_step_span`, `_start_tool_span`, `_end_tool_span`, `_make_link`, `_emit_approval_decided_span`, `_handle_deferred_event`, `_detach_task_context`, `_read_invocation_id_from_baggage`, `_active_tracer` property, `_tracer` field
-- `execute()`: ~135 lines → ~50 lines of business flow
-- `_pause_for_approval()`, `_finalize()`: inline span code replaced by single tracer calls
-- `_dispatch_step_event()`: each event case now has 1 tracer call + A2A artifact logic
-- `_handle_deferred_event()` split into `tracer.emit_approval_request_span(event)` + `_emit_deferred_artifact()`
-- `executor.py` has zero OTel imports — all span lifecycle lives in `_task_tracer.py`
-- All 880 tests pass unchanged
-
----
-
-### Skills API: v0.1 Implementation (shipped 2026-05-01, review triage 2026-05-02, refactor 2026-05-03)
-
-**Status:** Complete including skill loading refactor. 940 tests passing, `just ci` green.
-
-**What was implemented:**
-
-1. **`ApprovalRule` + `ApprovalPolicy.evaluate()`** — fnmatch-based per-subcommand approval rules. First-match semantics with `default` fallback. Replaces the old binary `always`/`never` mode.
-
-2. **`SkillConfig`** — config schema type for inline TOML skill definitions. Added to `AgentConfig.skills: dict[str, SkillConfig]`. No approval field — policies moved to agent level.
-
-3. **`SkillDefinition`, `SkillCatalog`, `SkillLoader`, `SkillManager`** — runtime types in `agents/skills.py`. `SkillLoader` resolves both inline TOML and SKILL.md files. `SkillManager` tracks loaded skills, provides `load_skill` callable, `loaded_tool_names()`, and generates catalog text.
-
-4. **SKILL.md file loader** — parses YAML frontmatter + markdown body following agentskills.io convention. Discovery from `.fin/skills/` and `~/.config/fin/skills/`. fin-assist extensions under `metadata.fin-assist.*`.
-
-5. **Config migration** — `config.toml` migrated from `tools`/`workflows` to `skills` with agent-level `tool_policies`. `WorkflowConfig` and `--workflow` CLI flag removed. `--skill` CLI flag. `base_tools` (default `["read_file"]`) for always-available tools.
-
-6. **Tool gating** — `_build_pydantic_agent()` registers only `base_tools` + `SkillManager.loaded_tool_names()`. Skills not loaded = tools not registered. Called on every `step()`, so loading takes effect next turn.
-
-7. **Agent-level tool policies** — `ToolPolicyConfig`/`ToolPolicyRuleConfig` replace per-skill `ApprovalConfig`. `_get_agent_tool_policy()` resolves policies per tool. Each tool has exactly one policy definition — no merge conflicts.
-
-8. **`skills/invoke` + `GET /skills` endpoints** — `POST /agents/{name}/skills/invoke` pre-loads a skill server-side. `GET /agents/{name}/skills` lists available skills. `HubClient.invoke_skill()` and `HubClient.list_skills()` client methods.
-
-9. **REPL `/skills` + `/skill:<name>`** — `/skills` lists available skills. `/skill:<name>` loads a skill mid-session via `invoke_skill_fn`. `SkillCompleter` with rapidfuzz fuzzy matching on `/skill:` prefix (mirrors `@file:` pattern).
-
-10. **Skill tracing** — `fin_assist.skill_load` span via `_TaskTracer.emit_skill_load_span()`. `fin_assist.skill.id`, `fin_assist.skill.entry_point`, `fin_assist.skill.tools_unlocked` attributes. `fin_assist.cli.skill` on CLI root span. `skill_id` param on `start_task_span()`.
-
-11. **`fin list skills`** — lists config-defined and SKILL.md-discovered skills, grouped by agent name.
-
-**Key design decisions:**
-
-- Skills are additive (no unloading in v0.1)
-- Tools shared across skills; name collisions = config error
-- Tool gating: `base_tools` + `loaded_tool_names()` only — LLM can't use unloaded tools
-- Agent-level `tool_policies` replace per-skill `approval` — each tool has exactly one policy
-- `base_tools` default `["read_file"]` — agents always need file reading
-- `_build_pydantic_agent()` called on every `step()` — skill loading takes effect next turn
-- `/skill:<name>` mirrors `@file:` pattern with `SkillCompleter` + rapidfuzz
-
-**Bug fixes shipped alongside:**
-
-- FileHistory dir creation (#54/#51) — `prompt.py:_build_session()` now creates parent dir
-- Malformed session file crash (#81) — `display.py:render_session_list()` catches JSONDecodeError
-- AgentCard version from package metadata (#78) — `factory.py` uses `importlib.metadata.version()`
-- `MessageToDict` consolidation (#86) — all direct calls replaced with `struct_to_dict()` from `protobuf.py`
-
-**New files:**
-- `src/fin_assist/agents/skills.py`
-- `tests/test_agents/test_skills.py`
-- `tests/test_agents/test_approval_policy_evaluate.py`
-
-**Modified files (key):**
-- `src/fin_assist/agents/tools.py` — `ApprovalRule`, `ApprovalPolicy.evaluate()`, simplified `__post_init__`
-- `src/fin_assist/agents/spec.py` — `skills` property (`dict[str, SkillConfig]`), derived `tools`, `_CONTEXT_TYPE_HINTS`, `get_skill_definitions()`
-- `src/fin_assist/agents/backend.py` — skill-based approval overrides, `load_skill` tool, catalog in prompt, public API for skill manager
-- `src/fin_assist/agents/skills.py` — YAML approval rule validation
-- `src/fin_assist/config/schema.py` — `SkillConfig`, `ApprovalConfig`, `ApprovalRuleConfig`; removed `WorkflowConfig`
-- `src/fin_assist/cli/main.py` — `_resolve_skill`, `--skill` flag, `fin list skills` grouped by agent
-- `src/fin_assist/hub/factory.py` — `PackageNotFoundError` fallback, version from metadata
-- `config.toml` — migrated to skills format
-
-**Post-v0.1 roadmap:**
-
-| Version | Feature |
-|---------|---------|
-| v0.1.1 | MCP tool source — `MCPToolset` registers discovered tools into `ToolRegistry` |
-| v0.1.1 | Pluggable base system prompts — user-overridable prompt templates, not hardcoded Python constants |
-| v0.1.1 | Per-subcommand approval evaluation at executor level |
-| v0.2 | Skill composability (skills invoking skills) + agent-to-agent orchestration |
-| v0.3 | Eval harness |
-
----
-
-### Skills API: Original Design Sketch (for reference)
-
-**Status:** Sketch resolved 2026-04-27. Ready to start Phase A.
-
-**Why this exists:** scoped CLI + WorkflowConfig pattern from the git agent is a prototype for the broader Skills API. Split into three sequenced phases, each independently shippable.
-
-**Grounding citations:**
-
-- Scoped CLI prototype + TODO for per-subcommand approval: `src/fin_assist/agents/tools.py:213`, `src/fin_assist/agents/tools.py:295`
-- Current `ApprovalPolicy` shape (only `never`/`always`, no rules): `src/fin_assist/agents/tools.py:40`
-- `AgentConfig.tools` flat list of names: `src/fin_assist/config/schema.py:99` *(field removed — tools now derive from skill union)*
-- Skills API vision: `docs/architecture.md:991`–`:1007`
-
----
-
-#### Phase A — Subcommand approval rules
-
-**Goal:** `git diff` runs un-gated; `git push` still asks. Aligned with TODO at `tools.py:213`.
-
-**Design:**
-
-```python
-@dataclass
-class ApprovalRule:
-    pattern: str            # fnmatch glob against full args string
-    mode: Literal["never", "always"]
-    reason: str | None = None
-
-@dataclass
-class ApprovalPolicy:
-    mode: Literal["never", "always"]        # fallback when no rule matches
-    rules: list[ApprovalRule] = field(default_factory=list)
-    reason: str | None = None
-
-    def evaluate(self, args: str) -> tuple[Literal["never", "always"], str | None]:
-        for r in self.rules:
-            if fnmatch(args, r.pattern):
-                return r.mode, r.reason
-        return self.mode, self.reason
-```
-
-**Touchpoints:**
-
-- `src/fin_assist/agents/tools.py:40` — extend `ApprovalPolicy`
-- `src/fin_assist/agents/tools.py:295` — `_make_scoped_cli` callable queries `policy.evaluate(args)` per call
-- Backend adapter — switch from static `requires_approval` to per-call evaluation
-- Rules still Python-defined in `create_default_registry()` — no config schema change yet
-
-**TDD tests:**
-
-- `test_approval_policy_evaluate.py`: pattern matching, first-match-wins, fallback to `mode`, empty rules
-- `test_tools_scoped_cli_approval.py`: `git diff` → never, `git push origin main` → always
-- Executor integration: deferred `StepEvent` emitted only when `evaluate()` returns `always`
-
-**Exit gate:** through the git agent, `git diff` runs without prompt; `git push` still pauses.
-
----
-
-#### Phase B — Skill bundling (ToolDefinition → SkillDefinition)
-
-**Goal:** one TOML object bundles a scoped CLI + its approval rules + named scripts + workflows.
-
-**Design (TOML shape):**
-
-```toml
-[skills.git]
-type = "cli"
-prefix = "git"
-description = "Run any git subcommand."
-
-[skills.git.approval]
-default = "always"
-rules = [
-  { pattern = "diff*",   mode = "never" },
-  { pattern = "status*", mode = "never" },
-  { pattern = "log*",    mode = "never" },
-]
-
-[skills.git.scripts.pr-checklist]
-description = "Print the PR review checklist"
-path = "scripts/git/pr-checklist.sh"
-approval = "never"
-
-[skills.git.workflows.commit]
-description = "Generate a conventional commit message."
-prompt_template = "git-commit"
-entry_prompt = "Analyze the current staged and unstaged changes..."
-```
-
-**Touchpoints:** new `src/fin_assist/skills/` package (definition, loader, registration), `config/schema.py` add `skills: dict[str, SkillConfig]`, migrate workflows from `AgentConfig` to `SkillConfig`, update `cli/main.py` workflow resolution.
-
-**Exit gate:** config.toml defines `skills.git` with rules + scripts; second skill authored end-to-end in TOML as validation.
-
----
-
-#### Phase C — Tool-type primitive
-
-**Goal:** `type: Literal["cli", "mcp", ...]` as first-class field, with type-specific OTel span attributes.
-
-**Gate for starting Phase C:** a second tool type has a concrete consumer. Most likely MCP ([#84](https://github.com/ColeB1722/fin-assist/issues/84)). **Do not start speculatively.**
-
-**Design:** `ToolTypeAdapter` protocol with `span_attributes()`, `invoke()`, `load_from_config()`. `ToolDefinition.type` field. Global `ToolTypeRegistry`. OTel instrumentation lives in the adapter, not the callable. `fin list tool-types` CLI surface.
-
-**Exit gate:** two type adapters landed end-to-end, span semantics verified in OTel backend.
-
----
-
-#### Sequencing summary
-
-| Phase | Ship | Blocks on | Real consumer |
-|---|---|---|---|
-| A | Per-subcommand approval | — | Git agent UX today |
-| B | Skill object (TOML-authored, workflows migrated) | Phase A | User-authored skills |
-| C | Tool-type taxonomy + adapter pattern | Phase B + real second type | MCP integration |
-
-#### Skills vs. `context/` overlap
-
-`GitContext` duplicates what the `git` scoped CLI tool does. With per-subcommand approval (Phase A), `@git:diff` can resolve through the skill (diff → `never` approval). `FileFinder` and `ShellHistory` remain as `ContextProvider`s — they have search/get_item semantics, not CLI-wrapper semantics.
-
----
-
-## Historical Reference
-
-Key completed milestones. See git log for full detail; code is the source of truth.
-
-### PR #103 Code Review Fixes (2026-04-30)
-
-Addressed all 21 review comments across 6 themes:
-
-1. **Framework agnosticism** — rewrote docstrings across all tracing files to use vendor-neutral language; explained OpenInference = semantic conventions, not a framework
-2. **Docstring verbosity** — stripped conversational comments, private cross-references, Phoenix-specific editorializing
-3. **Legacy cleanup** — removed `ALTER TABLE` migration sniffing, removed `save_trace_context`/`load_trace_context` methods, renamed to `save_pause_state`/`load_pause_state`
-4. **Config simplification** — removed `file_path` from `TracingSettings`; JSONL sink always-on via `paths.TRACES_PATH` when tracing enabled; removed `FIN_TRACING__FILE_PATH` env var
-5. **OTel conceptual clarity** — added docstrings explaining OTel Links, force_flush/shutdown lifecycle, duplicate span tradeoff
-6. **Argparse cleanup** — replaced `getattr(args, "agent", None) or ""` with `args.agent or ""` via `set_defaults(agent=None)`
-
-4 new tests added (876 → 880). `just ci` green.
-
-### Git Agent + Scoped CLI Tools (#79, 2026-04-27)
-
-First real end-user agent. Scoped CLI tools (`git`, `gh`), WorkflowConfig (agent-scoped prompt steering), three workflows (commit, PR, summarize).
-
-### Tier 1 Features + Doc Sync (2026-04-27)
-
-`@`-completion, `fin list`, `fin do` input panel + `--edit`, remove built-in agents, client artifact-merge fix, ContextSettings forwarding, doc sync.
-
-### Unified Executor & Agent Platform (PR #87, 2026-04-24→26)
-
-Unified executor loop, tool calling, dual-path context, HITL approval, OTel-ready step boundaries. Platform owns abstractions, backends adapt them.
-
-### Streaming UX Refactor (2026-04-23)
-
-Backend streams `StreamDelta(kind, content)`. Shared `render_stream()` with Rich Live. Both `do` and `talk` use same pipeline.
-
-### AgentBackend Extraction (2026-04-21)
-
-`AgentSpec` → pure config. All pydantic-ai knowledge in `PydanticAIBackend`. Executor has zero pydantic-ai imports.
-
-### fasta2a → a2a-sdk Migration (2026-04-20)
-
-Full migration to Google's `a2a-sdk` v1.0.0. `TaskUpdater` for state transitions, `InMemoryTaskStore` + SQLite `ContextStore`.
-
-### Config-Driven Redesign (2026-04-11)
-
-Agents from class-hierarchy to `ConfigAgent` driven by TOML. `ServingMode`, `OUTPUT_TYPES`, `SYSTEM_PROMPTS` registries.
-
-### Auth-Required Credential Pre-Check (2026-04-03)
-
-`MissingCredentialsError` before LLM call. A2A `auth-required` state. Client renders credential panel.
-
-### Reliable Server Lifecycle (2026-04-09)
-
-`fcntl.flock()` PID file, `atexit` + SIGTERM cleanup, lock-based stale detection.
-
-### Early Platform Setup (2026-03-25 → 2026-04-08)
-
-Phases 1–8b: repo setup, LLM module, credentials, context module, agent protocol, hub server, CLI client, REPL.
-
----
-
-## Context for Fresh Session
-
-1. Read this file for current state
-2. Read `docs/architecture.md` for full architecture
-3. Read `AGENTS.md` for development patterns
-4. Check "Implementation Progress" table
-5. Continue from "Next Session" section
-
-### Key Files Reference
-
-| File | Purpose |
-|------|---------|
-| `docs/architecture.md` | Full architecture, source of truth |
-| `AGENTS.md` | Dev workflow, commands, decisions |
-| `handoff.md` | This file — rolling session context |
-| `pyproject.toml` | Dependencies, tool config |
-| `justfile` | Task runner commands |
-
----
-
-## Notes
-
-- Target fish 3.2+ for shell integration
-- Config stored in `~/.config/fin/config.toml`
-- Credentials stored in `$FIN_DATA_DIR/credentials.json` (0600 permissions)
-- Server binds to `127.0.0.1` only
-- A2A protocol via a2a-sdk v1.0
-- Multi-path routing: N agents at `/agents/{name}/`
-- SQLite for context storage; `InMemoryTaskStore` for A2A tasks (ephemeral)
-- Server lifecycle: fcntl-locked PID file
-- `AgentSpec` is pure config; all LLM coupling in `PydanticAIBackend`
-- Platform types in `agents/` have zero `hub/` imports by design
-- `@`-completion is the sole user-driven context path; `--file`/`--git-diff` removed
-- Scoped CLI tools (`git`, `gh`) support per-subcommand approval via skills
-- JSONL trace sink always-on when tracing enabled, writes to `$FIN_DATA_DIR/traces.jsonl`
-- `OTEL_INSTRUMENTATION_A2A_SDK_ENABLED=false` set in `__init__.py` to suppress a2a-sdk noise
+Implemented REPL `/skills` + `/skill:<name>` commands with `SkillCompleter` (rapidfuzz fuzzy matching, mirrors `@file:` pattern), skill tracing attributes/spans (`fin_assist.skill_load`, `fin_assist.cli.skill`), and updated docs. Tool gating, agent-level `tool_policies`, `base_tools` defaults, `skills/invoke` + `GET /skills` endpoints, REPL slash-command loading, `fin list skills`. 940 tests passing. v0.1 shipped as PR #114, tagged `v0.1`.

--- a/handoff.md
+++ b/handoff.md
@@ -2,7 +2,7 @@
 
 Rolling context for session handoffs. Updated as checkpoints are reached.
 
-**Current state (2026-05-03):** 940 tests passing, `just ci` green. Skill loading refactor complete (Steps 1–14). Skills now genuinely gate tools, approval policies moved to agent level, REPL `/skills` and `/skill:<name>` commands wired, skill tracing added. Ready for manual review.
+**Current state (2026-05-09):** v0.1 shipped (PR #114, tag `v0.1`). 940 tests passing. v0.2 planning complete: backlog groomed (84 → 57 open), four-phase roadmap (v0.1.1 → v0.2 → v0.2.1 → v0.3), sub-agent design sketch captured. v0.2 anchor is in-process sub-agents as a context-compression primitive — see Design Sketch.
 
 **Recent work (this session):**
 
@@ -29,11 +29,10 @@ Rolling context for session handoffs. Updated as checkpoints are reached.
 
 - AgentBackend protocol simplification ([#80](https://github.com/ColeB1722/fin-assist/issues/80))
 - `supported_context_types` / `_CONTEXT_TYPE_HINTS` — CLI/BFF boundary not drawn explicitly; context-to-tool mapping lives in `agents/spec.py` but is a client concern. Needs broader architecture discussion: define CLI (display) vs BFF (context resolution, prompt shaping) vs hub/agent boundary, AgentCardMeta cleanup, and where context ownership should land.
-- Skill composability (skills invoking skills) — v0.2
-- Agent-to-agent orchestration — v0.2
-- MCP tool source — v0.1.1
+- MCP tool source — v0.1.1 ([#84](https://github.com/ColeB1722/fin-assist/issues/84))
 - Per-subcommand approval evaluation at executor level — v0.1.1
-- Eval harness — v0.3
+- Sub-agents (in-process, context-compression primitive) — v0.2 (see Design Sketch below)
+- Sub-agents (federated via A2A) + Eval harness — v0.3
 - Phase 4 architectural discussions — issues [#89–#94](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+is%3Aissue+89+90+91+92+93+94)
 
 ---
@@ -48,16 +47,21 @@ Rolling context for session handoffs. Updated as checkpoints are reached.
 
 ### Sequenced roadmap
 
-| # | Work | Status |
-|---|------|--------|
-| 1 | Tracing: OTel + OpenInference bridge | ✅ Complete — follow-ups [#104-#109](https://github.com/ColeB1722/fin-assist/issues?q=is%3Aopen+104+105+106+107+108+109) |
-| 2 | Skills API v0.1 | ✅ Complete — Phases 0–4 + code review triage shipped (924 tests) |
-| 3 | MCP tool source (v0.1.1) | ⬜ Queued — skill→tool binding is source-agnostic |
-| 3b | Pluggable base system prompts (v0.1.1) | ⬜ Queued — user-overridable prompt templates, not hardcoded constants |
-| 3c | Registry consistency + policy resolution audit (v0.1.1) | ⬜ Queued — compare registry APIs for consistency; review policy resolution flow (schema → evaluate → backend → executor) for end-user understandability |
-| 3d | Evaluate constant placement patterns (v0.1.1) | ⬜ Queued — [#122](https://github.com/ColeB1722/fin-assist/issues/122) assess whether domain/behavior constants (fuzzy thresholds, timeout values, context-type mappings) should centralize or stay local; follows #90 |
-| 4 | Eval harness (per-agent) | ⬜ Queued — rides on tracing |
-| 5 | Skill composability + agent-to-agent (v0.2) | ⬜ Queued |
+Post-v0.1 work is organized into four phases. Each phase ships under its own tag.
+
+**Pre-v0.1.1 — Backlog grooming** (✅ complete 2026-05-09): closed 27 stale issues (84 → 57 open). Verified shipped items, removed Textual-era issues (UI module deleted), collapsed duplicates, marked superseded items.
+
+| Phase | Tag | Scope | Status |
+|-------|-----|-------|--------|
+| 1 | **v0.1.1** | MCP tool source ([#84](https://github.com/ColeB1722/fin-assist/issues/84)), per-subcommand approval at executor level, pluggable system prompts ([#89](https://github.com/ColeB1722/fin-assist/issues/89)), registry consistency + policy resolution audit, SQLite/storage hardening ([#40](https://github.com/ColeB1722/fin-assist/issues/40), [#42](https://github.com/ColeB1722/fin-assist/issues/42), [#75](https://github.com/ColeB1722/fin-assist/issues/75)), constant placement ([#122](https://github.com/ColeB1722/fin-assist/issues/122)), chore-batch (#26, #33, #41, #43, #45, #46, #65, #76, #116, #117, #118, #119) | ⬜ Queued |
+| 2 | **v0.2** | Sub-agents in-process — context-compression primitive (see Design Sketch). Includes: HITL rationale ([#121](https://github.com/ColeB1722/fin-assist/issues/121)), context-aware compaction ([#102](https://github.com/ColeB1722/fin-assist/issues/102)), workflow chaining ([#63](https://github.com/ColeB1722/fin-assist/issues/63)), background tasks ([#110](https://github.com/ColeB1722/fin-assist/issues/110)), multi-choice HITL ([#113](https://github.com/ColeB1722/fin-assist/issues/113)). Exit gate: [#31](https://github.com/ColeB1722/fin-assist/issues/31) SDD+TDD pipeline runs end-to-end | ⬜ Queued |
+| 3 | **v0.2.1** | UX polish — render_stream simplification ([#92](https://github.com/ColeB1722/fin-assist/issues/92)), progressive thinking ([#72](https://github.com/ColeB1722/fin-assist/issues/72)), richer tool_result ([#91](https://github.com/ColeB1722/fin-assist/issues/91)), CLI constants ([#90](https://github.com/ColeB1722/fin-assist/issues/90)), `/spec` command ([#95](https://github.com/ColeB1722/fin-assist/issues/95)), `$EDITOR` for `--edit` ([#97](https://github.com/ColeB1722/fin-assist/issues/97)), `fin do` vs `fin prompt` clarity ([#94](https://github.com/ColeB1722/fin-assist/issues/94)), tracing follow-ups (#106, #107, #108, #109) | ⬜ Queued |
+| 4 | **v0.3** | Sub-agents federated via A2A (Flavor 2) + per-agent eval harness | ⬜ Queued |
+
+**Already shipped pre-v0.1:**
+
+- Tracing: OTel + OpenInference bridge — follow-ups #106-#109 deferred to v0.2.1
+- Skills API v0.1 (PR #114) — 940 tests, tool gating, agent-level policies, REPL `/skills`
 
 ---
 
@@ -106,6 +110,118 @@ Rolling context for session handoffs. Updated as checkpoints are reached.
 ---
 
 ## Design Sketches
+
+### Sub-agents as Context Compression (sketched 2026-05-09)
+
+**Status:** v0.2 anchor. Idea aligned, ready to detail-design before implementation.
+
+**Concept:** A running agent can invoke a *sub-agent* — a nested execution with restricted scope — to perform a discrete task and return a compact result. The parent's conversation only sees the sub-agent's final output, not its intermediate steps. This is a context-compression primitive: long, exploratory, tool-heavy reasoning happens inside the sub-agent and never reaches the parent's context window.
+
+**Why this framing matters:** Earlier discussion considered a `requires` field for skills (skill A declares dependency on skill B; loading A loads B). That was rejected — transitive skill loading is a small detail easy to miss, balloons fast, and any depth cap is arbitrary. Sub-agents subsume that need: if you want skill B's capabilities while running skill A, invoke a sub-agent with skill B loaded. The boundary is explicit, not transitive.
+
+#### Two flavors — only one ships in v0.2
+
+| Flavor | What | When | Cost |
+|--------|------|------|------|
+| **1: In-process** | Sub-agent runs inside the same hub process. `Executor.run_subtask(spec, prompt)` spins up a nested `AgentSpec` execution with a constrained tool set. No A2A protocol involvement. | **v0.2** | ~1-2 weeks |
+| **2: Federated** | Sub-agent runs as a separate A2A task, possibly on another agent or external process. Cross-process tracing via OTel Links. | **v0.3** | ~3-4 weeks |
+
+**Both flavors share the same caller-side API.** The `invoke_subagent` tool signature is designed so that v0.3 federation is a drop-in extension: when the target agent is local, route through `Executor.run_subtask`; when external, route through `HubClient`. Callers don't change.
+
+#### v0.2 design (Flavor 1)
+
+**Tool surface:**
+
+```python
+invoke_subagent(
+    agent: str | None = None,        # Default: same agent as parent
+    skills: list[str] | None = None, # Skills to load in the sub-agent
+    prompt: str = ...,               # The task to perform
+) -> str                              # Sub-agent's final output
+```
+
+**Execution semantics:**
+
+1. Parent agent's LLM calls `invoke_subagent`. Tool call goes through normal approval gate (agent-level `tool_policies`).
+2. `Executor.run_subtask()` constructs a fresh `AgentSpec` execution context: target `AgentSpec`, `SkillManager` with requested skills loaded, fresh conversation history (just the prompt).
+3. Sub-agent runs to completion as a self-contained task — its own `fin_assist.task` span, its own step loop, its own tool calls.
+4. Sub-agent's final string output is returned as the tool result to the parent.
+5. Parent's conversation now contains: tool call → tool result. **Sub-agent's intermediate reasoning, tool calls, and thinking are discarded from the parent's view.** Full transcript still in `traces.jsonl`.
+
+**Constraints (v0.2):**
+
+- **Same-process only.** If `agent` argument names an external A2A agent, raise — that's v0.3.
+- **No HITL inside sub-agents.** Sub-agents must run autonomously. If a sub-agent's tool requires approval, fail the sub-agent (don't pause the parent). Forces clean separation; v0.3 can lift this.
+- **No nested sub-agents.** A sub-agent cannot itself call `invoke_subagent`. Prevents unbounded depth. Revisit in v0.3.
+- **Tool gating reused as-is.** Sub-agent's tool set = `target_spec.base_tools` + tools from requested skills. Identical to a fresh `fin do` invocation.
+- **Approval policies inherited.** Sub-agent uses its target agent's `tool_policies`. The agent-level invariant (each tool has exactly one policy definition) is preserved.
+
+**Reporting format:** Sub-agent decides. Its system prompt gets a fixed appendix: *"You are being invoked as a sub-agent. Your final output is the only thing the caller sees — be concise and complete."* No `report_format` arg in v0.2; deferred to v0.3 along with structured output types.
+
+**Tracing:**
+
+```text
+fin_assist.task (parent agent)
+  └── fin_assist.step
+        └── fin_assist.tool_execution (invoke_subagent)
+              └── fin_assist.subagent
+                    └── fin_assist.task (sub-agent, full nested tree)
+                          ├── fin_assist.step
+                          │     └── chat {model}
+                          └── fin_assist.step
+                                ├── fin_assist.tool_execution
+                                └── chat {model}
+```
+
+New attributes on `fin_assist.subagent` span:
+- `fin_assist.subagent.target_agent` (str)
+- `fin_assist.subagent.skills` (list[str])
+- `fin_assist.subagent.parent_task_id` (str)
+- `fin_assist.subagent.result_length` (int) — for context-compression-effectiveness analysis
+
+**Phoenix UI benefit:** the compression is visually obvious — parent has 2 sub-spans (call, return), sub-agent has 30+. The tree shows exactly what was hidden from the parent's context.
+
+#### Touchpoints (implementation map)
+
+| File | Change |
+|------|--------|
+| `src/fin_assist/agents/tools.py` | Register `invoke_subagent` as a built-in tool in `create_default_registry()` |
+| `src/fin_assist/hub/executor.py` | New `Executor.run_subtask(spec, skills, prompt) -> str` method; reuses existing step loop with constrained scope |
+| `src/fin_assist/hub/_task_tracer.py` | Add `emit_subagent_span()` with attributes above |
+| `src/fin_assist/hub/tracing_attrs.py` | Add `FIN_SUBAGENT_*` attribute constants |
+| `src/fin_assist/agents/spec.py` | Validate that `invoke_subagent` is in `base_tools` for any agent that wants sub-agent capability (or always-available, TBD) |
+| `tests/test_hub/test_subagent.py` (new) | Unit tests: result return, tool gating in sub-agent, no HITL allowed, no nested calls, tracing attributes |
+| `tests/integration/test_subagent_e2e.py` (new) | Integration: parent invokes sub-agent via FakeBackend, parent's history correctly contains only tool result |
+
+#### Companion v0.2 work
+
+Sub-agents are the anchor, but several issues become much more useful once sub-agents exist:
+
+- **[#102](https://github.com/ColeB1722/fin-assist/issues/102) Context-aware agent handoff (compaction)** — sub-agents *are* compaction; this issue's "self-curated" framing now means "what does the sub-agent return."
+- **[#121](https://github.com/ColeB1722/fin-assist/issues/121) HITL rationale pass-through** — needed regardless, but particularly relevant when a parent's `invoke_subagent` call needs approval (the rationale is the prompt being delegated).
+- **[#110](https://github.com/ColeB1722/fin-assist/issues/110) Background tasks + sandboxing** — long sub-agents shouldn't block the parent indefinitely; a "fire and forget" mode is a natural extension once basic sub-agents work.
+- **[#113](https://github.com/ColeB1722/fin-assist/issues/113) Multi-choice HITL** — orchestration flows where parent agent surfaces sub-agent results and asks "which one?"
+- **[#63](https://github.com/ColeB1722/fin-assist/issues/63) Sequential agent chaining** — once sub-agents work, chaining is just a parent that calls multiple sub-agents in sequence.
+- **[#31](https://github.com/ColeB1722/fin-assist/issues/31) SDD+TDD pipeline** — exit gate. SDD agent invokes TDD sub-agents per task. If this works end-to-end, v0.2 is real.
+
+#### Open questions for v0.2 implementation
+
+1. **`invoke_subagent` always-available, or opt-in?** Easiest: always in `base_tools`, like `read_file`. Lets any agent compose. Trade-off: agents that shouldn't compose (single-purpose agents) get the tool anyway. Lean: always-available.
+2. **Sub-agent credential resolution.** Does the sub-agent share the parent's credentials, or re-resolve via its own agent's required providers? Lean: re-resolve. Sub-agent is a "real" agent execution, not a continuation of the parent.
+3. **Conversation-history serialization.** Sub-agents have no persistent context (no `context_id`). Each invocation is fresh. Does the JSONL sink record sub-agent turns separately, or as nested children? Lean: separate `task_id` in JSONL, with `parent_task_id` cross-reference for joining.
+4. **Cancellation propagation.** If parent task is cancelled mid-sub-agent, does the sub-agent get cancelled too? Lean: yes; the `invoke_subagent` tool call inherits the parent's cancellation token.
+5. **What does the parent's prompt see when the sub-agent fails?** Tool result with error string, or raise into the parent? Lean: tool result with error — preserves the parent's autonomy to retry, fall back, or surface to the user.
+
+#### What we explicitly defer
+
+- **Federated sub-agents (Flavor 2)** — v0.3
+- **Structured output from sub-agents** — v0.3
+- **Sub-agent invokes sub-agent (nesting)** — v0.3
+- **HITL inside sub-agents** — v0.3
+- **`report_format` argument** — v0.3
+- **Cross-agent skill invocation outside sub-agents** — explicitly NOT a feature; if you want skill B's tools while running agent A's skill, invoke a sub-agent with skill B loaded.
+
+---
 
 ### Dynamic Phasing in System Prompt (sketched 2026-05-09)
 

--- a/handoff.md
+++ b/handoff.md
@@ -15,6 +15,10 @@ In-flight design sketches and rolling session context. See `AGENTS.md` for what 
 
 ## Current state
 
+**2026-05-10 (session 2):** Audited context provider wiring (#129). The two paths (@-completion and tool calls) are incoherent: separate instances, no shared cache, `git` tool bypasses `GitContext` entirely, `git_status` and `Environment` are unreachable. Filed #129 with three design options and a blocking note on #84 (ToolProvider shape depends on answer) and #115 (don't wire Environment with current pattern). Added v0.1.1 milestone note that #129 direction must be resolved before those two ship.
+
+**2026-05-10 (session 1):** Audited `AgentCardMeta` field wiring. Finding: `serving_modes` is the only field with runtime enforcement; `supported_context_types` (computed, published, never consumed for filtering), `supported_providers` (always `None`, no config key), `supports_model_selection` (always `True`, never read), and `supports_thinking` (set but never read by CLI) are all declarative-only. Documented in milestone notes: context-type filtering paired with #115 in v0.1.1; provider filtering + model selection + thinking gate deferred to v0.2.1 with design questions. Also: `docs/architecture.md` edits from the doc-restructure session (deliverables table, local-first principle, maintenance contract, backend diagram) are on disk but uncommitted — awaiting user review.
+
 **2026-05-10:** Added "ToolProvider Protocol" design sketch — unifies tool registration across builtin, MCP, and file-based sources. Informs v0.1.1 (#84) architecture; ships progressively through v0.3. Updated milestone descriptions for v0.1.1, v0.2, v0.3 with ToolProvider context. Added comment to #84 with implementation sequence.
 
 **2026-05-09:** v0.1 shipped (PR #114, tag `v0.1`). 940 tests passing. v0.2 planning complete: backlog groomed (84 → 57 open issues), four-phase roadmap captured as milestones (v0.1.1 → v0.2 → v0.2.1 → v0.3). v0.2 anchor is in-process sub-agents as a context-compression primitive — see Design Sketch below.

--- a/handoff.md
+++ b/handoff.md
@@ -23,9 +23,10 @@ In-flight design sketches and rolling session context. See `AGENTS.md` for what 
 
 **Recommended picks (in priority order):**
 
-1. **Commit the doc-split + drift-fix work** — two commits' worth on `docs/planning`: existing `d8920a6` (split + rewrite) plus the staged drift-fix changes from this session. Push and open PR.
-2. **Begin v0.1.1 work** — milestone now has [#123](https://github.com/ColeB1722/fin-assist/issues/123) (skill tracing wiring), [#124](https://github.com/ColeB1722/fin-assist/issues/124) (`/connect` interactive setup), and [#125](https://github.com/ColeB1722/fin-assist/issues/125) (SKILL.md runtime loading) on top of the existing scope (MCP [#84](https://github.com/ColeB1722/fin-assist/issues/84), per-subcommand approval). [v0.1.1 milestone](https://github.com/ColeB1722/fin-assist/milestone/1).
-3. **Resolve open questions in the sub-agents Design Sketch below** before implementation begins. There are 5 questions; answering them unblocks v0.2.
+1. **Begin v0.1.1 work** — slimmed to 7 focused issues: MCP ([#84](https://github.com/ColeB1722/fin-assist/issues/84)), pluggable prompts ([#89](https://github.com/ColeB1722/fin-assist/issues/89)), GitContext size limits ([#85](https://github.com/ColeB1722/fin-assist/issues/85)), Environment context ([#115](https://github.com/ColeB1722/fin-assist/issues/115)), and the three drift-wiring issues from doc-validation ([#123](https://github.com/ColeB1722/fin-assist/issues/123) skill tracing, [#124](https://github.com/ColeB1722/fin-assist/issues/124) `/connect`, [#125](https://github.com/ColeB1722/fin-assist/issues/125) SKILL.md runtime). Per-subcommand approval is still in v0.1.x scope but not yet filed as an issue.
+2. **Resolve open questions in the sub-agents Design Sketch below** before implementation begins. There are 5 questions; answering them unblocks v0.2.
+
+**Sequence:** v0.1.1 (foundations) → [v0.1.2](https://github.com/ColeB1722/fin-assist/milestone/5) (visibility — badges + demo gif, [#127](https://github.com/ColeB1722/fin-assist/issues/127)) → v0.2 (sub-agents).
 
 ---
 
@@ -193,7 +194,16 @@ phase = "experimental"
 
 ## Recent work
 
-### 2026-05-09 (latest) — Code-validation pass on the new doc structure
+### 2026-05-09 (latest) — README rewrite + milestone re-split
+
+- Rewrote README into technical-writing register (per user feedback that "user-lens" had become conversational). Structure: Concepts → Example → Architecture → Install → CLI reference → Documentation → Status. Replaced user-lens diagram with structural Architecture diagram. Paired TOML config with invocation example so reader has vocabulary before seeing the CLI session. 161 → 141 lines.
+- Split v0.1.1 (was 35 issues, three mixed themes) into:
+  - **v0.1.1 — Foundations** (7 issues): #84, #85, #89, #115, #123, #124, #125
+  - **v0.1.2 — Visibility** (new milestone, 1 issue): [#127](https://github.com/ColeB1722/fin-assist/issues/127) (badges + demo gif)
+  - **No milestone** (28 issues): chore batch — test cleanup, type hints, CodeRabbit refactors. Per AGENTS.md context strategy, "things to do when convenient" don't belong in milestones.
+- Updated v0.1.1 milestone description to reflect the new 7-issue scope and document the chore-unmilestoning rationale.
+
+### 2026-05-09 (earlier) — Code-validation pass on the new doc structure
 
 - Ran a four-track validation pass (one sub-agent per doc) of every concrete claim in `architecture.md`, `skills.md`, `tracing.md`, `configuration.md` against `src/`. Each sub-agent returned a structured report citing `file:line` for every check.
 - Found ~25 drift items, grouped into four buckets:

--- a/handoff.md
+++ b/handoff.md
@@ -17,14 +17,14 @@ In-flight design sketches and rolling session context. See `AGENTS.md` for what 
 
 **2026-05-09:** v0.1 shipped (PR #114, tag `v0.1`). 940 tests passing. v0.2 planning complete: backlog groomed (84 → 57 open issues), four-phase roadmap captured as milestones (v0.1.1 → v0.2 → v0.2.1 → v0.3). v0.2 anchor is in-process sub-agents as a context-compression primitive — see Design Sketch below.
 
-**Context-strategy refactor (across two sessions):** documented the issue/milestone split and doc-surface roles in `AGENTS.md`; pruned this file from 625 → 210 lines; split the 1464-line `docs/architecture.md` into `architecture.md` (slim contracts + diagrams), `tracing.md`, `skills.md`, `decisions.md`, `configuration.md`; rewrote `README.md` with user-lens framing and a single user-friendly diagram surfacing skills/tools/agents.
+**Context-strategy refactor (across three sessions):** documented the issue/milestone split and doc-surface roles in `AGENTS.md`; pruned this file from 625 → ~220 lines; split the 1464-line `docs/architecture.md` into `architecture.md` (slim contracts + diagrams), `tracing.md`, `skills.md`, `decisions.md`, `configuration.md`; rewrote `README.md` with user-lens framing; ran code-validation pass and corrected ~25 drift items (signatures, defaults, phantom commands, unwired features).
 
 ## Next session
 
 **Recommended picks (in priority order):**
 
-1. **Commit the doc-split work** — five new docs + rewritten README + AGENTS.md/handoff.md/skills.py link fixups are unstaged.
-2. **Begin v0.1.1 work** — start with MCP tool source ([#84](https://github.com/ColeB1722/fin-assist/issues/84)) or per-subcommand approval at executor level (see [v0.1.1 milestone](https://github.com/ColeB1722/fin-assist/milestone/1) for the full set).
+1. **Commit the doc-split + drift-fix work** — two commits' worth on `docs/planning`: existing `d8920a6` (split + rewrite) plus the staged drift-fix changes from this session. Push and open PR.
+2. **Begin v0.1.1 work** — milestone now has [#123](https://github.com/ColeB1722/fin-assist/issues/123) (skill tracing wiring), [#124](https://github.com/ColeB1722/fin-assist/issues/124) (`/connect` interactive setup), and [#125](https://github.com/ColeB1722/fin-assist/issues/125) (SKILL.md runtime loading) on top of the existing scope (MCP [#84](https://github.com/ColeB1722/fin-assist/issues/84), per-subcommand approval). [v0.1.1 milestone](https://github.com/ColeB1722/fin-assist/milestone/1).
 3. **Resolve open questions in the sub-agents Design Sketch below** before implementation begins. There are 5 questions; answering them unblocks v0.2.
 
 ---
@@ -192,6 +192,18 @@ phase = "experimental"
 ---
 
 ## Recent work
+
+### 2026-05-09 (latest) — Code-validation pass on the new doc structure
+
+- Ran a four-track validation pass (one sub-agent per doc) of every concrete claim in `architecture.md`, `skills.md`, `tracing.md`, `configuration.md` against `src/`. Each sub-agent returned a structured report citing `file:line` for every check.
+- Found ~25 drift items, grouped into four buckets:
+  - **Critical (3)** — features documented as live but not actually wired up: `fin_assist.skill_load` span never emitted, `start_task_span(skill_id=...)` never invoked, SKILL.md files discoverable by `list skills` but not loaded into runtime `SkillManager`.
+  - **API drift (8)** — wrong signatures in arch.md "Key types" section: `AgentSpec.tools` → `skill_tool_names`, `run_stream` → `run_steps` returning `StepHandle` of `StepEvent`s (not text deltas), `AgentBackend` protocol has 8+1 methods not 5, `ContextItem.status` default `"available"` not `"ready"`, `create_hub_app` signature is `(agents: Sequence[AgentSpec], db_path: str = ":memory:", ...)` not `(config, credentials, *, db_path)`.
+  - **Phantom commands (3)** — `_poll_task` (doesn't exist anywhere in `src/`), `fin-assist /connect` (no command exists), bare positional `fin do <agent> <skill>` (argparse only has one positional; what works is `fin do --agent git commit` via prompt-as-skill auto-promotion).
+  - **Definition drift (12)** — thinking defaults, `system_prompt` "required" vs has default, `ProviderRegistry` doesn't read TOML, task-state enum missing `resumed_from_approval`, `DropSpansProcessor` is public not `_DropSpansProcessor`, `tracing_shared.py` omitted from Files list, etc.
+- Filed three GH issues under v0.1.1: [#123](https://github.com/ColeB1722/fin-assist/issues/123) (skill tracing wiring), [#124](https://github.com/ColeB1722/fin-assist/issues/124) (`/connect` interactive setup), [#125](https://github.com/ColeB1722/fin-assist/issues/125) (wire SKILL.md files into runtime `SkillManager`).
+- Applied fixes: rewrote `AgentSpec`/`AgentBackend`/`ContextItem`/`create_hub_app` API blocks in arch.md; demoted unwired skill spans to "scaffolding, not yet invoked" in skills.md + tracing.md; corrected `thinking`/`system_prompt`/`ProviderRegistry` claims in configuration.md; replaced phantom CLI commands with what actually works in arch.md + README; added `tracing_shared.py` to tracing.md Files. `just lint` clean.
+- 6 files changed, +130/-89 lines. Branch `docs/planning` still 1 commit ahead of origin (d8920a6); drift-fix changes are unstaged for the user to review and commit.
 
 ### 2026-05-09 (later) — Doc split + README "project soul" pass
 

--- a/justfile
+++ b/justfile
@@ -25,6 +25,11 @@ lint:
 lint-fix:
     uv run ruff check --fix src/
 
+# Architecture firewall — enforces hub/cli import boundary.
+# See docs/architecture.md § "Deliverables: Hub vs Client".
+lint-imports:
+    uv run lint-imports
+
 typecheck:
     uv run ty check src/
 
@@ -34,7 +39,7 @@ test *args:
 test-cov:
     uv run pytest tests/ --cov=fin_assist --cov-report=term-missing
 
-ci: check lint typecheck test
+ci: check lint lint-imports typecheck test
 
 # ── Local dev ────────────────────────────────────────────────────────────────
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "ruff>=0.9",
     "ty>=0.0.1a1",
     "arize-phoenix>=8.0",
+    "import-linter>=2.0",
 ]
 
 [project.scripts]
@@ -78,3 +79,45 @@ pythonVersion = "3.13"
 extraPaths = ["src"]
 reportMissingImports = true
 reportMissingTypeStubs = false
+
+# ---------------------------------------------------------------------------
+# Architecture firewall — see docs/architecture.md § "Deliverables: Hub vs Client"
+#
+# fin-assist is two deliverables in one repo, separated by the A2A protocol:
+#   - hub/  is the platform (Agent Hub)
+#   - cli/  is one A2A client (today the only one)
+#
+# The contracts below enforce the import boundary. Run with `just lint-imports`
+# (also part of `just ci`).
+#
+# When a new cli/ file legitimately needs the in-process launcher path (for
+# `fin-assist serve`), add the specific import to `ignore_imports` with a
+# justifying comment — DON'T weaken the contract itself.
+# ---------------------------------------------------------------------------
+[tool.importlinter]
+root_package = "fin_assist"
+
+[[tool.importlinter.contracts]]
+name = "hub must not import from cli"
+type = "forbidden"
+source_modules = ["fin_assist.hub"]
+forbidden_modules = ["fin_assist.cli"]
+# No ignore_imports — the platform must never know about specific clients.
+
+[[tool.importlinter.contracts]]
+name = "cli must not import from hub (except in-process launcher path)"
+type = "forbidden"
+source_modules = ["fin_assist.cli"]
+forbidden_modules = ["fin_assist.hub"]
+ignore_imports = [
+    # `fin-assist serve` boots the FastAPI hub in-process. These four imports
+    # are the launcher path; everything else in cli/ talks to the hub via
+    # cli/client.py over A2A.
+    "fin_assist.cli.main -> fin_assist.hub.app",
+    "fin_assist.cli.main -> fin_assist.hub.logging",
+    "fin_assist.cli.main -> fin_assist.hub.pidfile",
+    "fin_assist.cli.main -> fin_assist.hub.tracing",
+    # cli tracing setup re-uses the hub's file span exporter so CLI-side
+    # spans land in the same JSONL sink as hub-side spans.
+    "fin_assist.cli.tracing -> fin_assist.hub.file_exporter",
+]

--- a/src/fin_assist/agents/skills.py
+++ b/src/fin_assist/agents/skills.py
@@ -16,7 +16,7 @@ Key types:
 - ``SkillLoader`` — resolves ``SkillConfig`` (from config.toml) or
   SKILL.md files into ``SkillDefinition`` instances
 
-Design decisions (see architecture.md for full rationale):
+Design decisions (see docs/skills.md for full rationale):
 
 1. Skills are additive.  No skill unloading in v0.1.
 2. Tools are shared across skills.  Name collisions (two different

--- a/src/fin_assist/config/schema.py
+++ b/src/fin_assist/config/schema.py
@@ -186,7 +186,7 @@ class AgentConfig(BaseModel):
     thinking: ThinkingEffort = "medium"
     serving_modes: list[ServingMode] = Field(default_factory=lambda: ["do", "talk"])
     tags: list[str] = Field(default_factory=list)
-    base_tools: list[str] = Field(default_factory=lambda: ["read_file"])
+    base_tools: list[str] = Field(default_factory=list)
     tool_policies: dict[str, ToolPolicyConfig] = Field(default_factory=dict)
     skills: dict[str, SkillConfig] = Field(default_factory=dict)
 

--- a/tests/test_agents/test_backend.py
+++ b/tests/test_agents/test_backend.py
@@ -64,7 +64,7 @@ def _make_spec_with_tools(
             description="Default agent",
             system_prompt="chain-of-thought",
             output_type="text",
-            base_tools=base_tools or ["read_file"],
+            base_tools=base_tools or [],
             skills=skills,
         ),
         config=mock_config,

--- a/tests/test_agents/test_spec.py
+++ b/tests/test_agents/test_spec.py
@@ -440,7 +440,7 @@ class TestAgentSpecConfigProperties:
             config=mock_config,
             credentials=mock_credentials,
         )
-        assert agent.base_tools == ["read_file"]
+        assert agent.base_tools == []
 
     def test_base_tools_custom(self, mock_config, mock_credentials) -> None:
         agent = AgentSpec(

--- a/uv.lock
+++ b/uv.lock
@@ -1043,6 +1043,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "arize-phoenix" },
+    { name = "import-linter" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1074,6 +1075,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "arize-phoenix", specifier = ">=8.0" },
+    { name = "import-linter", specifier = ">=2.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.25" },
     { name = "pytest-cov", specifier = ">=6.0" },
@@ -1325,6 +1327,75 @@ wheels = [
 ]
 
 [[package]]
+name = "grimp"
+version = "3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/46/79764cfb61a3ac80dadae5d94fb10acdb7800e31fecf4113cf3d345e4952/grimp-3.14.tar.gz", hash = "sha256:645fbd835983901042dae4e1b24fde3a89bf7ac152f9272dd17a97e55cb4f871", size = 830882, upload-time = "2025-12-10T17:55:01.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/d6/a35ff62f35aa5fd148053506eddd7a8f2f6afaed31870dc608dd0eb38e4f/grimp-3.14-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ffabc6940301214753bad89ec0bfe275892fa1f64b999e9a101f6cebfc777133", size = 2178573, upload-time = "2025-12-10T17:53:42.836Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/bd2e80273da4d46110969fc62252e5372e0249feb872bc7fe76fdc7f1818/grimp-3.14-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:075d9a1c78d607792d0ed8d4d3d7754a621ef04c8a95eaebf634930dc9232bb2", size = 2110452, upload-time = "2025-12-10T17:53:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c3/7307249c657d34dca9d250d73ba027d6cfe15a98fb3119b6e5210bc388b7/grimp-3.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06ff52addeb20955a4d6aa097bee910573ffc9ef0d3c8a860844f267ad958156", size = 2283064, upload-time = "2025-12-10T17:52:07.673Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d2/cae4cf32dc8d4188837cc4ab183300d655f898969b0f169e240f3b7c25be/grimp-3.14-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d10e0663e961fcbe8d0f54608854af31f911f164c96a44112d5173050132701f", size = 2235893, upload-time = "2025-12-10T17:52:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/3f58bc3064fc305dac107d08003ba65713a5bc89a6d327f1c06b30cce752/grimp-3.14-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ab874d7ddddc7a1291259cf7c31a4e7b5c612e9da2e24c67c0eb1a44a624e67", size = 2393376, upload-time = "2025-12-10T17:53:02.397Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b8/f476f30edf114f04cb58e8ae162cb4daf52bda0ab01919f3b5b7edb98430/grimp-3.14-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54fec672ec83355636a852177f5a470c964bede0f6730f9ba3c7b5c8419c9eab", size = 2571342, upload-time = "2025-12-10T17:52:35.214Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ae/2e44d3c4f591f95f86322a8f4dbb5aac17001d49e079f3a80e07e7caaf09/grimp-3.14-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b9e221b5e8070a916c780e88c877fee2a61c95a76a76a2a076396e459511b0bb", size = 2359022, upload-time = "2025-12-10T17:52:49.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ac/42b4d6bc0ea119ce2e91e1788feabf32c5433e9617dbb495c2a3d0dc7f12/grimp-3.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea6b495f9b4a8d82f5ce544921e76d0d12017f5d1ac3a3bd2f5ac88ab055b1c", size = 2309424, upload-time = "2025-12-10T17:53:11.069Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/6a731989625c1790f4da7602dcbf9d6525512264e853cda77b3b3602d5e0/grimp-3.14-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:655e8d3f79cd99bb859e09c9dd633515150e9d850879ca71417d5ac31809b745", size = 2462754, upload-time = "2025-12-10T17:53:50.886Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4d/3d1571c0a39a59dd68be4835f766da64fe64cbab0d69426210b716a8bdf0/grimp-3.14-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a14f10b1b71c6c37647a76e6a49c226509648107abc0f48c1e3ecd158ba05531", size = 2501356, upload-time = "2025-12-10T17:54:06.014Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/8950b8229095ebda5c54c8784e4d1f0a6e19423f2847289ef9751f878798/grimp-3.14-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:81685111ee24d3e25f8ed9e77ed00b92b58b2414e1a1c2937236026900972744", size = 2504631, upload-time = "2025-12-10T17:54:34.441Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/23bed3da9206138d36d01890b656c7fb7adfb3a37daac8842d84d8777ade/grimp-3.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ce8352a8ea0e27b143136ea086582fc6653419aa8a7c15e28ed08c898c42b185", size = 2514751, upload-time = "2025-12-10T17:54:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/6f1f55c97ee982f133ec5ccb22fc99bf5335aee70c208f4fb86cd833b8d5/grimp-3.14-cp312-cp312-win32.whl", hash = "sha256:3fc0f98b3c60d88e9ffa08faff3200f36604930972f8b29155f323b76ea25a06", size = 1875041, upload-time = "2025-12-10T17:55:13.326Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/03ba01288e2a41a948bc8526f32c2eeaddd683ed34be1b895e31658d5a4c/grimp-3.14-cp312-cp312-win_amd64.whl", hash = "sha256:6bca77d1d50c8dc402c96af21f4e28e2f1e9938eeabd7417592a22bd83cde3c3", size = 2013868, upload-time = "2025-12-10T17:55:05.907Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bd/d12a9c821b79ba31fc52243e564712b64140fc6d011c2bdbb483d9092a12/grimp-3.14-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af8a625554beea84530b98cc471902155b5fc042b42dc47ec846fa3e32b0c615", size = 2178632, upload-time = "2025-12-10T17:53:44.55Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8c/d6620dbc245149d5a5a7a9342733556ba91a672f358259c0ab31d889b56b/grimp-3.14-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0dd1942ffb419ad342f76b0c3d3d2d7f312b264ddc578179d13ce8d5acec1167", size = 2110288, upload-time = "2025-12-10T17:53:21.662Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9d/ea51edc4eb295c99786040051c66466bfa235fd1def9f592057b36e03d0f/grimp-3.14-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:537f784ce9b4acf8657f0b9714ab69a6c72ffa752eccc38a5a85506103b1a194", size = 2282197, upload-time = "2025-12-10T17:52:09.304Z" },
+    { url = "https://files.pythonhosted.org/packages/28/6e/7db27818ced6a797f976ca55d981a3af5c12aec6aeda12d63965847cd028/grimp-3.14-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:78ab18c08770aa005bef67b873bc3946d33f65727e9f3e508155093db5fa57d6", size = 2235720, upload-time = "2025-12-10T17:52:21.806Z" },
+    { url = "https://files.pythonhosted.org/packages/37/26/0e3bbae4826bd6eaabf404738400414071e73ddb1e65bf487dcce17858c4/grimp-3.14-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28ca58728c27e7292c99f964e6ece9295c2f9cfdefc37c18dea0679c783ffb6f", size = 2393023, upload-time = "2025-12-10T17:53:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f2/7da91db5703da34c7ef4c7cddcbb1a8fc30cd85fe54756eba942c6fb27d8/grimp-3.14-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9b5577de29c6c5ae6e08d4ca0ac361b45dba323aa145796e6b320a6ea35414b7", size = 2571108, upload-time = "2025-12-10T17:52:36.523Z" },
+    { url = "https://files.pythonhosted.org/packages/25/5e/4d6278f18032c7208696edf8be24a4b5f7fad80acc20ffca737344bcecb5/grimp-3.14-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d7d1f9f42306f455abcec34db877e4887ff15f2777a43491f7ccbd6936c449b", size = 2358531, upload-time = "2025-12-10T17:52:50.521Z" },
+    { url = "https://files.pythonhosted.org/packages/24/fb/231c32493161ac82f27af6a56965daefa0ec6030fdaf5b948ddd5d68d000/grimp-3.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39bd5c9b7cef59ee30a05535e9cb4cbf45a3c503f22edce34d0aa79362a311a9", size = 2308831, upload-time = "2025-12-10T17:53:12.587Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/f6db325bf5efbbebc9c85cad0af865e821a12a0ba58ee309e938cbd5fedf/grimp-3.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7fec3116b4f780a1bc54176b19e6b9f2e36e2ef3164b8fc840660566af35df88", size = 2462138, upload-time = "2025-12-10T17:53:52.403Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2e/cc3fe29cf07f70364018086840c228a190539ab8105147e34588db590792/grimp-3.14-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0233a35a5bbb23688d63e1736b54415fa9994ace8dfeb7de8514ed9dee212968", size = 2501393, upload-time = "2025-12-10T17:54:22.486Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/eb/54cada9a726455148da23f64577b5cd164164d23a6449e3fa14551157356/grimp-3.14-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e46b2fef0f1da7e7e2f8129eb93c7e79db716ff7810140a22ce5504e10ed86df", size = 2504514, upload-time = "2025-12-10T17:54:36.34Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/e6afe4f0652df07e8762f61899d1202b73c22c559c804d0a09e5aab2ff17/grimp-3.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3e6d9b50623ee1c3d2a1927ec3f5d408995ea1f92f3e91ed996c908bb40e856f", size = 2514018, upload-time = "2025-12-10T17:54:50.76Z" },
+    { url = "https://files.pythonhosted.org/packages/75/13/2b8550acc1f010301f02c4fe9664810929fd9277cd032ab608b8534a96fb/grimp-3.14-cp313-cp313-win32.whl", hash = "sha256:fd57c56f5833c99320ec77e8ba5508d56f6fb48ec8032a942f7931cc6ebb80ce", size = 1874922, upload-time = "2025-12-10T17:55:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c7/bc9db5a54ef22972cd17d15ad80a8fee274a471bd3f02300405702d29ea5/grimp-3.14-cp313-cp313-win_amd64.whl", hash = "sha256:173307cf881a126fe5120b7bbec7d54384002e3c83dcd8c4df6ce7f0fee07c53", size = 2013705, upload-time = "2025-12-10T17:55:07.488Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7e/02710bf5e50997168c84ac622b10dd41d35515efd0c67549945ad20996a0/grimp-3.14-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebe29f8f13fbd7c314908ed535183a36e6db71839355b04869b27f23c58fa082", size = 2281868, upload-time = "2025-12-10T17:52:10.589Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/2e440c6762cc78bd50582e1b092357d2255f0852ccc6218d8db25170ab31/grimp-3.14-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:073d285b00100153fd86064c7726bb1b6d610df1356d33bb42d3fd8809cb6e72", size = 2230917, upload-time = "2025-12-10T17:52:23.212Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bb/2e7dce129b88f07fc525fe5c97f28cfb7ed7b62c59386d39226b4d08969c/grimp-3.14-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f6d6efc37e1728bbfcd881b89467be5f7b046292597b3ebe5f8e44e89ea8b6cb", size = 2571371, upload-time = "2025-12-10T17:52:37.84Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2b/8f1be8294af60c953687db7dec25525d87ed9c2aa26b66dcbe5244abaca2/grimp-3.14-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5337d65d81960b712574c41e85b480d4480bbb5c6f547c94e634f6c60d730889", size = 2356980, upload-time = "2025-12-10T17:52:52.004Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ca/ead91e04b3ddd4774ae74601860ea0f0f21bcf6b970b6769ba9571eb2904/grimp-3.14-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:84a7fea63e352b325daa89b0b7297db411b7f0036f8d710c32f8e5090e1fc3ca", size = 2461540, upload-time = "2025-12-10T17:53:53.749Z" },
+    { url = "https://files.pythonhosted.org/packages/94/aa/f8a085ff73c37d6e6a37de9f58799a3fea9e16badf267aaef6f11c9a53a3/grimp-3.14-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:d0b19a3726377165fe1f7184a8af317734d80d32b371b6c5578747867ab53c0b", size = 2497925, upload-time = "2025-12-10T17:54:23.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a3/db3c2d6df07fe74faf5a28fcf3b44fad2831d323ba4a3c2ff66b77a6520c/grimp-3.14-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9caa4991f530750f88474a3f5ecf6ef9f0d064034889d92db00cfb4ecb78aa24", size = 2501794, upload-time = "2025-12-10T17:54:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/095f4e3765e7b60425a41e9fbd2b167f8b0acb957cc88c387f631778a09d/grimp-3.14-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1876efc119b99332a5cc2b08a6bdaada2f0ad94b596f0372a497e2aa8bda4d94", size = 2515203, upload-time = "2025-12-10T17:54:52.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5f/ee02a3a1237282d324f596a50923bf9d2cb1b1230ef2fef49fb4d3563c2c/grimp-3.14-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3ccf03e65864d6bc7bf1c003c319f5330a7627b3677f31143f11691a088464c2", size = 2177150, upload-time = "2025-12-10T17:53:46.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/64/2a92889e5fc78e8ef5c548e6a5c6fed78b817eeb0253aca586c28108393a/grimp-3.14-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9ecd58fa58a270e7523f8bec9e6452f4fdb9c21e4cd370640829f1e43fa87a69", size = 2109280, upload-time = "2025-12-10T17:53:23.345Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/5d0b9ab54821e7fbdeb02f3919fa2cb8b9f0c3869fa6e4b969a5766f0ffa/grimp-3.14-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d75d1f8f7944978b39b08d870315174f1ffcd5123be6ccff8ce90467ace648a", size = 2283367, upload-time = "2025-12-10T17:52:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/96/a77c40c92faf7500f42ac019ab8de108b04ffe3db8ec8d6f90416d2322ce/grimp-3.14-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6f70bbb1dd6055d08d29e39a78a11c4118c1778b39d17cd8271e18e213524ca7", size = 2237125, upload-time = "2025-12-10T17:52:24.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/3e1483721c83057bff921cf454dd5ff3e661ae1d2e63150a380382d116c2/grimp-3.14-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f21b7c003626c902669dc26ede83a91220cf0a81b51b27128370998c2f247b4", size = 2391735, upload-time = "2025-12-10T17:53:05.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cb/25fad4a174fe672d42f3e5616761a8120a3b03c8e9e2ae3f31159561968a/grimp-3.14-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80d9f056415c936b45561310296374c4319b5df0003da802c84d2830a103792a", size = 2571388, upload-time = "2025-12-10T17:52:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/456df7f6a765ce3f160eb32a0f64ed0c1c3cd39b518555dde02087f9b6e4/grimp-3.14-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0332963cd63a45863775d4237e59dedf95455e0a1ea50c356be23100c5fc1d7c", size = 2359637, upload-time = "2025-12-10T17:52:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/98/3e5005ef21a4e2243f0da489aba86aaaff0bc11d5240d67113482cba88e0/grimp-3.14-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f4144350d074f2058fe7c89230a26b34296b161f085b0471a692cb2fe27036f", size = 2308335, upload-time = "2025-12-10T17:53:13.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/03/4e055f756946d6f71ab7e9d1f8536a9e476777093dd7a050f40412d1a2b1/grimp-3.14-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e148e67975e92f90a8435b1b4c02180b9a3f3d725b7a188ba63793f1b1e445a0", size = 2463680, upload-time = "2025-12-10T17:53:55.507Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b9/3c76b7c2e1587e4303a6eff6587c2117c3a7efe1b100cd13d8a4a5613572/grimp-3.14-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1093f7770cb5f3ca6f99fb152f9c949381cc0b078dfdfe598c8ab99abaccda3b", size = 2502808, upload-time = "2025-12-10T17:54:25.383Z" },
+    { url = "https://files.pythonhosted.org/packages/20/80/ada10b85ad3125ebedea10256d9c568b6bf28339d2f79d2d196a7b94f633/grimp-3.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a213f45ec69e9c2b28ffd3ba5ab12cc9859da17083ba4dc39317f2083b618111", size = 2504013, upload-time = "2025-12-10T17:54:39.762Z" },
+    { url = "https://files.pythonhosted.org/packages/05/45/7c369f749d50b0ceac23cd6874ca4695cc1359a96091c7010301e5c8b619/grimp-3.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f003ac3f226d2437a49af0b6036f26edba57f8a32d329275dbde1b2b2a00a56", size = 2515043, upload-time = "2025-12-10T17:54:54.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/85135fe83826ce11ae56a340d32a1391b91eed94d25ce7bc318019f735de/grimp-3.14-cp314-cp314-win32.whl", hash = "sha256:eec81be65a18f4b2af014b1e97296cc9ee20d1115529bf70dd7e06f457eac30b", size = 1877509, upload-time = "2025-12-10T17:55:17.062Z" },
+    { url = "https://files.pythonhosted.org/packages/db/61/e4a2234edecb3bb3cff8963bc4ec5cc482a9e3c54f8df0946d7d90003830/grimp-3.14-cp314-cp314-win_amd64.whl", hash = "sha256:cd3bab6164f1d5e313678f0ab4bf45955afe7f5bdb0f2f481014aa9cca7e81ba", size = 2014364, upload-time = "2025-12-10T17:55:08.896Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/3d304443fbf1df4d60c09668846d0c8a605c6c95646226e41d8f5c3254da/grimp-3.14-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1df33de479be4d620f69633d1876858a8e64a79c07907d47cf3aaf896af057", size = 2281385, upload-time = "2025-12-10T17:52:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/13/493e2648dbb83b3fc517ee675e464beb0154551d726053c7982a3138c6a8/grimp-3.14-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07096d4402e9d5a2c59c402ea3d601f4b7f99025f5e32f077468846fc8d3821b", size = 2231470, upload-time = "2025-12-10T17:52:26.104Z" },
+    { url = "https://files.pythonhosted.org/packages/80/84/e772b302385a6b7ec752c88f84ffe35c33d14076245ae27a635aed9c63a2/grimp-3.14-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:712bc28f46b354316af50c469c77953ba3d6cb4166a62b8fb086436a8b05d301", size = 2571579, upload-time = "2025-12-10T17:52:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/5b23aa7b89c5f4f2cfa636cbeaf33e784378a6b0a823d77a3448670dfacc/grimp-3.14-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abe2bbef1cf8e27df636c02f60184319f138dee4f3a949405c21a4b491980397", size = 2356545, upload-time = "2025-12-10T17:52:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/bcf2116f4b1c3939ab35f9cdddd9ca59e953e57e9a0ac0c143deaf9f29cc/grimp-3.14-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2f9ae3fabb7a7a8468ddc96acc84ecabd84f168e7ca508ee94d8f32ea9bd5de2", size = 2461022, upload-time = "2025-12-10T17:53:56.923Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ce/1a076dce6bc22bca4b9ad5d1bbcd7e1023dcf7bf20ea9404c6462d78f049/grimp-3.14-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:efaf11ea73f7f12d847c54a5d6edcbe919e0369dce2d1aabae6c50792e16f816", size = 2498256, upload-time = "2025-12-10T17:54:27.214Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ea/ac735bed202c1c5c019e611b92d3861779e0cfbe2d20fdb0dec94266d248/grimp-3.14-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e089c9ab8aa755ff5af88c55891727783b4eb6b228e7bdf278e17209d954aa1e", size = 2502056, upload-time = "2025-12-10T17:54:41.537Z" },
+    { url = "https://files.pythonhosted.org/packages/80/8f/774ce522de6a7e70fbeceeaeb6fbe502f5dfb8365728fb3bb4cb23463da8/grimp-3.14-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a424ad14d5deb56721ac24ab939747f72ab3d378d42e7d1f038317d33b052b77", size = 2515157, upload-time = "2025-12-10T17:54:55.874Z" },
+]
+
+[[package]]
 name = "groq"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1499,6 +1570,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "import-linter"
+version = "2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/55b697a17bb15c6cb88d97d73716813f5427281527b90f02cc0a600abc6e/import_linter-2.11.tar.gz", hash = "sha256:5abc3394797a54f9bae315e7242dc98715ba485f840ac38c6d3192c370d0085e", size = 1153682, upload-time = "2026-03-06T12:11:38.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/aa/2ed2c89543632ded7196e0d93dcc6c7fe87769e88391a648c4a298ea864a/import_linter-2.11-py3-none-any.whl", hash = "sha256:3dc54cae933bae3430358c30989762b721c77aa99d424f56a08265be0eeaa465", size = 637315, upload-time = "2026-03-06T12:11:36.599Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three-session doc-restructure pass aligning forever-docs with the context-strategy section in [\`AGENTS.md\`](AGENTS.md). The 1464-line \`docs/architecture.md\` god-doc is split into focused single-purpose docs; \`README.md\` is rewritten with a user-lens framing; every concrete claim in the new docs is validated against \`src/\` with drift corrected.

## What changed

### Doc surface restructure (commits \`85328a0\`, \`fd7a882\`, \`d8920a6\`)

- **Split \`docs/architecture.md\` (1464 → ~330 lines).** Slim core: principles, contracts, hub structure, A2A integration, structural request flow. Keeps Hub Internals + Backend Layer Mermaid diagrams.
- **New \`docs/tracing.md\` (~140 lines).** Extracted tracing prose plus the full instrumented request-flow sequence diagram with HITL pause/resume.
- **New \`docs/skills.md\` (~170 lines).** Extracted skills section.
- **New \`docs/decisions.md\` (~70 lines).** Appendix Design Decisions + Open Questions table + External Federation deep-dive.
- **New \`docs/configuration.md\` (~110 lines).** Extracted config schema, env var convention pointer, credential storage.
- **Rewrote \`README.md\` (256 → ~140 lines)** with user-lens framing: example \`fin do git commit\` interaction up top, single user-friendly Mermaid diagram surfacing skills/tools/agents/approval (replaces 4 developer-lens diagrams which moved to \`docs/\`), getting-started flow, 30-second config example. Deleted the 17-row Status phase table (milestones own that now).
- **Deleted from old architecture.md:** ASCII System Overview + Component Diagram (160 lines, redundant), Directory Structure tree (110 lines), Implementation Phases (150 lines, git log territory), Future Considerations long-term/deferred bullets, Related Documents/Issues sections.
- Fixed link references in \`AGENTS.md\` x5, \`handoff.md\` x1, \`src/fin_assist/agents/skills.py:19\`. \`.coderabbit.yaml\` references kept (architecture.md still canonical for component contracts).

### Code-validation pass on the new docs (commit \`246f22f\`)

Ran a four-track validation pass (one sub-agent per doc) of every concrete claim in the new docs against \`src/\`. Found ~25 drift items across four buckets:

- **Critical (3) — features documented as live but not actually wired up.** Reworded as scaffolding/planned, with tracking issues filed under v0.1.1:
  - \`fin_assist.skill_load\` span never emitted, \`start_task_span(skill_id=...)\` never invoked → [#123](https://github.com/ColeB1722/fin-assist/issues/123)
  - SKILL.md files discoverable by \`list skills\` but not loaded into runtime \`SkillManager\` → [#125](https://github.com/ColeB1722/fin-assist/issues/125)
- **API drift (8)** — wrong signatures in arch.md \"Key types\" section: \`AgentSpec.tools\` → \`skill_tool_names\`, \`run_stream\` → \`run_steps\` returning \`StepHandle\` of \`StepEvent\`s, \`AgentBackend\` protocol has 8+1 methods not 5, \`ContextItem.status\` default \`\"available\"\` not \`\"ready\"\`, \`create_hub_app\` signature is \`(agents: Sequence[AgentSpec], db_path: str = \":memory:\", ...)\` not \`(config, credentials, *, db_path)\`. All corrected.
- **Phantom commands (3)** — \`_poll_task\` (doesn't exist anywhere in \`src/\`), \`fin-assist /connect\` (no command exists; filed as [#124](https://github.com/ColeB1722/fin-assist/issues/124)), bare positional \`fin do <agent> <skill>\` (argparse only has one positional; what works is \`fin do --agent git commit\` via prompt-as-skill auto-promotion). All removed or rephrased.
- **Definition drift (12)** — \`thinking\` defaults, \`system_prompt\` \"required\" vs has default, \`ProviderRegistry\` doesn't read TOML, task-state enum missing \`resumed_from_approval\`, \`DropSpansProcessor\` is public not \`_DropSpansProcessor\`, \`tracing_shared.py\` omitted from Files list, etc. All corrected.

## Why this matters

The forever-docs were drifting from reality (and from each other) because there was no single rule for what each doc surface owns. \`AGENTS.md\` now states the rule explicitly (single-source-of-truth table for every doc surface, with one job and one update cadence). The restructure makes each surface match its job: README is the user front door, \`docs/\*\` are developer references, \`handoff.md\` is rolling session context, milestones own committed work, issues own discussion. The validation pass ensures the developer references actually match the code they describe.

## Tracking issues filed under v0.1.1

- [#123](https://github.com/ColeB1722/fin-assist/issues/123) — Wire skill tracing (\`emit_skill_load_span\`, \`start_task_span(skill_id=)\`)
- [#124](https://github.com/ColeB1722/fin-assist/issues/124) — \`fin-assist /connect\` interactive provider setup
- [#125](https://github.com/ColeB1722/fin-assist/issues/125) — Wire SKILL.md files into runtime \`SkillManager\`

## Test plan

No code changed — docs and \`handoff.md\` only. \`just ci\` passes (940 tests, 1 pre-existing pydantic-ai upstream warning).

## Commits

1. \`85328a0\` phasing brainstorming
2. \`fd7a882\` documentation cleanup
3. \`d8920a6\` docs: split architecture.md into focused docs, rewrite README
4. \`246f22f\` docs: code-validation pass on the new structure, fix drift, file v0.1.1 tracking issues