### PR TITLE
docs: concept-inventory alignment as v0.1.2 milestone

### DIFF
--- a/docs/concept-inventory.md
+++ b/docs/concept-inventory.md
@@ -1,0 +1,148 @@
+# Concept Inventory
+
+The set of first-class concepts the hub maintains, and the rule for what counts as one. This document is the canonical destination-state reference for hub architecture; `handoff.md` carries the in-flight migration sketch.
+
+## The rule
+
+**The hub maintains a concept only when no protocol carries it.** Anything a pressure-tested protocol (A2A, MCP, ACP) already defines as a first-class entity is offloaded to that protocol. The hub's job is to host agents and orchestrate them — not to re-invent abstractions that exist in the surrounding ecosystem.
+
+Two consequences fall out:
+
+1. **Tools come from MCP servers.** The hub maintains an MCP server registry, not a tool registry. Tools are an MCP concept; the hub's only job is to know which MCP servers exist and which agents have access to them.
+2. **Inbound context comes from clients via ACP.** Editors push selection, file, diagnostic context through the ACP session protocol. The hub does not pull context through a rolled-our-own provider registry.
+
+What remains genuinely hub-shaped:
+
+- **Agents** — the addressable unit a client talks to. Defined in TOML, hosted by the hub.
+- **Skills** — the unit of capability composition inside an agent. Project SKILL.md, user SKILL.md, and inline TOML all flow into one unified skill registry.
+- **MCP servers** — infrastructure the hub knows about; agents opt in per-agent.
+- **Models** — selected by name from the framework's known-model set; per-agent config.
+- **Approval policies** — pure behavior; per-agent.
+
+That's the inventory. Five concepts. Everything else is a protocol concern or a skill-local concern.
+
+## Authoring patterns
+
+### Infrastructure is global, behavior is per-agent
+
+The pattern from tools (the cleanest pre-alignment example) generalizes: **infrastructure is registered globally** (MCP servers, skills); **behavior is per-agent** (which skills are bound, which MCP servers are accessible, which approval policies apply, what the system prompt says).
+
+`config.toml` is purely orchestration. It does not define infrastructure inline (with one ergonomic shorthand — see below). It binds existing infrastructure to agents and shapes the agent's behavior.
+
+### Two authoring conveniences for skills
+
+To keep ergonomics good without sacrificing the "global registry" mental model, skills can be authored two ways:
+
+1. **Top-level `[skills.<name>]`** — registers globally. Agents bind explicitly: `[agents.git] skills = ["commit"]`. Best for skills shared across multiple agents.
+2. **Inline `[agents.<agent>.skills.<name>]`** — registers globally *and* auto-binds to that agent. Best for one-off, agent-specific skills.
+
+Same registry, two authoring shapes. The mental model stays clean (everything is in a registry); the ergonomics stay good (one-offs don't require two TOML blocks).
+
+### SKILL.md files
+
+Skills can also be authored as Markdown files following the [agentskills.io](https://agentskills.io) open standard:
+
+- **Project skills**: `.fin/skills/<name>/SKILL.md`
+- **User skills**: `~/.config/fin/skills/<name>/SKILL.md`
+
+These are discovered at startup and merged into the same global skill registry alongside TOML-defined skills.
+
+**Precedence (highest to lowest):**
+
+1. Project SKILL.md (`.fin/skills/<name>/SKILL.md`)
+2. User SKILL.md (`~/.config/fin/skills/<name>/SKILL.md`)
+3. Top-level TOML (`[skills.<name>]`)
+4. Inline TOML (`[agents.<agent>.skills.<name>]`)
+
+**Agent binding for SKILL.md skills:** declared in frontmatter via `agents: [git, shell]`. The skill ships self-contained — drop the file in, declare which agents can load it, done. No separate config edit required to make a SKILL.md skill discoverable to an agent.
+
+### Skill-bound tools
+
+Skills can declare their own tools alongside their prose. These are not registered globally — they live with the skill and are only loadable when the skill is loaded.
+
+**Shape:** a Python module at `.fin/skills/<name>/tools.py` (or `~/.config/fin/skills/<name>/tools.py`) with `@tool`-decorated functions. The decorator carries description, approval policy, and (optionally) a name override.
+
+```python
+# .fin/skills/commit/tools.py
+from fin_assist.skills import tool, ApprovalPolicy
+
+@tool(
+    description="Stage all changes in the current repository.",
+    approval=ApprovalPolicy(default="always"),
+)
+def stage_all() -> str:
+    """Run git add -A."""
+    ...
+```
+
+**Why skill-bound, not global:**
+
+- Tools are skill-specific by nature — `commit_message` only makes sense when the commit skill is loaded.
+- Sub-agents (v0.2) inherit a skill's tools when they load that skill, no extra wiring.
+- Skill-packages (`.fin/skills/<name>/`) become the unit of redistribution — drop a directory in, get the skill + its tools as one bundle.
+
+**Why Python decorator, not shell script:** Python composes with type hints, docstring schemas, and the test harness. Shell-script tools (the agentskills.io `allowed-tools: ["!git status"]` pattern) are deferred — Python covers the cases we care about, and shipping both forms doubles the surface area without a clear win.
+
+### MCP servers are per-agent opt-in
+
+MCP servers are global infrastructure — they're defined in `[mcp.servers.<name>]` and live as processes managed by the hub. But agents must explicitly opt in:
+
+```toml
+[agents.git]
+mcp_servers = ["github", "filesystem"]
+```
+
+This matches the tools/skills binding pattern: global definition, per-agent binding. No more "every agent gets every MCP server" implicit-availability.
+
+### System prompts: deferred to #89
+
+System prompts today are resolved through a name-based Python registry (`SYSTEM_PROMPTS` in `src/fin_assist/agents/registry.py`). `AgentConfig.system_prompt = "chain-of-thought"` references the registry; arbitrary string content is also accepted as a fallback. This is half-aligned with the destination state — it *is* a registry, but it's hardcoded and not extensible from config.
+
+Issue [#89](https://github.com/ColeB1722/fin-assist/issues/89) asks whether prompts should be loadable from markdown files (parallel to SKILL.md). The concept-inventory alignment **does not touch prompts** — that question lives with #89.
+
+When #89 picks up, two shapes to consider (sketched in `handoff.md`):
+
+- **Option 1: Two-shape pattern, mirroring skills.** Inline `system_prompt = "..."` (string content) OR `system_prompt = "@prompt-name"` (name reference) resolves through: `[prompts.<name>]` TOML → `.fin/prompts/<name>.md` → `~/.config/fin/prompts/<name>.md` → hardcoded Python registry as fallback. Same precedence rule as skills. No breaking changes.
+- **Option 2: Delete the Python registry, require config.** All current `SHELL_INSTRUCTIONS` / `CHAIN_OF_THOUGHT_INSTRUCTIONS` / `TEST_INSTRUCTIONS` move to shipped-default markdown files in the repo (loaded via the same lookup). Aggressive; breaks current configs that reference Python registry names.
+
+Default lean: option 1. The decision lives with #89.
+
+## What this displaces
+
+The reframe deletes several concepts that exist in the codebase today. Listed here so the migration cost is honest:
+
+| Removed concept | Replacement | Cost |
+|---|---|---|
+| `ToolRegistry` aggregating builtin + MCP + file tools | `MCPServerRegistry` (MCP only) + skill-bound `@tool` discovery | Delete `create_default_registry()`, migrate any built-in tools worth keeping into skills, rename registry to reflect MCP-only purpose |
+| Built-in tools (`read_file`, `git`, `gh`, `shell_history`, `run_shell`) | Skill-bound `@tool`-decorated functions in appropriate skills | All five rehome (conservative path resolved during execution). Nothing deleted in this iteration; future iterations may delete `run_shell` once skill-bound pattern is settled |
+| `ContextProvider` / `ContextProviderRegistry` (shipped PR #152) | ACP for inbound editor context; thin CLI-local helpers for `@-completion` | Delete the abstraction. `@-completion` becomes CLI-local prompt-composition helpers; `FileFinder`'s gitignore + fuzzy-match logic extracted into a CLI utility module to preserve the existing perf work. `ContextItem` dropped — helpers return plain strings |
+| `AgentSpec.base_tools` listing built-in tool names | `AgentSpec.mcp_servers` listing MCP server names; skill-bound tools are loaded with the skill | Rename + retype the field; `tool_policies` still applies, indexed by `mcp.<server>.<tool>` or skill-bound tool name |
+| Inline TOML skills as the *only* registration shape | Inline TOML *and* top-level TOML *and* SKILL.md files, all merged into one registry | Additive — existing configs still work; new shapes available |
+
+## Non-goals
+
+- **No prompt registry.** Until reuse pressure exists.
+- **No "tools" as a hub abstraction.** Tools live in MCP servers (external) or in skills (skill-bound). The hub does not maintain a tool-shaped concept apart from those two locations.
+- **No rolled-our-own context-injection layer.** ACP and MCP cover the surface.
+- **No multi-flavor skill-bound tooling.** Python `@tool` decorator only. Shell scripts and binaries are not a supported shape in this iteration.
+
+## Resolved execution decisions
+
+Resolved during the eighth-session conversation (2026-05-18). Migration order and milestone shape live in `handoff.md`; the destination-state implications are summarized here.
+
+1. **Built-in tool fate.** All five current built-ins (`read_file`, `git`, `gh`, `shell_history`, `run_shell`) rehome as skill-bound `@tool`-decorated functions in appropriate skills. Nothing is deleted outright in this iteration — the conservative path is taken to preserve test coverage and avoid simultaneously breaking working behavior and changing concepts. Future iterations may delete some (`run_shell` is the most likely candidate) once the skill-bound pattern is settled.
+
+2. **`@-completion` backing.** The CLI gets thin, fresh helpers per `@-prefix`, with the gitignore + fuzzy-match + caching logic from today's `FileFinder` extracted into a CLI-local utility module (e.g. `cli/file_scan.py`) so the existing performance work isn't lost in the rewrite. The four current provider classes (`FileFinder`, `GitContext`, `ShellHistory`, `Environment`) are not preserved — their boilerplate-heavy shape carries the `ContextProvider` mental model we're rejecting. `ContextItem` is also dropped; CLI helpers return plain strings (or raise) and display errors inline.
+
+3. **Migration order.** Context-deletion ships first (it's the ACP-unblock and mechanically isolated). Then the big step: unified skill registry + skill-bound `@tool` + built-in rehoming as one PR (these are coupled). Finally MCP per-agent opt-in as a small tail. See `handoff.md` for code-level touchpoints and milestone scope.
+
+4. **MCP server scope.** Hub starts MCP servers lazily based on the union of agents' `mcp_servers` opt-in lists. Globally-defined in `[mcp.servers.<name>]` (same as today); per-agent bound via `AgentConfig.mcp_servers = [...]`. Same pattern as skills: global infrastructure, per-agent binding. The CLI itself does not consume MCP servers — it only forwards config to the hub at startup (which is the current behavior; no change).
+
+5. **System prompt scope.** Deferred. The current Python registry (`SYSTEM_PROMPTS` in `agents/registry.py`) is half-aligned with the destination state — it's a registry, but hardcoded. Issue [#89](https://github.com/ColeB1722/fin-assist/issues/89) discusses making prompts file-loadable. The alignment work does not touch prompts; #89 picks this up separately. Two candidate shapes are sketched in `handoff.md` for when that issue graduates. Default lean: option 1 (TOML + `.md` files, mirroring the skills pattern), but the decision lives with #89.
+
+## Relationship to existing docs
+
+- `docs/architecture.md` — hub topology, protocol surfaces, deliverables. This file *refines* its "agents are the unit; protocols carry the rest" stance by enumerating the concept inventory.
+- `docs/skills.md` — skill internals (loader, manager, runtime). Will be updated when the unified skill registry lands; until then it documents the inline-TOML-only world.
+- `docs/decisions.md` — design-decision log. Specific decisions made under this alignment land there as rows.
+- `handoff.md` — in-flight migration sketch with current code state, audit findings, and proposed migration order.

--- a/handoff.md
+++ b/handoff.md
@@ -15,6 +15,40 @@ In-flight design sketches and rolling session context. See `AGENTS.md` for what 
 
 ## Current state
 
+**2026-05-18 (eighth session — concept-inventory alignment surfaced as blocking for ACP):** The execution plan from the seventh session's resolution (Path C, dependency-driven interleaving starting with #125+#123) was paused mid-execution to dig into a broader architectural question raised during the design conversation for #125's agent-binding decision.
+
+The conversation generalized from "how do SKILL.md skills bind to agents?" to "what is the hub's concept inventory and what authoring patterns govern it?" Audit of current state revealed organic-growth misalignment: tools and models follow "infrastructure global, behavior per-agent," but skills, system prompts, MCP servers, and context providers don't — each grew its own pattern independently.
+
+**Destination state (resolved this session):**
+
+- Tool registry → **MCP server registry only**. Built-in tools deleted; skill-specific tools live as skill-bound `@tool`-decorated Python modules.
+- Context providers → **deleted**. ACP carries inbound editor context; MCP carries data-shaped context (resources). The `ContextProvider` abstraction shipped in PR #152 is reverted as part of this alignment.
+- Skills → **unified registry** merging project SKILL.md > user SKILL.md > top-level TOML > inline TOML. SKILL.md frontmatter declares `agents: [...]` binding.
+- MCP servers → **per-agent opt-in** (`mcp_servers = [...]` in `AgentConfig`), not global-implicit.
+- System prompts → **scope is open**. Default lean is inline; explicitly flagged for revisit per the eighth-session conversation. See open question 5 in `docs/concept-inventory.md`.
+- `config.toml` → **pure orchestration**; binding-only with the inline-shorthand convenience for skills.
+
+Canonical destination-state reference: `docs/concept-inventory.md` (new this session). Migration sketch lives below in Design Sketches.
+
+**Why this is blocking for ACP-server (#162):** the original v0.1.3 plan was to ship ACP on top of the current concept inventory. Concrete risk: ACP-server has to bridge between *"ACP context"* (carried inbound by the protocol) and *fin's* `ContextProvider` registry — gluing two abstractions instead of one. Deleting `ContextProvider` first turns ACP-server into "unpack ACP context into the agent's prompt envelope," which is the intended shape. Same logic applies to `ToolRegistry` aggregation: ACP-server wants to forward MCP tools cleanly, and the existing `ToolProvider` aggregation layer adds a translation seam that disappears once the registry is MCP-only.
+
+**Cost to name honestly:**
+
+- PR #152 shipped `ContextProviderRegistry` (Phase A of the now-rejected ToolProvider/ContextProvider sketch). That code gets deleted as part of this alignment. Roughly: `src/fin_assist/context/base.py` registry shape, `create_default_context_registry()`, all `ContextProvider` subclasses' registration glue, and the wiring through `cli/main.py` and `hub/factory.py`. The provider classes themselves (`FileFinder`, `GitContext`, `ShellHistory`, `Environment`) may survive as MCP-server-backed equivalents or as CLI-local conveniences — TBD during execution per open question 2 in `docs/concept-inventory.md`.
+- The "ToolProvider + ContextProvider Protocols" sketch below is now **superseded**. Retained in this file with a header marker so the old context isn't lost mid-conversation; deletes when the alignment ships.
+
+**Milestone shape (resolved end of eighth session):** new `v0.1.2 — Concept inventory alignment` milestone with three step-issues (one per migration step). Existing v0.1.2/v0.1.3 renumber to v0.1.3/v0.1.4. #125 migrates from v0.1.1 into the new v0.1.2 (folded into Step 2). #85 stays in v0.1.1 but rescopes (now about CLI `@git:` helper size limits, not `GitContext` provider). #123 stays in v0.1.1 (orthogonal to alignment). See Concept Inventory Migration sketch in Design Sketches for full milestone table + GitHub mutations checklist.
+
+**All five open questions resolved end of session.** Concrete decisions:
+
+1. **Built-in tool fate:** all 5 rehome as skill-bound `@tool`s (conservative path; nothing deleted).
+2. **`@-completion` backing:** thin CLI helpers fresh; `FileFinder`'s scan logic extracted to a CLI utility module.
+3. **Migration ordering:** context-deletion first → skills+tools as one big PR → MCP scoping tail.
+4. **MCP server scope:** lazy startup based on union of agent opt-ins.
+5. **System prompts:** deferred to #89 with two-option sketch in handoff.md.
+
+---
+
 **2026-05-17 (seventh session — doc migration complete + transport-precision fix):** Durable claims from `docs/platform-stance.md` migrated to the forever-docs. The platform-stance work is fully retired; the next session resumes dev work.
 
 - **→ `docs/architecture.md`** — *Deliverables: Hub vs Client* renamed to *Deliverables: Hub vs CLI* and rewritten ("hub as the deliverable; CLI is a dev tool"). New *Inbound protocol surfaces* subsection names A2A-server (existing), MCP-server (committed, unmilestoned), ACP-server (v0.1.3, see [#162](https://github.com/ColeB1722/fin-assist/issues/162)) plus the outbound surfaces. Vision intro replaced "CLI-first, TUI-later" with "Hub as the deliverable; clients are protocol peers." Design principle #5 rewritten. Non-goal added ("CLI that grows into an end-user conversational client"). CLI entry-points section gained a forward-pointing note that the verification-only contraction is in-flight via v0.1.3 + v0.2.1.
@@ -63,13 +97,39 @@ The decision frame's working notes (§6 dated session logs for all five decision
 - **CI required-check deadlock fixed.** `paths-ignore: [docs/**, *.md]` + ruleset-required `format`/`lint`/`test` was a deadlock for doc-only PRs (skipped workflow → required checks perpetually pending). Reworked `ci.yml` to drop `paths-ignore` *and* add a `ci-required` sentinel job (skipped = success). Ruleset updated to require only `ci-required`; future jobs added by listing them in `ci-required.needs`. Industry consensus (DevOps Directive Aug 2025) grounded the choice. Full write-up in `docs/decisions.md` § CI required checks.
 - **Process lesson:** PR #152 was merged before its handoff doc-update commit (`a925b5d`) was pushed. The "Pre-Merge Documentation Discipline" section in `AGENTS.md` was renamed and tightened in response — code, tests, and docs are one logical unit per commit.
 
-**Open in v0.1.1 (7 issues):** #85 (GitContext limits), #89 (system prompts — design-first), #123 (skill tracing wiring), #124 (`/connect`), #125 (SKILL.md runtime wiring), #135 (dogfooding repo agent), #156 (per-subcommand approval at executor).
+**Open in v0.1.1 (4 issues):** #85 (GitContext limits), #123 (skill tracing wiring), #125 (SKILL.md runtime wiring), #156 (per-subcommand approval at executor). #124 moved to v0.1.2 (pairs with README/demo), #135 moved to v0.1.3 (validates post-ACP state), #89 unmilestoned (design-first, needs conversation before commitment).
 
 ## Next session
 
-**Strategic decision phase, issue-hygiene pass, doc migration, *and* the v0.1.1-vs-v0.1.3 starting-point decision are all complete.** The next session opens the cohesive PR and starts dev work.
+**The alignment is fully scoped, decided, and committed to GitHub.** Next session opens the first migration PR cold.
 
-### Starting-point decision (resolved 2026-05-17, seventh session)
+### Ninth-session pickup (the next session)
+
+1. **Read `docs/concept-inventory.md`** — destination state. Five resolved questions in the "Resolved execution decisions" section.
+2. **Read the "Concept Inventory Migration" sketch** in Design Sketches below — code-level touchpoints for Step 1.
+3. **Open the v0.1.2 milestone on GitHub** — three step-issues filed; Step 1 is the starting point.
+4. **Start Step 1 (context provider deletion)** following SDD → TDD per AGENTS.md:
+   - Branch: `step-1-delete-context-providers` (or similar) off `main`
+   - Files to touch: enumerated in the migration sketch's Step 1 touchpoints table
+   - Tests first: `tests/test_cli/test_completions.py` + `tests/test_cli/test_file_scan.py` (new); delete `tests/test_context/`
+   - Implementation: extract `file_scan.py`, write helpers, delete `src/fin_assist/context/`, remove `ContextProvider` plumbing from backend + hub + CLI startup
+   - Pre-merge doc updates per AGENTS.md: update `docs/concept-inventory.md` "What this displaces" row for context providers (mark as done); update `handoff.md` (mark Step 1 shipped under Recent work); update v0.1.1 #85 issue scope; close v0.1.2 Step 1 issue when PR merges
+   - Run `just ci`; open PR to main
+5. **After Step 1 merges:** ACP-server work (#162 in v0.1.4) is unblocked; Step 2 (skills + tools) starts.
+
+### Carryover gotchas
+
+- **PR #152 reversion narrative.** When Step 1's PR description is written, be honest: `ContextProviderRegistry` shipped in #152 and is being reverted. Link to the platform-stance work that drove the reversal so future archaeology has the trail.
+- **`ContextSettings` fate.** Currently threaded through hub + CLI as a hub-level setting. After Step 1, the size limits live with CLI helpers. Decide during Step 1 whether `ContextSettings` survives as a CLI-local config or gets inlined into the helpers. Lean: keep as CLI-local (still tunable; just no longer plumbed through the hub).
+- **`#123` (skill tracing) timing.** Orthogonal to alignment; ships when convenient. Could be a small standalone PR before Step 1, between Step 1 and Step 2, or alongside Step 2. Don't gate Step 1 on it.
+
+### Earlier session context — seventh-session resolution (superseded by eighth session)
+
+The seventh session resolved a starting-point decision (Path C — selective v0.1.1 prefix, then #162) with a 7-step dependency-driven execution plan. **That plan is superseded** by the concept-inventory alignment surfaced in the eighth session. The v0.1.4 (renumbered from v0.1.3) ACP-server work (#162) is now gated on the alignment milestone (v0.1.2). The portions of the seventh-session plan that survive (#85 rescoped, #156, #123) stay in v0.1.1.
+
+The seventh-session reasoning chain is preserved in `git log` (see commit history around 2026-05-17) and `docs/decisions.md § Platform stance` for the architectural decisions that grounded it.
+
+### Original seventh-session execution plan (preserved for reference)
 
 **Resolution: Path C — selective v0.1.1 prefix, then #162.** Ship the v0.1.1 work that's directly load-bearing for ACP-server's first cut, then jump to #162. Backfill the rest of v0.1.1 as it closes out (or migrate to v0.1.2 / v0.2 as appropriate).
 
@@ -79,33 +139,45 @@ The decision frame's working notes (§6 dated session logs for all five decision
 - **Path B (jump straight to #162)** builds ACP-server's permission round-trip on top of `ApprovalPolicy.evaluate()` that's only consulted at top-level mode for scoped CLI tools (#156 wires per-rule fnmatch gating), and ships ACP-server on top of a skill-loading path where `fin list skills` shows files that `fin do --skill` rejects (#125 + #123). That's shipping a protocol-peer that exposes the same incoherence to Zed. Likely surfaces more friction than it prevents.
 - **Path C respects the dependency graph, ignores the milestone number.** Versioning-narrative cost is small: v0.1.1 doesn't ship as a clean milestone until later. Material cost is zero — Git tags don't care about issue order within a milestone.
 
-### Execution order
+### Execution plan (eighth session, 2026-05-18)
 
-1. **#125 + #123** — one PR. SKILL.md runtime wiring + skill tracing share the same code paths. After this, `fin list skills` and `fin do --skill` agree on what skills exist, and skill loads emit `fin_assist.skill_load` spans. Load-bearing for ACP-server because the protocol-peer should not expose a skill loader inconsistency to Zed.
-2. **#156** — per-subcommand approval at executor for scoped CLI tools. `ApprovalPolicy.evaluate()` consulted at the backend approval gate, not just top-level mode. Load-bearing for ACP-server's `session/request_permission` round-trip; the same mechanism is exposed across the protocol boundary in #162.
-3. **#162 (ACP-server first cut)** — with both foundations in place. Issue body is well-specified: session lifecycle, streaming text, permission round-trip; Zed as test client. Plus #143 (dead-code removal — natural pairing) and minimal #137 (positional grammar + `entry_prompt` two-turn fix) per the repurposed v0.1.3 milestone description.
-4. **Backfill v0.1.1 closure** — #85, #124, #89, #135. Order is flexible; #135 (dogfooding) is best last so it validates the post-#162 state. #89 (system prompts as loadable markdown) is design-first; defer or split if the conversation hasn't happened.
+**Branching strategy: dependency-driven interleaving, all on main.** Research confirms the dominant best practice for sequential dependencies across milestones: merge each PR to main independently in dependency order, rather than milestone-per-branch. Milestones are tracking labels, not branch names. Each PR targets main directly — no stacking, no feature flags. (Source: stacked-PR pattern, trunk-based development, "merge early / never branch from another feature" rule.)
 
-### Open the cohesive PR
+**Issue mutations (eighth session):**
 
-Branch state: 7 commits ahead of `main` (seed → Q1–Q4 → Q5 → Q6 → Q7 → hygiene-pass handoff → doc migration), 6 pushed, last commit (`1483000` doc migration) local. Push, then open one PR — "platform stance + hygiene + migration" — per the agreed plan.
+- #124 → v0.1.2 (pairs with README/demo work)
+- #135 → v0.1.3 (validates post-ACP state, becomes v0.1.3 exit gate)
+- #89 → unmilestoned (design-first, needs conversation before commitment per AGENTS.md §Issues vs milestones)
 
-### Optional follow-up (not load-bearing)
+**Final milestone shape:**
 
-~13 GitHub issue comments filed during the hygiene pass link to `docs/platform-stance.md`. The compressed stub resolves those links to a useful redirect (so the comments work without further action), but sweeping them to point at `decisions.md#platform-stance` / `architecture.md#inbound-protocol-surfaces` directly would be cleaner for navigation. Worth doing if it comes up naturally; not worth a dedicated session.
+| Milestone | Open | Scope |
+|---|---|---|
+| v0.1.1 | 4 | #125 + #123 (skill coherence), #156 (approval gate), #85 (GitContext limits) |
+| v0.1.2 | 3 | #127 README + #158 MCP ship-along + #124 `/connect` |
+| v0.1.3 | 4 | #137 (positional grammar) → #143 (dead-code removal) → #162 (ACP-server) → #135 (dogfooding exit gate) |
+| v0.2 | 10 | Sub-agents + migrated #154 |
+| v0.2.1 | 6 | Tracing maturation + #92 |
+| v0.3 | 3 | Federation + repo-as-package |
 
-**If continuing v0.1.1 implementation work:**
+**Execution order (dependency graph):**
 
-**Recommended sequence:**
+1. **#125 + #123** — one PR to main. SKILL.md runtime wiring + skill tracing share the same code paths. Load-bearing: protocol-peer should not expose skill loader inconsistency.
+2. **#156** — one PR to main. Per-subcommand approval at executor gate. Load-bearing: ACP-server's `session/request_permission` uses the same mechanism.
+3. **#85** — one PR to main. GitContext size limits. Standalone, not load-bearing for ACP.
+4. **#137** — one PR to main. Positional grammar + entry_prompt two-turn fix. Changes how skill-load signals flow; must land before #143 deletes the old routes.
+5. **#143** — one PR to main. Dead-code removal of `/skills` + `/skills/invoke` REST routes. Natural consequence of #137; pairs with ACP wiring.
+6. **#162** — one PR to main. ACP-server first cut. Depends on #125/#123 and #156 being in place.
+7. **#135** — one PR to main. Dogfooding repo agent. v0.1.3 exit gate — validates post-ACP state.
 
-1. **#125 + #123 together** — same code paths (SkillManager + tracing). One PR delivers "SKILL.md actually loads at runtime *and* emits a span when it does." Highest-leverage v0.1.1 closer; pre-empts a v0.1.2-demo embarrassment where `fin list skills` shows files that don't actually load.
-2. **#85** — small, safe, closes the unbounded `git diff` output gap. Easy follow-up.
-3. **#156** — per-subcommand approval at executor. Code comments in `agents/tools.py:306, 334` already reference this issue as a known v0.1.x deferral; landing it removes the "see #156" annotations.
-4. **#124** — `/connect` UX. Probably best paired with v0.1.2 README/demo work since the demo benefits from a polished first-run flow.
-5. **#135 dogfooding** — v0.1.1 exit gate. Best done *after* the above so it actually validates the foundation it's meant to validate.
-6. **#89** — defer or split as a design-first issue. The "loadable markdown files" question is real but the design conversation hasn't happened yet; not a blocker for v0.1.1 ship.
+**Unscheduled:** #89 (system prompts — unmilestoned, design-first). Returns to a milestone when the design conversation resolves.
 
-**Sequence (post-hygiene-pass, live state):** v0.1.1 (7 issues left, ~half-day to a few days of work) → [v0.1.2](https://github.com/ColeB1722/fin-assist/milestone/5) (#127 README + #158 MCP ship-along) → [v0.1.3](https://github.com/ColeB1722/fin-assist/milestone/6) (#162 ACP-server first cut + #143 + minimal #137) → [v0.2](https://github.com/ColeB1722/fin-assist/milestone/2) (sub-agents, plus migrated #154). [v0.2.1](https://github.com/ColeB1722/fin-assist/milestone/3) is now tracing-only + #92 ship-along; v0.3 unchanged but undercommitted at the issue level; MCP-client expansion (#153 + #139 + #151) and MCP-server/ACP-client remain unscheduled per Q6c.
+**Open questions (now resolved):**
+
+- **#124 placement:** → v0.1.2. Pairs with demo/README work.
+- **#89 placement:** → unmilestoned. Design-first per its own issue body; AGENTS.md says issues are for conversation, milestones for committed work.
+- **#135 placement:** → v0.1.3. Validates post-ACP state; better exit gate than v0.1.1 entry gate.
+- **Interleaving vs sequential:** → dependency-driven interleaving, all on main. Milestone boundaries are tracking labels, not branch boundaries.
 
 **Earlier session context (kept for reference):**
 
@@ -115,6 +187,172 @@ Branch state: 7 commits ahead of `main` (seed → Q1–Q4 → Q5 → Q6 → Q7 �
 ---
 
 ## Design Sketches
+
+### Concept Inventory Migration (sketched 2026-05-18, resolved end of eighth session)
+
+**Status:** Decided. Destination state in `docs/concept-inventory.md`; all five open questions resolved; milestone shape decided. This sketch holds the in-flight migration plan (code touchpoints + step-by-step ordering) until the first migration PR lands.
+
+#### Resolved decisions (one-line summary; full reasoning in `docs/concept-inventory.md`)
+
+1. **Built-in tool fate.** All five (`read_file`, `git`, `gh`, `shell_history`, `run_shell`) rehome as skill-bound `@tool` functions. Conservative path — nothing deleted in this iteration.
+2. **`@-completion` backing.** Thin CLI-local helpers per `@-prefix`, written fresh. `FileFinder`'s gitignore+fuzzy-match+caching logic extracted to a CLI utility module (e.g. `cli/file_scan.py`) to preserve perf work. `ContextItem` dropped; helpers return plain strings.
+3. **Migration ordering.** Modified Option B: context-deletion first → skills+tools+built-ins as one big step → MCP scoping as small tail.
+4. **MCP server scope.** Hub starts MCP servers lazily based on the union of agents' `mcp_servers` opt-in lists. CLI itself doesn't consume MCP (no change from today).
+5. **System prompts.** Deferred to #89. Two-option sketch below for when #89 picks up.
+
+#### Migration steps — final ordering
+
+**Step 1: Context provider deletion + CLI `@-completion` rewrite.** (ACP-unblock; mechanically isolated; smallest blast radius.)
+
+- Delete `src/fin_assist/context/` package (`base.py`, `files.py`, `git.py`, `history.py`, `environment.py`) — entire module gone
+- Extract `FileFinder._scan_paths` + `_load_gitignore_spec` + `_matches_spec` into new `src/fin_assist/cli/file_scan.py` as plain functions (no class, no ABC)
+- Write thin CLI helpers in `src/fin_assist/cli/completions.py` (or fold into `cli/prompt.py`): one helper per `@-prefix`. `@file:` uses `file_scan`; `@git:diff` / `@git:status` / `@git:log` shell out fresh; `@history:` reads shell history fresh; `@env:VAR` reads `os.environ` fresh
+- Remove `ContextProvider` plumbing from `agents/backend.py` (tool delegation no longer needs it)
+- Remove `ContextProviderRegistry` from `cli/main.py` startup + `hub/factory.py`
+- Remove `context_settings: ContextSettings` parameter threading through the hub (the size limits now live with the CLI helpers, not in a hub abstraction) — *or* keep `ContextSettings` as a CLI-local config (TBD; lean: keep, it controls helper behavior)
+- Update tests: delete `tests/test_context/`, write fresh `tests/test_cli/test_completions.py` + `tests/test_cli/test_file_scan.py`
+- Absorbs #85 (GitContext size limits → CLI `@git:` helper size limits)
+
+**Step 2: Unified skill registry + skill-bound `@tool` + built-in rehoming.** (The big one; ships as one PR to keep the replacement story coherent.)
+
+- Add top-level `[skills.<name>]` parsing in `config/schema.py`
+- `SkillLoader.load_all()` merges sources: project SKILL.md > user SKILL.md > top-level TOML > inline TOML
+- SKILL.md frontmatter `agents: [...]` parsed for binding
+- `AgentSpec.get_skill_definitions()` consults the unified registry, no longer reads only from `AgentConfig.skills`
+- New `@tool` decorator in `src/fin_assist/agents/skill_tools.py` (location TBD; could be `skills/tools.py` for clearer scoping)
+- `SkillLoader` discovers skill-bound tools: for each skill, look for `tools.py` in the skill directory; import; collect `@tool`-decorated functions
+- `SkillManager.load_skill()` registers the skill's tools; `unload_skill()` removes them (skill manager already has lifecycle hooks for this)
+- Built-in rehoming: move each of the five built-ins from `agents/tools.py` `create_default_registry()` into a shipped-default skill:
+  - `read_file` → `core` skill (shipped default at `~/.config/fin/skills/core/`)
+  - `git` → `git` skill
+  - `gh` → `git` skill (gh subcommands are part of the git workflow) or separate `github` skill (TBD during execution)
+  - `shell_history` → `shell` skill
+  - `run_shell` → `shell` skill
+- Delete `create_default_registry()` builtin definitions; the function shrinks to MCP-only
+- Absorbs #125 (SKILL.md runtime wiring) — folded entirely
+- Includes #123 (skill tracing wiring) if scheduling allows; otherwise ships independently
+- `cli/main.py:_resolve_skill` reads from the unified registry
+
+**Step 3: Per-agent MCP opt-in with lazy startup.** (Small mechanical change.)
+
+- Add `mcp_servers: list[str] = []` field to `AgentConfig` in `config/schema.py`
+- At hub startup, compute `union = set().union(*[agent.mcp_servers for agent in agents])`; only spawn MCP server processes in `union`
+- `agents/backend.py` tool registration filters: an agent's tool set includes only MCP-tools from servers in its `mcp_servers` opt-in list
+- Tests: agent-with-no-mcp-servers gets no MCP tools; servers not in any opt-in are not spawned
+- Validation: warn at startup if `[mcp.servers.X]` is defined but no agent opts in (X is unused)
+
+#### Code touchpoints (updated for resolved ordering)
+
+Step 1 (Context deletion):
+
+| File | Change |
+|---|---|
+| `src/fin_assist/context/` (whole package) | DELETE |
+| `src/fin_assist/cli/file_scan.py` (new) | Extract `_scan_paths` / `_load_gitignore_spec` / `_matches_spec` as plain functions |
+| `src/fin_assist/cli/completions.py` (new, or extend `cli/prompt.py`) | Thin helpers per `@-prefix`, returning plain strings |
+| `src/fin_assist/agents/backend.py` | Remove `ContextProvider` plumbing |
+| `src/fin_assist/cli/main.py` | Remove `create_default_context_registry` calls + parameter threading |
+| `src/fin_assist/hub/factory.py` | Remove context registry from `create_hub_app` |
+| `tests/test_context/` | DELETE; replaced by `tests/test_cli/test_completions.py` + `tests/test_cli/test_file_scan.py` |
+
+Step 2 (Skills + tools):
+
+| File | Change |
+|---|---|
+| `src/fin_assist/config/schema.py` | Add top-level `[skills.X]` table parsing; `SkillConfig.agents` for SKILL.md binding |
+| `src/fin_assist/agents/skills.py` | `SkillLoader.load_all()` merges sources with precedence; SKILL.md frontmatter `agents:` parsed |
+| `src/fin_assist/agents/skill_tools.py` (new) | `@tool` decorator; skill-directory discovery |
+| `src/fin_assist/agents/spec.py` | `get_skill_definitions()` consults unified registry |
+| `src/fin_assist/agents/tools.py` | `create_default_registry()` shrinks to MCP-only; built-ins removed |
+| Shipped-default skills (new) | `core/` (read_file), `git/` (git, gh), `shell/` (shell_history, run_shell) |
+| `src/fin_assist/cli/main.py` | `_resolve_skill` reads unified registry; `fin list skills` reflects new sources |
+| `src/fin_assist/hub/factory.py` | `/skills` + `/skills/invoke` (existing) use unified registry |
+| `tests/test_agents/test_skills.py` | Merge + binding tests |
+
+Step 3 (MCP scoping):
+
+| File | Change |
+|---|---|
+| `src/fin_assist/config/schema.py` | `AgentConfig.mcp_servers: list[str] = []` |
+| `src/fin_assist/agents/backend.py` | Tool registration filters by agent's opt-in list |
+| `src/fin_assist/agents/mcp.py` | `MCPToolProvider` consumes union, not full set |
+| `src/fin_assist/cli/main.py` / `hub/factory.py` | Lazy startup logic; warn on unused server |
+| `tests/test_agents/test_mcp.py` | Opt-in filtering + lazy-startup tests |
+
+#### Milestone shape
+
+**Resolved:** new `v0.1.2 — Concept inventory alignment` milestone, three issues (one per step). Existing `v0.1.2` (visibility) renumbers to `v0.1.3`; existing `v0.1.3` (ACP-server) renumbers to `v0.1.4`. `#125` migrates from `v0.1.1` into the new `v0.1.2` (folded into Step 2 issue). `#123` stays in `v0.1.1` (orthogonal). `#85` stays in `v0.1.1` but is rescoped (now about CLI `@git:` helper size limits, not `GitContext`).
+
+Final milestone shape after mutations:
+
+| Milestone | Open | Scope |
+|---|---|---|
+| v0.1.1 | 3 | #85 (rescoped: CLI helper size limits), #123 (skill tracing), #156 (per-subcommand approval) |
+| **v0.1.2 (new)** | 3 | **Step 1 (context deletion), Step 2 (skills + tools), Step 3 (MCP opt-in)** |
+| v0.1.3 (was v0.1.2) | 3 | #127 README + #158 + #124 |
+| v0.1.4 (was v0.1.3) | 4 | #137, #143, #162 ACP-server (gated on v0.1.2 Step 1), #135 |
+| v0.2 | 10 | Sub-agents (unchanged) |
+| v0.2.1 | 6 | Tracing maturation (unchanged) |
+| v0.3 | 3 | Federation + repo-as-package (unchanged; v0.2/v0.3 milestone descriptions need updating to drop stale `FileToolProvider` references) |
+
+#### System prompts: two-option sketch (for when #89 picks up)
+
+The alignment work doesn't touch prompts. When #89 graduates, the two candidate shapes:
+
+**Option 1 — Two-shape pattern (mirrors skills):** `system_prompt` field accepts either inline string content OR a `@name` reference resolving through: `[prompts.<name>]` TOML → `.fin/prompts/<name>.md` → `~/.config/fin/prompts/<name>.md` → hardcoded Python registry as fallback. Same precedence rule as skills. No breaking changes; current configs that reference `"chain-of-thought"` etc. still work via the Python-registry fallback.
+
+**Option 2 — Delete the Python registry, require config:** Current `SHELL_INSTRUCTIONS` / `CHAIN_OF_THOUGHT_INSTRUCTIONS` / `TEST_INSTRUCTIONS` move to shipped-default markdown files in the repo (e.g. `fin_assist/data/prompts/chain-of-thought.md`). The hardcoded `SYSTEM_PROMPTS` dict goes away. Breaks current configs unless we ship the markdown files in the package data.
+
+**Default lean: Option 1.** Same reasoning as skills — additive change, no breakage, clear precedence.
+
+**Note for #89 author:** the destination state for prompts depends partly on whether skills end up having `prompt_template` references (see `SkillConfig.prompt_template` in `config/schema.py:205`). If skills carry prompt fragments, prompts and skills might want to share a lookup mechanism. Worth checking the skill code surface when picking up #89.
+
+#### Issues to update on GitHub (eighth-session mutations)
+
+Captured here as a checklist; mutations execute during the eighth-session end-of-session GitHub pass.
+
+- [ ] Comment on closed #129: its Phase A resolution shipped but is being reverted as part of this alignment; the new direction is in `docs/concept-inventory.md`
+- [ ] Rename existing v0.1.2 milestone → v0.1.3
+- [ ] Rename existing v0.1.3 milestone → v0.1.4
+- [ ] Create new v0.1.2 milestone "Concept inventory alignment" with description pointing at `docs/concept-inventory.md` + this migration sketch
+- [ ] File 3 step-issues under new v0.1.2 milestone (one per migration step)
+- [ ] Move #125 from v0.1.1 into new v0.1.2 (commenting that it's folded into Step 2 issue)
+- [ ] Rewrite v0.1.1 description: drop stale `ToolProvider` and `ContextProvider` architecture notes; remove #125 reference; rescope #85 mention
+- [ ] Rewrite v0.1.3 (was v0.1.2) milestone description: still visibility, but ships after alignment so demo shows new state
+- [ ] Rewrite v0.1.4 (was v0.1.3) milestone description: ACP-server now depends on v0.1.2 alignment Step 1
+- [ ] Rewrite v0.2 milestone description: drop "File-based tool discovery note" referencing `FileToolProvider`; point at `docs/concept-inventory.md` for the new direction (skill-bound `@tool`)
+- [ ] Update #85 issue body: scope shifts from `GitContext` provider size limits to CLI `@git:` helper size limits
+
+#### What this sketch is not
+
+- **Not a destination-state spec.** That's `docs/concept-inventory.md`.
+- **Not a code patch.** The touchpoints tables are for planning, not implementation.
+
+#### When this sketch retires
+
+This sketch retires when the first migration PR (Step 1: context deletion) opens. At that point: the durable destination state is in `docs/concept-inventory.md`; the milestone exists with three issues; the work is committed. This sketch deletes.
+
+---
+
+### ~~ToolProvider + ContextProvider Protocols: Unifying Provider Registration (sketched 2026-05-10, extended 2026-05-16)~~ — SUPERSEDED 2026-05-18
+
+**Status:** **Superseded by the Concept Inventory Migration sketch above (2026-05-18).** The architectural premise (unify tool sources under a `ToolProvider` aggregation; build a parallel `ContextProviderRegistry`) is no longer the direction. The destination state in `docs/concept-inventory.md` deletes both abstractions:
+
+- `ToolProvider` aggregation → `MCPServerRegistry` (MCP only); built-in tools rehome to skills via `@tool` decorator
+- `ContextProviderRegistry` → deleted entirely; ACP carries inbound context, MCP carries data-shaped context
+
+PR #152 shipped Phase A of this sketch's plan (`ContextProviderRegistry` in `src/fin_assist/context/base.py`). That code is being reverted as part of the alignment.
+
+This sketch is retained in this file with a strikethrough header so:
+
+1. Eighth-session readers see the pivot context inline (the "what changed and why" surfaces here)
+2. The industry-pattern research (Strands, mcpp, Pi, AgentPatterns.ai, InitRunner, R2R) isn't lost — some of it informed the eventual skill-bound `@tool` decision
+
+It deletes when the alignment migration ships. Until then, treat any reference to "ToolProvider protocol" or "ContextProviderRegistry" in milestone descriptions or issue bodies as stale; the canonical state is `docs/concept-inventory.md`.
+
+The original sketch body follows for reference.
+
+---
 
 ### Sub-agents as Context Compression (sketched 2026-05-09)
 


### PR DESCRIPTION
## Summary

- Introduces `docs/concept-inventory.md` as the canonical destination-state reference for hub architecture: the rule (hub maintains a concept only when no protocol carries it), the inventory (agents, skills, MCP servers, models, approval policies), and the authoring patterns
- Adds in-flight migration sketch to `handoff.md` with resolved decisions, step-by-step ordering, code touchpoints, milestone plan, and Q5 system-prompt sketches for when #89 picks up
- Reframes the v0.1.x roadmap: new v0.1.2 "Concept inventory alignment" milestone (3 step-issues); existing v0.1.2/v0.1.3 renumber to v0.1.3/v0.1.4

## Why now

ACP-server design (#162, v0.1.4 after renumber) depends on knowing what the hub's concept inventory *is*. Today's organic-growth state — tools and models follow "infrastructure global, behavior per-agent," but skills, system prompts, MCP servers, and context providers each developed their own pattern — adds translation seams between ACP's protocol surface and fin's rolled-our-own abstractions. The alignment removes those seams before ACP-server work starts.

## What's resolved

Five open questions surfaced during the eighth-session conversation, all resolved end of session:

1. **Built-in tool fate** — all 5 (`read_file`, `git`, `gh`, `shell_history`, `run_shell`) rehome as skill-bound `@tool` functions in shipped-default skills. Conservative path; nothing deleted.
2. **`@-completion` backing** — thin CLI-local helpers fresh; `FileFinder`'s scan logic extracted to a CLI utility module to preserve perf work.
3. **Migration ordering** — context-deletion first (ACP-unblock) → skills + tools as one big PR → MCP scoping tail.
4. **MCP server scope** — lazy startup based on union of agent opt-ins; CLI doesn't consume MCP (no change).
5. **System prompts** — deferred to #89 with two-option sketch in `handoff.md`.

## Costs named honestly

PR #152 shipped `ContextProviderRegistry` (Phase A of the now-rejected ToolProvider/ContextProvider sketch). That code gets reverted as part of v0.1.2 Step 1. The superseded sketch is retained in `handoff.md` with a strikethrough header so the pivot context is visible in-session; it deletes when the migration ships.

## Follow-up (after merge)

GitHub mutations to land alongside this PR:

- Comment on closed #129 noting its resolution is stale
- Rename existing v0.1.2 → v0.1.3, existing v0.1.3 → v0.1.4
- Create new v0.1.2 "Concept inventory alignment" milestone
- File 3 step-issues under new v0.1.2
- Move #125 from v0.1.1 into new v0.1.2 (folded into Step 2)
- Rewrite v0.1.1, v0.1.3, v0.1.4, v0.2 milestone descriptions
- Rewrite #85 to reflect rescope (CLI @git: helper, not ContextProvider)

These mutations were scoped in this session's `handoff.md` but execute against GitHub directly; they need this PR's docs to be visible first so milestone descriptions can link to them.