### PR TITLE
feat(agents): per-subcommand approval at executor level (#156)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -97,7 +97,9 @@ Each tool has exactly one policy definition — no merging, no conflicts.
 
 Rules use fnmatch patterns matched against the tool's args string. `ApprovalPolicy.evaluate(args)` checks rules in first-match order; if no rule matches, `default` applies.
 
-This is conservative in v0.1: if `default="always"` or any rule has `mode="always"`, the tool gets `requires_approval=True` at registration time. Fine-grained per-subcommand evaluation at the executor level is planned for v0.1.1.
+Per-subcommand approval is evaluated at call time: the backend wraps each tool callable with `_wrap_with_approval` in `_build_pydantic_agent()`, which calls `policy.evaluate(args)` before execution. When `evaluate()` returns `mode="always"`, the wrapper raises `ApprovalRequired` (pydantic-ai's native mechanism) and the framework defers only that specific call. When `mode="never"`, the tool executes immediately. This enables e.g. `git diff` → execute immediately while `git push` → defer for human approval, within the same tool.
+
+`DeferredToolRequests` is included in the agent's `output_type` when any tool has an approval policy that can produce `mode="always"` (detected by `_tool_has_approval_policy`).
 
 ## skills/invoke endpoint
 
@@ -203,7 +205,7 @@ CLI usage:
 |---------|---------|
 | v0.1.1 | MCP tool source — `MCPToolset` registers discovered tools into `ToolRegistry` |
 | v0.1.1 | Pluggable base system prompts — user-overridable prompt templates, not hardcoded Python constants |
-| v0.1.1 | Per-subcommand approval evaluation at executor level |
+| v0.1.1 | ~~Per-subcommand approval evaluation at executor level~~ (shipped #156) |
 | v0.1.1 | Registry consistency + policy resolution audit |
 | v0.2 | Skill composability (skills invoking skills) + agent-to-agent orchestration |
 | v0.3 | Eval harness |

--- a/handoff.md
+++ b/handoff.md
@@ -99,19 +99,15 @@ The decision frame's working notes (§6 dated session logs for all five decision
 
 **Open in v0.1.1 (4 issues):** #85 (GitContext limits), #123 (skill tracing wiring), #125 (SKILL.md runtime wiring), #156 (per-subcommand approval at executor). #124 moved to v0.1.2 (pairs with README/demo), #135 moved to v0.1.3 (validates post-ACP state), #89 unmilestoned (design-first, needs conversation before commitment).
 
+**2026-05-19 (ninth session — PR 1 #156 implemented):** Per-subcommand approval at executor level is implemented on branch `feature/per-subcommand-approval`. Key change: `_wrap_with_approval` in `backend.py` evaluates `ApprovalPolicy.evaluate(args)` at call time and raises `ApprovalRequired` for `mode="always"` matches. Tools are no longer registered with `requires_approval=True`; instead the callable itself raises `ApprovalRequired` and pydantic-ai defers only that call. This enables `git diff` → execute immediately, `git push` → defer, within the same tool.
+
+Changes: `backend.py` (new `_wrap_with_approval` + `_build_args_string`, replaced `_policy_requires_approval` → `_tool_has_approval_policy`, updated `_get_approval_description` to accept `call_args`), `tools.py` (updated docstring + descriptions), `executor.py` (structured logging on deferred events), 254 lines of new tests. All `just ci` checks pass.
+
+Next: PR 2 (`step-1-delete-context-providers`, #165 + closes #85) — the ninth-session execution plan in Design Sketches has full TDD order.
+
 ## Next session
 
-**The alignment is fully scoped, decided, and committed to GitHub.** Next session opens the first migration PR cold.
-
-### Ninth-session pickup (the next session)
-
-1. **Read `docs/concept-inventory.md`** — destination state. Five resolved questions in the "Resolved execution decisions" section.
-2. **Read the "Concept Inventory Migration" sketch** in Design Sketches below — code-level touchpoints for Step 1.
-3. **Open the v0.1.2 milestone on GitHub** — three step-issues filed; Step 1 is the starting point.
-4. **Start Step 1 (context provider deletion)** following SDD → TDD per AGENTS.md:
-   - Branch: `step-1-delete-context-providers` (or similar) off `main`
-   - Files to touch: enumerated in the migration sketch's Step 1 touchpoints table
-   - Tests first: `tests/test_cli/test_completions.py` + `tests/test_cli/test_file_scan.py` (new); delete `tests/test_context/`
+**Start PR 2 (#165) implementation** — delete `context/` package, extract to `cli/file_scan.py` + `cli/completions.py`, rewrite `resolve_at_references`. Full plan in the "Ninth-session execution plan" sketch below.
    - Implementation: extract `file_scan.py`, write helpers, delete `src/fin_assist/context/`, remove `ContextProvider` plumbing from backend + hub + CLI startup
    - Pre-merge doc updates per AGENTS.md: update `docs/concept-inventory.md` "What this displaces" row for context providers (mark as done); update `handoff.md` (mark Step 1 shipped under Recent work); update v0.1.1 #85 issue scope; close v0.1.2 Step 1 issue when PR merges
    - Run `just ci`; open PR to main

--- a/src/fin_assist/agents/backend.py
+++ b/src/fin_assist/agents/backend.py
@@ -62,6 +62,66 @@ from fin_assist.agents.serialization import unwrap_payload, wrap_payload
 from fin_assist.agents.step import StepEvent
 from fin_assist.agents.tools import ApprovalDecision, ApprovalPolicy, DeferredToolCall
 
+
+def _wrap_with_approval(callable_fn: Any, policy: ApprovalPolicy, *, tool_name: str = "") -> Any:
+    """Wrap a tool callable to evaluate approval policy before execution.
+
+    If ``policy.evaluate(args)`` returns ``"always"``, raises
+    ``ApprovalRequired`` (pydantic-ai defers the call).  Otherwise,
+    delegates to the original callable.
+
+    The ``args`` string for evaluation is constructed from the
+    callable's keyword arguments: for scoped CLI tools (``git``, ``gh``),
+    the ``args`` parameter is prefixed with ``tool_name`` to match
+    patterns like ``"git diff*"``.
+    """
+    import inspect
+
+    from pydantic_ai import ApprovalRequired
+
+    if inspect.iscoroutinefunction(callable_fn):
+
+        async def _async_wrapper(**kwargs: Any) -> str:
+            args_str = _build_args_string(kwargs, tool_name)
+            mode, _ = policy.evaluate(args_str)
+            if mode == "always":
+                raise ApprovalRequired(metadata={"tool_name": tool_name, "args": args_str})
+            return await callable_fn(**kwargs)
+
+        _async_wrapper.__name__ = getattr(callable_fn, "__name__", "_wrapped")
+        return _async_wrapper
+    else:
+
+        def _sync_wrapper(**kwargs: Any) -> str:
+            args_str = _build_args_string(kwargs, tool_name)
+            mode, _ = policy.evaluate(args_str)
+            if mode == "always":
+                raise ApprovalRequired(metadata={"tool_name": tool_name, "args": args_str})
+            return callable_fn(**kwargs)
+
+        _sync_wrapper.__name__ = getattr(callable_fn, "__name__", "_wrapped")
+        return _sync_wrapper
+
+
+def _build_args_string(kwargs: dict[str, Any], tool_name: str) -> str:
+    """Build the args string for approval policy evaluation.
+
+    For scoped CLI tools (git, gh), the ``args`` param contains
+    the subcommand — we prefix it with ``tool_name`` to match
+    patterns like ``"git diff*"``.  For run_shell, the ``command``
+    param is the full command.  For other tools, we join all param
+    values.
+    """
+    if "args" in kwargs:
+        val = str(kwargs["args"])
+        if tool_name and not val.startswith(f"{tool_name} "):
+            return f"{tool_name} {val}"
+        return val
+    if "command" in kwargs:
+        return str(kwargs["command"])
+    return " ".join(str(v) for v in kwargs.values() if v is not None)
+
+
 _message_ta = TypeAdapter(list[ModelMessage])
 
 
@@ -193,7 +253,9 @@ class _PydanticAIStepHandle:
                             tool_name=call.tool_name,
                             tool_call_id=call.tool_call_id,
                             args=call.args_as_dict(),
-                            description=self._backend._get_approval_description(call.tool_name),
+                            description=self._backend._get_approval_description(
+                                call.tool_name, call.args_as_dict()
+                            ),
                         ),
                         step=step,
                         tool_name=call.tool_name,
@@ -458,24 +520,18 @@ class PydanticAIBackend:
             tool_defs = self._tool_registry.get_for_agent(sorted(active_tool_names))
             for td in tool_defs:
                 effective_policy = self._get_agent_tool_policy(td.name) or td.approval_policy
-                needs_approval = effective_policy is not None and self._policy_requires_approval(
+                if effective_policy is not None and self._tool_has_approval_policy(
                     effective_policy
-                )
-                if needs_approval:
+                ):
                     has_approval_tools = True
-                    pydantic_tools.append(
-                        Tool(
-                            td.callable,
-                            takes_ctx=False,
-                            name=td.name,
-                            description=td.description,
-                            requires_approval=True,
-                        )
-                    )
-                else:
-                    pydantic_tools.append(
-                        Tool(td.callable, takes_ctx=False, name=td.name, description=td.description)
-                    )
+                callable_fn = (
+                    _wrap_with_approval(td.callable, effective_policy, tool_name=td.name)
+                    if effective_policy is not None
+                    else td.callable
+                )
+                pydantic_tools.append(
+                    Tool(callable_fn, takes_ctx=False, name=td.name, description=td.description)
+                )
 
         if skill_mgr is not None and skill_mgr.available_skills():
             pydantic_tools.append(
@@ -531,14 +587,13 @@ class PydanticAIBackend:
         )
 
     @staticmethod
-    def _policy_requires_approval(policy: ApprovalPolicy) -> bool:
-        """Check if an approval policy requires approval for any invocation.
+    def _tool_has_approval_policy(policy: ApprovalPolicy) -> bool:
+        """Check if an approval policy can ever require approval.
 
         Returns True if the default mode is "always" or any rule has mode
-        "always".  This is conservative — some subcommands may not need
-        approval, but pydantic-ai sets approval at registration time, not
-        at call time.  Fine-grained per-subcommand evaluation will be
-        integrated at the executor level in a future version.
+        "always".  When True, the tool's callable may raise
+        ``ApprovalRequired`` at call time and the agent needs
+        ``DeferredToolRequests`` in its output_type.
         """
         if policy.default == "always":
             return True
@@ -578,15 +633,27 @@ class PydanticAIBackend:
 
         return FallbackModel(*models)
 
-    def _get_approval_description(self, tool_name: str) -> str | None:
+    def _get_approval_description(
+        self, tool_name: str, call_args: dict[str, Any] | None = None
+    ) -> str | None:
         agent_policy = self._get_agent_tool_policy(tool_name)
         if agent_policy is not None:
+            if call_args is not None:
+                args_str = _build_args_string(call_args, tool_name)
+                _, desc = agent_policy.evaluate(args_str)
+                if desc is not None:
+                    return desc
             return agent_policy.description
         if self._tool_registry is None:
             return None
         td = self._tool_registry.get(tool_name)
         if td is None or td.approval_policy is None:
             return None
+        if call_args is not None:
+            args_str = _build_args_string(call_args, tool_name)
+            _, desc = td.approval_policy.evaluate(args_str)
+            if desc is not None:
+                return desc
         return td.approval_policy.description
 
     def build_deferred_results(self, decisions: list[ApprovalDecision]) -> Any:

--- a/src/fin_assist/agents/backend.py
+++ b/src/fin_assist/agents/backend.py
@@ -76,30 +76,31 @@ def _wrap_with_approval(callable_fn: Any, policy: ApprovalPolicy, *, tool_name: 
     patterns like ``"git diff*"``.
     """
     import inspect
+    from functools import wraps
 
     from pydantic_ai import ApprovalRequired
 
     if inspect.iscoroutinefunction(callable_fn):
 
-        async def _async_wrapper(**kwargs: Any) -> str:
+        @wraps(callable_fn)
+        async def _async_wrapper(**kwargs: Any):
             args_str = _build_args_string(kwargs, tool_name)
             mode, _ = policy.evaluate(args_str)
             if mode == "always":
                 raise ApprovalRequired(metadata={"tool_name": tool_name, "args": args_str})
             return await callable_fn(**kwargs)
 
-        _async_wrapper.__name__ = getattr(callable_fn, "__name__", "_wrapped")
         return _async_wrapper
     else:
 
-        def _sync_wrapper(**kwargs: Any) -> str:
+        @wraps(callable_fn)
+        def _sync_wrapper(**kwargs: Any):
             args_str = _build_args_string(kwargs, tool_name)
             mode, _ = policy.evaluate(args_str)
             if mode == "always":
                 raise ApprovalRequired(metadata={"tool_name": tool_name, "args": args_str})
             return callable_fn(**kwargs)
 
-        _sync_wrapper.__name__ = getattr(callable_fn, "__name__", "_wrapped")
         return _sync_wrapper
 
 

--- a/src/fin_assist/agents/tools.py
+++ b/src/fin_assist/agents/tools.py
@@ -13,8 +13,11 @@ tools the agent needs.
 
 **Scoped CLI tools** (``git``, ``gh``) support per-subcommand approval
 via ``ApprovalPolicy.rules`` — each rule is an fnmatch pattern matched
-against the tool's args string.  This enables e.g. ``git diff`` → never
-require approval while ``git push`` → always requires approval.
+against the tool's args string.  At call time, the backend wrapper
+evaluates ``policy.evaluate(args)`` and raises ``ApprovalRequired`` for
+``mode="always"`` matches, causing pydantic-ai to defer only that call.
+This enables e.g. ``git diff`` → execute immediately while ``git push``
+→ defer for human approval.
 
 MCP integration (#84): A future ``MCPToolset`` would wrap an MCP client
 and register discovered tools into the ``ToolRegistry`` with appropriate
@@ -301,10 +304,7 @@ class BuiltinToolProvider:
                 },
                 approval_policy=ApprovalPolicy(
                     mode="always",
-                    description=(
-                        "Git commands require approval "
-                        "(per-subcommand approval via ApprovalPolicy.rules — see #156)"
-                    ),
+                    description="Git commands require approval",
                 ),
             ),
             ToolDefinition(
@@ -329,10 +329,7 @@ class BuiltinToolProvider:
                 },
                 approval_policy=ApprovalPolicy(
                     mode="always",
-                    description=(
-                        "GitHub CLI commands require approval "
-                        "(per-subcommand approval via ApprovalPolicy.rules — see #156)"
-                    ),
+                    description="GitHub CLI commands require approval",
                 ),
             ),
             ToolDefinition(

--- a/src/fin_assist/hub/executor.py
+++ b/src/fin_assist/hub/executor.py
@@ -493,6 +493,14 @@ class Executor(AgentExecutor):
                 ctx.tracer.end_step_span()
             case "deferred":
                 ctx.tracer.emit_approval_request_span(event)
+                deferred_call = event.content
+                if isinstance(deferred_call, DeferredToolCall):
+                    logger.info(
+                        "tool deferred for approval tool=%s tool_call_id=%s args=%s",
+                        event.tool_name,
+                        deferred_call.tool_call_id,
+                        deferred_call.args,
+                    )
                 await self._emit_deferred_artifact(event, ctx)
 
     async def _emit_artifact(

--- a/tests/test_agents/test_backend.py
+++ b/tests/test_agents/test_backend.py
@@ -721,6 +721,94 @@ class TestPydanticAIBackendBuildPydanticAgent:
         agent = backend._build_pydantic_agent()
         assert agent.output_type is str
 
+    def test_tool_with_approval_policy_gets_deferred_output_type_without_requires_approval(
+        self, mock_config, mock_credentials
+    ) -> None:
+        from pydantic_ai import DeferredToolRequests
+
+        from fin_assist.agents.tools import (
+            ApprovalPolicy,
+            ApprovalRule,
+            ToolDefinition,
+            ToolRegistry,
+        )
+
+        registry = ToolRegistry()
+        registry.register(
+            ToolDefinition(
+                name="git",
+                description="Git",
+                callable=lambda args: args,
+                parameters_schema={"type": "object", "properties": {}},
+                approval_policy=ApprovalPolicy(
+                    mode="always",
+                    default="always",
+                    rules=[ApprovalRule(pattern="git diff*", mode="never")],
+                ),
+            )
+        )
+        spec = AgentSpec(
+            name="git",
+            agent_config=AgentConfig(
+                description="Git agent",
+                system_prompt="git",
+                output_type="text",
+                base_tools=["git"],
+            ),
+            config=mock_config,
+            credentials=mock_credentials,
+        )
+        backend = PydanticAIBackend(agent_spec=spec, tool_registry=registry)
+        agent = backend._build_pydantic_agent()
+        assert isinstance(agent.output_type, list)
+        assert DeferredToolRequests in agent.output_type
+
+    def test_tool_with_never_only_policy_has_no_deferred_output_type(
+        self, mock_config, mock_credentials
+    ) -> None:
+        from fin_assist.agents.tools import ApprovalPolicy, ToolDefinition, ToolRegistry
+
+        registry = ToolRegistry()
+        registry.register(
+            ToolDefinition(
+                name="safe_tool",
+                description="Always safe",
+                callable=lambda: "ok",
+                parameters_schema={"type": "object", "properties": {}},
+                approval_policy=ApprovalPolicy(mode="never"),
+            )
+        )
+        spec = AgentSpec(
+            name="test",
+            agent_config=AgentConfig(
+                description="Test agent",
+                system_prompt="test",
+                output_type="text",
+                base_tools=["safe_tool"],
+            ),
+            config=mock_config,
+            credentials=mock_credentials,
+        )
+        backend = PydanticAIBackend(agent_spec=spec, tool_registry=registry)
+        agent = backend._build_pydantic_agent()
+        assert agent.output_type is str
+
+    def test_tool_has_approval_policy_static(self) -> None:
+        from fin_assist.agents.tools import ApprovalPolicy, ApprovalRule
+
+        policy_with_rules = ApprovalPolicy(
+            mode="always",
+            default="always",
+            rules=[ApprovalRule(pattern="git diff*", mode="never")],
+        )
+        assert PydanticAIBackend._tool_has_approval_policy(policy_with_rules) is True
+
+        policy_never = ApprovalPolicy(mode="never")
+        assert PydanticAIBackend._tool_has_approval_policy(policy_never) is False
+
+        policy_always_no_rules = ApprovalPolicy(mode="always")
+        assert PydanticAIBackend._tool_has_approval_policy(policy_always_no_rules) is True
+
     def test_skill_tools_not_registered_when_not_loaded(
         self, mock_config, mock_credentials
     ) -> None:
@@ -1014,6 +1102,93 @@ class TestPydanticAIBackendGetApprovalReason:
         )
         backend = PydanticAIBackend(agent_spec=spec, tool_registry=registry)
         assert backend._get_approval_description("read_file") is None
+
+    def test_returns_rule_description_when_args_match(self, mock_config, mock_credentials) -> None:
+        from fin_assist.agents.tools import (
+            ApprovalPolicy,
+            ApprovalRule,
+            ToolDefinition,
+            ToolRegistry,
+        )
+
+        registry = ToolRegistry()
+        registry.register(
+            ToolDefinition(
+                name="git",
+                description="Git",
+                callable=lambda args: args,
+                parameters_schema={"type": "object", "properties": {}},
+                approval_policy=ApprovalPolicy(
+                    mode="always",
+                    description="Git commands require approval",
+                    rules=[
+                        ApprovalRule(
+                            pattern="git push*", mode="always", description="Push needs approval"
+                        ),
+                    ],
+                ),
+            )
+        )
+        spec = AgentSpec(
+            name="git",
+            agent_config=AgentConfig(
+                description="Git agent",
+                system_prompt="git",
+                output_type="text",
+                base_tools=["git"],
+            ),
+            config=mock_config,
+            credentials=mock_credentials,
+        )
+        backend = PydanticAIBackend(agent_spec=spec, tool_registry=registry)
+        assert (
+            backend._get_approval_description("git", {"args": "push origin main"})
+            == "Push needs approval"
+        )
+        assert (
+            backend._get_approval_description("git", {"args": "diff HEAD~1"})
+            == "Git commands require approval"
+        )
+
+    def test_without_args_returns_policy_description(self, mock_config, mock_credentials) -> None:
+        from fin_assist.agents.tools import (
+            ApprovalPolicy,
+            ApprovalRule,
+            ToolDefinition,
+            ToolRegistry,
+        )
+
+        registry = ToolRegistry()
+        registry.register(
+            ToolDefinition(
+                name="git",
+                description="Git",
+                callable=lambda args: args,
+                parameters_schema={"type": "object", "properties": {}},
+                approval_policy=ApprovalPolicy(
+                    mode="always",
+                    description="Git commands require approval",
+                    rules=[
+                        ApprovalRule(
+                            pattern="git push*", mode="always", description="Push needs approval"
+                        ),
+                    ],
+                ),
+            )
+        )
+        spec = AgentSpec(
+            name="git",
+            agent_config=AgentConfig(
+                description="Git agent",
+                system_prompt="git",
+                output_type="text",
+                base_tools=["git"],
+            ),
+            config=mock_config,
+            credentials=mock_credentials,
+        )
+        backend = PydanticAIBackend(agent_spec=spec, tool_registry=registry)
+        assert backend._get_approval_description("git") == "Git commands require approval"
 
 
 # -- PydanticAIBackend._build_model -------------------------------------------

--- a/tests/test_agents/test_tools.py
+++ b/tests/test_agents/test_tools.py
@@ -10,9 +10,12 @@ import pytest
 from fin_assist.agents.tools import (
     ApprovalDecision,
     ApprovalPolicy,
+    ApprovalRule,
     DeferredToolCall,
     ToolDefinition,
     ToolRegistry,
+    _make_scoped_cli,
+    _run_shell,
     create_default_registry,
 )
 
@@ -550,3 +553,79 @@ class TestCreateDefaultRegistryContextSettings:
     def test_none_context_settings_works(self):
         registry = create_default_registry(context_settings=None)
         assert registry is not None
+
+
+class TestScopedCliApproval:
+    @pytest.mark.asyncio
+    async def test_raises_approval_required_for_always_args(self) -> None:
+        from pydantic_ai import ApprovalRequired
+
+        from fin_assist.agents.backend import _wrap_with_approval
+
+        policy = ApprovalPolicy(
+            mode="always",
+            default="always",
+            rules=[
+                ApprovalRule(pattern="git diff*", mode="never"),
+                ApprovalRule(pattern="git status*", mode="never"),
+            ],
+        )
+        base_callable = _make_scoped_cli("git")
+        wrapped = _wrap_with_approval(base_callable, policy, tool_name="git")
+        with pytest.raises(ApprovalRequired):
+            await wrapped(args="push origin main")
+
+    @pytest.mark.asyncio
+    async def test_executes_immediately_for_never_args(self) -> None:
+        from fin_assist.agents.backend import _wrap_with_approval
+
+        policy = ApprovalPolicy(
+            mode="always",
+            default="always",
+            rules=[
+                ApprovalRule(pattern="git diff*", mode="never"),
+                ApprovalRule(pattern="git status*", mode="never"),
+            ],
+        )
+        proc = _FakeProc(stdout=b"M file.py\n")
+        with patch("asyncio.create_subprocess_shell", return_value=proc):
+            base_callable = _make_scoped_cli("git")
+            wrapped = _wrap_with_approval(base_callable, policy, tool_name="git")
+            result = await wrapped(args="diff HEAD~1")
+        assert "M file.py" in result
+
+    @pytest.mark.asyncio
+    async def test_approval_required_carries_metadata(self) -> None:
+        from pydantic_ai import ApprovalRequired
+
+        from fin_assist.agents.backend import _wrap_with_approval
+
+        policy = ApprovalPolicy(
+            mode="always",
+            default="always",
+            description="Git commands require approval",
+            rules=[
+                ApprovalRule(pattern="git diff*", mode="never"),
+            ],
+        )
+        base_callable = _make_scoped_cli("git")
+        wrapped = _wrap_with_approval(base_callable, policy, tool_name="git")
+        with pytest.raises(ApprovalRequired) as exc_info:
+            await wrapped(args="push origin main")
+        assert exc_info.value.metadata is not None
+        assert "git push origin main" in exc_info.value.metadata.get("args", "")
+
+    @pytest.mark.asyncio
+    async def test_run_shell_approval_with_command_param(self) -> None:
+        from pydantic_ai import ApprovalRequired
+
+        from fin_assist.agents.backend import _wrap_with_approval
+
+        policy = ApprovalPolicy(
+            mode="always",
+            default="always",
+            description="Shell commands require approval",
+        )
+        wrapped = _wrap_with_approval(_run_shell, policy, tool_name="run_shell")
+        with pytest.raises(ApprovalRequired):
+            await wrapped(command="rm -rf /")


### PR DESCRIPTION
## Summary

- Implement per-subcommand approval by raising `ApprovalRequired` from a wrapper function (`_wrap_with_approval`) around the tool callable, evaluated dynamically per-call using the effective approval policy
- Replace `requires_approval=True` tool registration with callable-level `ApprovalRequired` raises — tools are registered as normal tools, and pydantic-ai handles deferral automatically
- Introduce `_build_args_string` helper to construct args strings for policy evaluation (prefixes `args` with `tool_name` for scoped CLI tools like `git`/`gh` to match patterns like `"git diff*"`)
- Replace `_policy_requires_approval` with `_tool_has_approval_policy` (static check for whether `DeferredToolRequests` should be in output type)
- Update `_get_approval_description` to accept optional `call_args` so deferred events surface rule-specific descriptions
- Add structured logging on deferred events in executor
- Fix wrapper functions to use `functools.wraps` and remove incorrect `-> str` return type annotations

Closes #156